### PR TITLE
Tweak: Fix up Dockerfile

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,6 +16,8 @@ jobs:
         uses: actions/checkout@v1
       - name: Make test
         run: make test
+      - name: Build docker image
+        run: make docker-build
 #      - name: Convert coverage to lcov
 #        uses: jandelgado/gcov2lcov-action@v1.0.0
 #        with:

--- a/.gitignore
+++ b/.gitignore
@@ -22,4 +22,4 @@ bin
 
 .DS_Store
 
-.k8s-infra.cluster
+.k8sinfra.cluster

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,7 @@ RUN go mod download
 COPY main.go main.go
 COPY api/ api/
 COPY controllers/ controllers/
+COPY pkg/ pkg/
 
 # Build
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build -a -o manager main.go


### PR DESCRIPTION
Quick fix up as `make docker-build` on master currently fails. 

- Add `/pkg` file to the `dockerfile`
- Add `make docker-build` to the CI to ensure breaks caught in CI
- Fix rename gitignore for `kind` cluster name file. 