### PR TITLE
feat: async reconciliation

### DIFF
--- a/apis/microsoft.resources/v1/resourcegroup_types.go
+++ b/apis/microsoft.resources/v1/resourcegroup_types.go
@@ -24,6 +24,7 @@ type ResourceGroupSpec struct {
 // ResourceGroupStatus defines the observed state of ResourceGroup
 type ResourceGroupStatus struct {
 	ID                string `json:"id,omitempty"`
+	DeploymentID      string `json:"deploymentId,omitempty"`
 	ProvisioningState string `json:"provisioningState,omitempty"`
 }
 
@@ -56,13 +57,14 @@ func (*ResourceGroup) Hub() {
 func (rg *ResourceGroup) ToResource() (zips.Resource, error) {
 	res := zips.Resource{
 		ID:                rg.Status.ID,
+		DeploymentID:      rg.Status.DeploymentID,
 		Type:              "Microsoft.Resources/resourceGroups",
 		Name:              rg.Name,
 		APIVersion:        rg.Spec.APIVersion,
 		Location:          rg.Spec.Location,
 		Tags:              rg.Spec.Tags,
 		ManagedBy:         rg.Spec.ManagedBy,
-		ProvisioningState: rg.Status.ProvisioningState,
+		ProvisioningState: zips.ProvisioningState(rg.Status.ProvisioningState),
 	}
 
 	return *res.SetAnnotations(rg.Annotations), nil
@@ -70,7 +72,8 @@ func (rg *ResourceGroup) ToResource() (zips.Resource, error) {
 
 func (rg *ResourceGroup) FromResource(res zips.Resource) error {
 	rg.Status.ID = res.ID
-	rg.Status.ProvisioningState = res.ProvisioningState
+	rg.Status.ProvisioningState = string(res.ProvisioningState)
+	rg.Status.DeploymentID = res.DeploymentID
 	rg.Spec.Tags = res.Tags
 	rg.Spec.ManagedBy = res.ManagedBy
 	return nil

--- a/config/crd/bases/microsoft.network.infra.azure.com_virtualnetworks.yaml
+++ b/config/crd/bases/microsoft.network.infra.azure.com_virtualnetworks.yaml
@@ -158,6 +158,8 @@ spec:
           status:
             description: VirtualNetworkStatus defines the observed state of VirtualNetwork
             properties:
+              deploymentId:
+                type: string
               id:
                 type: string
               provisioningState:

--- a/config/crd/bases/microsoft.resources.infra.azure.com_resourcegroups.yaml
+++ b/config/crd/bases/microsoft.resources.infra.azure.com_resourcegroups.yaml
@@ -52,6 +52,8 @@ spec:
           status:
             description: ResourceGroupStatus defines the observed state of ResourceGroup
             properties:
+              deploymentId:
+                type: string
               id:
                 type: string
               provisioningState:

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -5,4 +5,4 @@ kind: Kustomization
 images:
 - name: controller
   newName: devigned/k8s-infra-contoller-dev
-  newTag: 20200209-082935
+  newTag: 20200213-122422

--- a/go.mod
+++ b/go.mod
@@ -3,11 +3,10 @@ module github.com/Azure/k8s-infra
 go 1.13
 
 require (
-	github.com/Azure/azure-sdk-for-go v37.2.0+incompatible
 	github.com/Azure/go-autorest/autorest v0.9.3
 	github.com/Azure/go-autorest/autorest/azure/auth v0.4.2
-	github.com/Azure/go-autorest/autorest/to v0.3.0
-	github.com/Azure/go-autorest/autorest/validation v0.2.0 // indirect
+	github.com/Azure/go-autorest/autorest/date v0.2.0
+	github.com/devigned/tab v0.1.1
 	github.com/go-logr/logr v0.1.0
 	github.com/google/uuid v1.1.1
 	github.com/onsi/ginkgo v1.8.0

--- a/go.sum
+++ b/go.sum
@@ -2,8 +2,6 @@ cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMT
 cloud.google.com/go v0.34.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 cloud.google.com/go v0.38.0 h1:ROfEUZz+Gh5pa62DJWXSaonyu3StP6EA6lPEXPI6mCo=
 cloud.google.com/go v0.38.0/go.mod h1:990N+gfupTy94rShfmMCWGDn0LpTmnzTp2qbd1dvSRU=
-github.com/Azure/azure-sdk-for-go v37.2.0+incompatible h1:LTdcd2GK+cv+e7yhWCN8S7yf3eblBypKFZsPfKjCQ7E=
-github.com/Azure/azure-sdk-for-go v37.2.0+incompatible/go.mod h1:9XXNKU+eRnpl9moKnB4QOLf1HestfXbmab5FXxiDBjc=
 github.com/Azure/go-ansiterm v0.0.0-20170929234023-d6e3b3328b78/go.mod h1:LmzpDX56iTiv29bbRTIsUNlaFfuhWRQBWjQdVyAevI8=
 github.com/Azure/go-autorest/autorest v0.9.0 h1:MRvx8gncNaXJqOoLmhNjUAKh33JJF8LyxPhomEtOsjs=
 github.com/Azure/go-autorest/autorest v0.9.0/go.mod h1:xyHB1BMZT0cuDHU7I0+g046+BFDTQ8rEZB0s4Yfa6bI=
@@ -26,10 +24,6 @@ github.com/Azure/go-autorest/autorest/mocks v0.1.0/go.mod h1:OTyCOPRA2IgIlWxVYxB
 github.com/Azure/go-autorest/autorest/mocks v0.2.0/go.mod h1:OTyCOPRA2IgIlWxVYxBee2F5Gr4kF2zd2J5cFRaIDN0=
 github.com/Azure/go-autorest/autorest/mocks v0.3.0 h1:qJumjCaCudz+OcqE9/XtEPfvtOjOmKaui4EOpFI6zZc=
 github.com/Azure/go-autorest/autorest/mocks v0.3.0/go.mod h1:a8FDP3DYzQ4RYfVAxAN3SVSiiO77gL2j2ronKKP0syM=
-github.com/Azure/go-autorest/autorest/to v0.3.0 h1:zebkZaadz7+wIQYgC7GXaz3Wb28yKYfVkkBKwc38VF8=
-github.com/Azure/go-autorest/autorest/to v0.3.0/go.mod h1:MgwOyqaIuKdG4TL/2ywSsIWKAfJfgHDo8ObuUk3t5sA=
-github.com/Azure/go-autorest/autorest/validation v0.2.0 h1:15vMO4y76dehZSq7pAaOLQxC6dZYsSrj2GQpflyM/L4=
-github.com/Azure/go-autorest/autorest/validation v0.2.0/go.mod h1:3EEqHnBxQGHXRYq3HT1WyXAvT7LLY3tl70hw6tQIbjI=
 github.com/Azure/go-autorest/logger v0.1.0 h1:ruG4BSDXONFRrZZJ2GUXDiUyVpayPmb1GnWeHDdaNKY=
 github.com/Azure/go-autorest/logger v0.1.0/go.mod h1:oExouG+K6PryycPJfVSxi/koC6LSNgds39diKLz7Vrc=
 github.com/Azure/go-autorest/tracing v0.5.0 h1:TRn4WjSnkcSy5AEG3pnbtFSwNtwzjr4VYyQflFE619k=
@@ -63,6 +57,8 @@ github.com/davecgh/go-spew v0.0.0-20151105211317-5215b55f46b2/go.mod h1:J7Y8YcW2
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/devigned/tab v0.1.1 h1:3mD6Kb1mUOYeLpJvTVSDwSg5ZsfSxfvxGRTxRsJsITA=
+github.com/devigned/tab v0.1.1/go.mod h1:XG9mPq0dFghrYvoBF3xdRrJzSTX1b7IQrvaL9mzjeJY=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible h1:7qlOGliEKZXTDg6OTjfoBKDXWrumCAMpl/TFQ4/5kLM=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
 github.com/dimchansky/utfbom v1.1.0 h1:FcM3g+nofKgUteL8dm/UpdRXNC9KmADgTpLKsu0TRo4=

--- a/internal/test/test.go
+++ b/internal/test/test.go
@@ -1,0 +1,28 @@
+package test
+
+import (
+	"math/rand"
+	"time"
+)
+
+var (
+	letterRunes = []rune("abcdefghijklmnopqrstuvwxyz123456789")
+)
+
+func init() {
+	rand.Seed(time.Now().Unix())
+}
+
+// RandomName generates a random Event Hub name tagged with the suite id
+func RandomName(prefix string, length int) string {
+	return RandomString(prefix, length)
+}
+
+// RandomString generates a random string with prefix
+func RandomString(prefix string, length int) string {
+	b := make([]rune, length)
+	for i := range b {
+		b[i] = letterRunes[rand.Intn(len(letterRunes))]
+	}
+	return prefix + string(b)
+}

--- a/pkg/zips/client.go
+++ b/pkg/zips/client.go
@@ -1,0 +1,335 @@
+package zips
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"net/http/httputil"
+	"net/url"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/Azure/go-autorest/autorest"
+	"github.com/Azure/go-autorest/autorest/azure"
+	"github.com/devigned/tab"
+)
+
+type (
+	// Client is the HTTP client for the Cloud Partner Portal
+	Client struct {
+		HTTPClient *http.Client
+		Authorizer autorest.Authorizer
+		Host       string
+		mwStack    []MiddlewareFunc
+	}
+
+	// ClientOption is a variadic optional configuration func
+	ClientOption func(c *Client) error
+
+	// MiddlewareFunc allows a consumer of the Client to inject handlers within the request / response pipeline
+	//
+	// The example below adds the atom xml content type to the request, calls the next middleware and returns the
+	// result.
+	//
+	// addAtomXMLContentType MiddlewareFunc = func(next RestHandler) RestHandler {
+	//		return func(ctx context.Context, req *http.Request) (res *http.Response, e error) {
+	//			if req.Method != http.MethodGet && req.Method != http.MethodHead {
+	//				req.Header.Add("content-Type", "application/atom+xml;type=entry;charset=utf-8")
+	//			}
+	//			return next(ctx, req)
+	//		}
+	//	}
+	MiddlewareFunc func(next RestHandler) RestHandler
+
+	// RestHandler is used to transform a request and response within the http pipeline
+	RestHandler func(ctx context.Context, req *http.Request) (*http.Response, error)
+
+	// SimpleTokenProvider makes it easy to authorize with a string bearer token
+	SimpleTokenProvider struct{}
+
+	HttpError struct {
+		StatusCode int
+		Body       string
+		Response   *http.Response
+	}
+)
+
+var (
+	httpLogger MiddlewareFunc = func(next RestHandler) RestHandler {
+		return func(ctx context.Context, req *http.Request) (*http.Response, error) {
+			printErrLine := func(format string, args ...interface{}) {
+				_, _ = fmt.Fprintf(os.Stderr, format, args...)
+			}
+
+			requestDump, err := httputil.DumpRequest(req, true)
+			if err != nil {
+				printErrLine("+%v\n", err)
+			}
+			printErrLine(string(requestDump))
+
+			res, err := next(ctx, req)
+			if err != nil {
+				return res, err
+			}
+
+			resDump, err := httputil.DumpResponse(res, true)
+			if err != nil {
+				printErrLine("+%v\n", err)
+			}
+			printErrLine(string(resDump))
+
+			return res, err
+		}
+	}
+)
+
+func NewClient(authorizer autorest.Authorizer, opts ...ClientOption) (*Client, error) {
+	c := &Client{
+		Authorizer: authorizer,
+		Host:       azure.PublicCloud.ResourceManagerEndpoint,
+	}
+
+	for _, opt := range opts {
+		if err := opt(c); err != nil {
+			return nil, err
+		}
+	}
+
+	return c, nil
+}
+
+func (c *Client) PutDeployment(ctx context.Context, deployment *Deployment, mw ...MiddlewareFunc) (*Deployment, error) {
+	entityPath, err := deployment.GetEntityPath()
+	if err != nil {
+		return nil, err
+	}
+
+	bits, err := json.Marshal(deployment)
+	if err != nil {
+		return nil, err
+	}
+
+	res, err := c.Put(ctx, entityPath, bytes.NewReader(bits), mw...)
+	defer closeResponse(ctx, res)
+
+	if err != nil {
+		return nil, err
+	}
+
+	body, err := ioutil.ReadAll(res.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	if res.StatusCode > 299 {
+		return nil, fmt.Errorf("uri: %s, status: %d, body: %s", res.Request.URL, res.StatusCode, body)
+	}
+
+	if err := json.Unmarshal(body, deployment); err != nil {
+		return deployment, err
+	}
+
+	return deployment, nil
+}
+
+func (c *Client) GetResource(ctx context.Context, resourceID string, resource interface{}, mw ...MiddlewareFunc) error {
+	res, err := c.Get(ctx, resourceID, mw...)
+	defer closeResponse(ctx, res)
+
+	if err != nil {
+		return err
+	}
+
+	body, err := ioutil.ReadAll(res.Body)
+	if err != nil {
+		return err
+	}
+
+	if res.StatusCode > 299 {
+		return NewHttpError(res, string(body))
+	}
+
+	return json.Unmarshal(body, resource)
+}
+
+// DeleteResource will make an HTTP DELETE call to the resourceID and attempt to fill the resource with the response.
+// If the body of the response is empty, the resource will be nil.
+func (c *Client) DeleteResource(ctx context.Context, resourceID string, resource interface{}, mw ...MiddlewareFunc) error {
+	res, err := c.Delete(ctx, resourceID, mw...)
+	defer closeResponse(ctx, res)
+	if err != nil {
+		return err
+	}
+
+	if res.StatusCode == 404 {
+		// you asked it to be gone, well, it is.
+		return nil
+	}
+
+	if res.StatusCode > 299 {
+		// do our best to read the body, but if we can't, just carry on
+		body, _ := ioutil.ReadAll(res.Body)
+		return NewHttpError(res, string(body))
+	}
+
+	body, err := ioutil.ReadAll(res.Body)
+	if err != nil {
+		return err
+	}
+
+	if len(body) == 0 || resource == nil {
+		return nil
+	}
+
+	return json.Unmarshal(body, resource)
+}
+
+func (c *Client) HeadResource(ctx context.Context, resourceID string, mw ...MiddlewareFunc) (bool, error) {
+	res, err := c.Head(ctx, idWithAPIVersion(resourceID), mw...)
+	defer closeResponse(ctx, res)
+
+	if err != nil {
+		return false, err
+	}
+
+	if res.StatusCode == 404 {
+		// you asked it to be gone, well, it is.
+		return false, nil
+	}
+
+	if res.StatusCode > 299 {
+		// do our best to read the body, but if we can't, just carry on
+		body, _ := ioutil.ReadAll(res.Body)
+		return false, NewHttpError(res, string(body))
+	}
+
+	return true, nil
+}
+
+// Get will execute a HTTP GET request
+func (c *Client) Get(ctx context.Context, entityPath string, mw ...MiddlewareFunc) (*http.Response, error) {
+	return c.execute(ctx, http.MethodGet, entityPath, nil, mw...)
+}
+
+// Put will execute a HTTP PUT request
+func (c *Client) Put(ctx context.Context, entityPath string, body io.Reader, mw ...MiddlewareFunc) (*http.Response, error) {
+	return c.execute(ctx, http.MethodPut, entityPath, body, mw...)
+}
+
+// Post will execute a HTTP POST request
+func (c *Client) Post(ctx context.Context, entityPath string, body io.Reader, mw ...MiddlewareFunc) (*http.Response, error) {
+	return c.execute(ctx, http.MethodPost, entityPath, body, mw...)
+}
+
+// Delete will execute a HTTP DELETE request
+func (c *Client) Delete(ctx context.Context, entityPath string, mw ...MiddlewareFunc) (*http.Response, error) {
+	return c.execute(ctx, http.MethodDelete, entityPath, nil, mw...)
+}
+
+// Head will execute a HTTP HEAD request
+func (c *Client) Head(ctx context.Context, entityPath string, mw ...MiddlewareFunc) (*http.Response, error) {
+	return c.execute(ctx, http.MethodHead, entityPath, nil, mw...)
+}
+
+func (c *Client) execute(ctx context.Context, method string, entityPath string, body io.Reader, mw ...MiddlewareFunc) (*http.Response, error) {
+	req, err := http.NewRequest(method, c.Host+strings.TrimPrefix(entityPath, "/"), body)
+	if err != nil {
+		tab.For(ctx).Error(err)
+		return nil, err
+	}
+
+	final := func(_ RestHandler) RestHandler {
+		return func(reqCtx context.Context, request *http.Request) (*http.Response, error) {
+			client := c.getHTTPClient()
+			request = request.WithContext(reqCtx)
+			request.Header.Set("Content-Type", "application/json")
+			request, err := autorest.CreatePreparer(c.Authorizer.WithAuthorization()).Prepare(request)
+			if err != nil {
+				return nil, err
+			}
+
+			return client.Do(request)
+		}
+	}
+
+	mwStack := []MiddlewareFunc{final}
+	if os.Getenv("DEBUG") == "true" {
+		mwStack = append(mwStack, httpLogger)
+	}
+
+	sl := len(c.mwStack) - 1
+	for i := sl; i >= 0; i-- {
+		mwStack = append(mwStack, c.mwStack[i])
+	}
+
+	for i := len(mw) - 1; i >= 0; i-- {
+		if mw[i] != nil {
+			mwStack = append(mwStack, mw[i])
+		}
+	}
+
+	var h RestHandler
+	for _, mw := range mwStack {
+		h = mw(h)
+	}
+
+	return h(ctx, req)
+}
+
+func (c *Client) getHTTPClient() *http.Client {
+	if c.HTTPClient != nil {
+		return c.HTTPClient
+	}
+
+	return &http.Client{
+		Timeout: 60 * time.Second,
+	}
+}
+
+func closeResponse(ctx context.Context, res *http.Response) {
+	if res == nil {
+		return
+	}
+
+	if err := res.Body.Close(); err != nil {
+		tab.For(ctx).Error(err)
+	}
+}
+
+func NewHttpError(response *http.Response, body string) *HttpError {
+	var statusCode int
+	if response != nil {
+		statusCode = response.StatusCode
+	}
+	return &HttpError{
+		StatusCode: statusCode,
+		Body:       body,
+		Response:   response,
+	}
+}
+
+func (e HttpError) Error() string {
+	var u *url.URL
+	if e.Response != nil && e.Response.Request != nil {
+		u = e.Response.Request.URL
+	}
+	return fmt.Sprintf("uri: %s, status: %d, body: %s", u, e.StatusCode, e.Body)
+}
+
+// WithAuthorization will inject the AZURE_TOKEN env var as the bearer token for API auth
+//
+// This is useful if you want to use a token from az cli.
+// `AZURE_TOKEN=$(az account get-access-token --resource https://cloudpartner.azure.com --query "accessToken" -o tsv) pub publishers list`
+func (s SimpleTokenProvider) WithAuthorization() autorest.PrepareDecorator {
+	return func(p autorest.Preparer) autorest.Preparer {
+		return autorest.PreparerFunc(func(r *http.Request) (*http.Request, error) {
+			r.Header.Add("Authorization", fmt.Sprintf("Bearer %s", os.Getenv("AZURE_TOKEN")))
+			return r, nil
+		})
+	}
+}

--- a/pkg/zips/duration/duration.go
+++ b/pkg/zips/duration/duration.go
@@ -1,0 +1,170 @@
+package duration
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"regexp"
+	"strconv"
+	"strings"
+	"time"
+)
+
+type (
+	ISO8601 struct {
+		time.Duration
+	}
+)
+
+var (
+	durationRegex = regexp.MustCompile(`P([\d\.]+Y)?([\d\.]+M)?([\d\.]+D)?T?([\d\.]+H)?([\d\.]+M)?([\d\.]+?S)?`)
+)
+
+/*
+Duration marshalling
+
+TODO: remove after go v2: https://github.com/golang/go/issues/10275
+*/
+
+func (d ISO8601) MarshalJSON() ([]byte, error) {
+	return []byte(fmt.Sprintf(`"%s"`, d.String())), nil
+}
+
+func (d *ISO8601) UnmarshalJSON(b []byte) error {
+	var v interface{}
+	if err := json.Unmarshal(b, &v); err != nil {
+		return err
+	}
+	switch value := v.(type) {
+	case float64:
+		d.Duration = time.Duration(value)
+		return nil
+	case string:
+		pd, err := parseDuration(value)
+		if err != nil {
+			return err
+		}
+
+		d.Duration = pd
+		return nil
+	default:
+		return errors.New("invalid duration")
+	}
+}
+
+func (d ISO8601) String() string {
+	if d.Duration == time.Duration(0) {
+		return "PT0S"
+	}
+
+	builder := new(strings.Builder)
+	builder.WriteString("P")
+	part, duration := stringPart(d.Duration, time.Hour*24*365, "Y")
+	if part != "" {
+		builder.WriteString(part)
+	}
+
+	part, duration = stringPart(duration, time.Hour*24*30, "M")
+	if part != "" {
+		builder.WriteString(part)
+	}
+
+	part, duration = stringPart(duration, time.Hour*24*7, "W")
+	if part != "" {
+		builder.WriteString(part)
+	}
+
+	part, duration = stringPart(duration, time.Hour*24, "D")
+	if part != "" {
+		builder.WriteString(part)
+	}
+
+	if duration <= 0 {
+		return builder.String()
+	}
+
+	builder.WriteString("T")
+	part, duration = stringPart(duration, time.Hour, "H")
+	if part != "" {
+		builder.WriteString(part)
+	}
+
+	part, duration = stringPart(duration, time.Minute, "M")
+	if part != "" {
+		builder.WriteString(part)
+	}
+
+	part, _ = stringPart(duration, time.Second, "S")
+	if part != "" {
+		builder.WriteString(strings.TrimRight(part, "0"))
+	}
+
+	return builder.String()
+}
+
+func stringPart(duration time.Duration, unit time.Duration, unitSymbol string) (string, time.Duration) {
+	if duration >= unit {
+		if unitSymbol == "S" {
+			remainder := duration % unit
+			if remainder == 0 {
+				units := int64(duration / unit)
+				return fmt.Sprintf("%dS", units), 0
+			}
+
+			units := float64(duration) / float64(unit)
+			return fmt.Sprintf("%sS", strconv.FormatFloat(units, 'f', -1, 64)), 0
+		}
+
+		units := int64(duration / unit)
+		return fmt.Sprintf("%d%s", units, unitSymbol), duration - time.Duration(units*int64(unit))
+	}
+	return "", duration
+}
+
+// parseDuration converts a ISO8601 duration into a time.Duration
+func parseDuration(str string) (time.Duration, error) {
+	matches := durationRegex.FindStringSubmatch(str)
+
+	years, err := parseDurationPart(matches[1], time.Hour*24*365)
+	if err != nil {
+		return 0, err
+	}
+
+	months, err := parseDurationPart(matches[2], time.Hour*24*30)
+	if err != nil {
+		return 0, err
+	}
+
+	days, err := parseDurationPart(matches[3], time.Hour*24)
+	if err != nil {
+		return 0, err
+	}
+
+	hours, err := parseDurationPart(matches[4], time.Hour)
+	if err != nil {
+		return 0, err
+	}
+
+	minutes, err := parseDurationPart(matches[5], time.Second*60)
+	if err != nil {
+		return 0, err
+	}
+
+	seconds, err := parseDurationPart(matches[6], time.Second)
+	if err != nil {
+		return 0, err
+	}
+
+	return years + months + days + hours + minutes + seconds, nil
+}
+
+func parseDurationPart(value string, unit time.Duration) (time.Duration, error) {
+	if len(value) != 0 {
+		parsed, err := strconv.ParseFloat(value[:len(value)-1], 64)
+		if err != nil {
+			return 0, err
+		}
+		return time.Duration(float64(unit) * parsed), nil
+	}
+	return 0, nil
+}

--- a/pkg/zips/duration/duration_test.go
+++ b/pkg/zips/duration/duration_test.go
@@ -1,0 +1,98 @@
+package duration
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/onsi/gomega"
+)
+
+type (
+	DurationTest struct {
+		ADuration *ISO8601 `json:"aduration,omitempty"`
+		Name      string   `json:"name,omitempty"`
+	}
+)
+
+func TestDuration_String(t *testing.T) {
+	cases := []struct {
+		Duration time.Duration
+		Expected string
+	}{
+		{
+			Duration: 30 * time.Second,
+			Expected: "PT30S",
+		},
+		{
+			Duration: 30*time.Second + 4*time.Millisecond,
+			Expected: "PT30.004S",
+		},
+		{
+			Duration: 987654*time.Minute + 30*time.Second + 4*time.Millisecond,
+			Expected: "P1Y10M2W6DT20H54M30.004S",
+		},
+		{
+			Duration: time.Hour * 24 * 7,
+			Expected: "P1W",
+		},
+		{
+			Duration: time.Hour * 24 * 2,
+			Expected: "P2D",
+		},
+		{
+			Duration: time.Hour*24*2 + time.Hour,
+			Expected: "P2DT1H",
+		},
+	}
+
+	for _, c := range cases {
+		c := c
+		t.Run(c.Expected, func(t *testing.T) {
+			d := ISO8601{Duration: c.Duration}
+			g := gomega.NewGomegaWithT(t)
+			g.Expect(d.String()).To(gomega.Equal(c.Expected))
+		})
+	}
+}
+
+func TestDuration_JSON(t *testing.T) {
+	cases := []struct {
+		Name   string
+		JSON   string
+		Struct DurationTest
+	}{
+		{
+			Name: "duration specified",
+			JSON: `{"aduration":"PT30.05S","name":"foo"}`,
+			Struct: DurationTest{
+				ADuration: &ISO8601{
+					Duration: 30050 * time.Millisecond,
+				},
+				Name: "foo",
+			},
+		},
+		{
+			Name: "duration not specified",
+			JSON: `{"name":"foo"}`,
+			Struct: DurationTest{
+				ADuration: nil,
+				Name:      "foo",
+			},
+		},
+	}
+
+	for _, c := range cases {
+		c := c
+		t.Run(c.Name, func(t *testing.T) {
+			t.Parallel()
+			var testStruct DurationTest
+			g := gomega.NewGomegaWithT(t)
+			g.Expect(json.Unmarshal([]byte(c.JSON), &testStruct))
+			g.Expect(testStruct).To(gomega.Equal(c.Struct))
+			bits, err := json.Marshal(testStruct)
+			g.Expect(err).ToNot(gomega.HaveOccurred())
+			g.Expect(string(bits)).To(gomega.Equal(c.JSON))
+		})
+	}
+}

--- a/pkg/zips/template_test.go
+++ b/pkg/zips/template_test.go
@@ -45,8 +45,7 @@ func TestNewAzureTemplateClient(t *testing.T) {
 			},
 			Expect: func(g *gomega.GomegaWithT, client *zips.AzureTemplateClient, err error) {
 				g.Expect(err).To(gomega.BeNil())
-				g.Expect(client.DeploymentsClient).ToNot(gomega.BeNil())
-				g.Expect(client.ResourceClient).ToNot(gomega.BeNil())
+				g.Expect(client.RawClient).ToNot(gomega.BeNil())
 			},
 		},
 		{
@@ -83,18 +82,4 @@ func TestNewAzureTemplateClient(t *testing.T) {
 			c.Expect(g, client, err)
 		})
 	}
-}
-
-func TestNewResourceGroupDeploymentTemplate(t *testing.T) {
-	g := gomega.NewGomegaWithT(t)
-	template := zips.NewResourceGroupDeploymentTemplate(zips.Resource{})
-	g.Expect(template.Schema).To(gomega.Equal("https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#"))
-	g.Expect(template.ContentVersion).To(gomega.Equal("1.0.0.0"))
-}
-
-func TestNewSubscriptionDeploymentTemplate(t *testing.T) {
-	g := gomega.NewGomegaWithT(t)
-	template := zips.NewSubscriptionDeploymentTemplate(zips.Resource{})
-	g.Expect(template.Schema).To(gomega.Equal("https://schema.management.azure.com/schemas/2018-05-01/subscriptionDeploymentTemplate.json"))
-	g.Expect(template.ContentVersion).To(gomega.Equal("1.0.0.0"))
 }

--- a/pkg/zips/testdata/resource_group_deployment.json
+++ b/pkg/zips/testdata/resource_group_deployment.json
@@ -1,0 +1,71 @@
+{
+  "id": "/subscriptions/1234/resourcegroups/myResourceGroup/providers/Microsoft.Resources/deployments/exampleDeploymentName",
+  "name": "exampleDeploymentName",
+  "type": "Microsoft.Resources/deployments",
+  "properties": {
+    "templateLink": {
+      "uri": "https://microsoft.com/template",
+      "contentVersion": "1.0.0.0"
+    },
+    "parameters": {},
+    "mode": "Complete",
+    "provisioningState": "Accepted",
+    "timestamp": "2019-03-01T00:00:00.0000000Z",
+    "duration": "PT0.8204881S",
+    "correlationId": "correlationID",
+    "providers": [
+      {
+        "namespace": "Microsoft.Network",
+        "resourceTypes": [
+          {
+            "resourceType": "virtualNetworks",
+            "locations": [
+              "centralus"
+            ]
+          },
+          {
+            "resourceType": "virtualNetworks/subnets",
+            "locations": [
+              "centralus"
+            ]
+          }
+        ]
+      }
+    ],
+    "dependencies": [
+      {
+        "dependsOn": [
+          {
+            "id": "{resourceid}",
+            "resourceType": "Microsoft.Network/virtualNetworks",
+            "resourceName": "VNet1"
+          }
+        ],
+        "id": "{resourceid}",
+        "resourceType": "Microsoft.Network/virtualNetworks/subnets",
+        "resourceName": "VNet1/Subnet1"
+      },
+      {
+        "dependsOn": [
+          {
+            "id": "{resourceid}",
+            "resourceType": "Microsoft.Network/virtualNetworks",
+            "resourceName": "VNet1"
+          },
+          {
+            "id": "{resourceid}",
+            "resourceType": "Microsoft.Network/virtualNetworks/subnets",
+            "resourceName": "VNet1/Subnet1"
+          }
+        ],
+        "id": "{resourceid}",
+        "resourceType": "Microsoft.Network/virtualNetworks/subnets",
+        "resourceName": "VNet1/Subnet2"
+      }
+    ],
+    "onErrorDeployment": {
+      "type": "LastSuccessful",
+      "deploymentName": "{nameOfLastSuccesfulDeployment}"
+    }
+  }
+}

--- a/pkg/zips/types.go
+++ b/pkg/zips/types.go
@@ -1,0 +1,180 @@
+package zips
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/Azure/go-autorest/autorest/date"
+
+	"github.com/Azure/k8s-infra/pkg/zips/duration"
+)
+
+type (
+	ARMMeta struct {
+		Name           string `json:"name,omitempty"`
+		Type           string `json:"type,omitempty"`
+		ID             string `json:"id,omitempty"`
+		Location       string `json:"location,omitempty"`
+		ResourceGroup  string `json:"-"`
+		SubscriptionID string `json:"-"`
+	}
+
+	ProvisioningState string
+
+	DeploymentScope string
+
+	DetailLevel string
+
+	DeploymentMode string
+
+	DebugSetting struct {
+		DetailLevel DetailLevel `json:"detailLevel,omitempty"`
+	}
+
+	OutputResource struct {
+		ID string `json:"id,omitempty"`
+	}
+
+	DeploymentStatus struct {
+		ProvisioningState ProvisioningState `json:"provisioningState,omitempty"`
+		Timestamp         *date.Time        `json:"timestamp,omitempty"`
+		Duration          *duration.ISO8601 `json:"duration,omitempty"`
+		CorrelationID     string            `json:"correlationId,omitempty"`
+		Outputs           json.RawMessage   `json:"outputs,omitempty"`
+		OutputResources   []OutputResource  `json:"outputResources,omitempty"`
+	}
+
+	DeploymentSpec struct {
+		DebugSetting *DebugSetting  `json:"debugSetting,omitempty"`
+		Mode         DeploymentMode `json:"mode,omitempty"`
+		Template     *Template      `json:"template,omitempty"`
+	}
+
+	DeploymentProperties struct {
+		DeploymentStatus `json:",inline"`
+		DeploymentSpec   `json:",inline"`
+	}
+
+	Deployment struct {
+		ARMMeta    `json:",inline"`
+		Scope      DeploymentScope `json:"-"`
+		Properties *DeploymentProperties
+	}
+)
+
+const (
+	ResourceGroupScope DeploymentScope = "resourceGroup"
+	SubscriptionScope  DeploymentScope = "subscription"
+
+	RequestContentDetailLevel            DetailLevel = "requestContent"
+	ResponseContentDetailLevel           DetailLevel = "responseContent"
+	RequestAndResponseContentDetailLevel DetailLevel = "requestContent,responseContent"
+
+	IncrementalDeploymentMode DeploymentMode = "Incremental"
+	CompleteDeploymentMode    DeploymentMode = "Complete"
+
+	SucceededProvisioningState ProvisioningState = "Succeeded"
+	FailedProvisioningState    ProvisioningState = "Failed"
+	DeletingProvisioningState  ProvisioningState = "Deleting"
+	AcceptedProvisioningState  ProvisioningState = "Accepted"
+)
+
+func NewResourceGroupDeployment(subscriptionID, groupName, deploymentName string, resources ...Resource) (*Deployment, error) {
+	return &Deployment{
+		Scope: ResourceGroupScope,
+		Properties: &DeploymentProperties{
+			DeploymentSpec: DeploymentSpec{
+				DebugSetting: &DebugSetting{
+					DetailLevel: RequestAndResponseContentDetailLevel,
+				},
+				Mode: IncrementalDeploymentMode,
+				Template: &Template{
+					Schema:         "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+					ContentVersion: "1.0.0.0",
+					Resources:      resources,
+				},
+			},
+		},
+		ARMMeta: ARMMeta{
+			Name:           deploymentName,
+			ResourceGroup:  groupName,
+			SubscriptionID: subscriptionID,
+		},
+	}, nil
+}
+
+func NewSubscriptionDeployment(subscriptionID, location, deploymentName string, resources ...Resource) (*Deployment, error) {
+	return &Deployment{
+		Scope: SubscriptionScope,
+		Properties: &DeploymentProperties{
+			DeploymentSpec: DeploymentSpec{
+				DebugSetting: &DebugSetting{
+					DetailLevel: RequestAndResponseContentDetailLevel,
+				},
+				Mode: IncrementalDeploymentMode,
+				Template: &Template{
+					Schema:         "https://schema.management.azure.com/schemas/2018-05-01/subscriptionDeploymentTemplate.json#",
+					ContentVersion: "1.0.0.0",
+					Resources:      resources,
+				},
+			},
+		},
+		ARMMeta: ARMMeta{
+			Name:           deploymentName,
+			Location:       location,
+			SubscriptionID: subscriptionID,
+		},
+	}, nil
+}
+
+func (d *Deployment) GetEntityPath() (string, error) {
+	if err := d.Validate(); err != nil {
+		return "", err
+	}
+
+	var entityPath string
+	switch d.Scope {
+	case SubscriptionScope:
+		entityPath = fmt.Sprintf("subscriptions/%s/providers/Microsoft.Resources/deployments/%s?api-version=2019-10-01", d.SubscriptionID, d.Name)
+	case ResourceGroupScope:
+		entityPath = fmt.Sprintf("subscriptions/%s/resourcegroups/%s/providers/Microsoft.Resources/deployments/%s?api-version=2019-10-01", d.SubscriptionID, d.ResourceGroup, d.Name)
+	default:
+		return "", fmt.Errorf("unknown scope %s", d.Scope)
+	}
+
+	return entityPath, nil
+}
+
+func (d *Deployment) Validate() error {
+	switch d.Scope {
+	case SubscriptionScope:
+		if d.SubscriptionID == "" || d.Name == "" {
+			return fmt.Errorf("validate: require subscription ID and name to not be empty")
+		}
+	case ResourceGroupScope:
+		if d.SubscriptionID == "" || d.Name == "" || d.ResourceGroup == "" {
+			return fmt.Errorf("validate: require subscription ID, name and resource group to not be empty")
+		}
+	}
+
+	return nil
+}
+
+func (d *Deployment) IsTerminalProvisioningState() bool {
+	return d.Properties != nil && IsTerminalProvisioningState(d.Properties.ProvisioningState)
+}
+
+func (d *Deployment) ProvisioningStateOrUnknown() string {
+	if d.Properties != nil {
+		return "unknown"
+	}
+	return string(d.Properties.ProvisioningState)
+}
+
+func idWithAPIVersion(resourceID string) string {
+	return resourceID + "?api-version=2019-10-01"
+}
+
+func IsTerminalProvisioningState(state ProvisioningState) bool {
+	return state == SucceededProvisioningState || state == FailedProvisioningState
+}

--- a/pkg/zips/types_test.go
+++ b/pkg/zips/types_test.go
@@ -1,0 +1,77 @@
+package zips_test
+
+import (
+	"encoding/json"
+	"io/ioutil"
+	"testing"
+	"time"
+
+	"github.com/Azure/go-autorest/autorest/date"
+	"github.com/onsi/gomega"
+
+	"github.com/Azure/k8s-infra/pkg/zips"
+	"github.com/Azure/k8s-infra/pkg/zips/duration"
+)
+
+func TestNewResourceGroupDeployment(t *testing.T) {
+	res := zips.Resource{
+		ObjectMeta:     zips.ResourceMeta{},
+		ResourceGroup:  "foo",
+		SubscriptionID: "subID",
+		Name:           "name",
+		Location:       "westus2",
+		Type:           "Microsoft.Network/virtualNetworks",
+		APIVersion:     "2019-09-01",
+		Properties:     nil,
+	}
+	rgd, err := zips.NewResourceGroupDeployment("subID", "foo", "dep", res)
+	g := gomega.NewGomegaWithT(t)
+	g.Expect(err).ToNot(gomega.HaveOccurred())
+	g.Expect(rgd.Scope).To(gomega.Equal(zips.ResourceGroupScope))
+	template := rgd.Properties.Template
+	g.Expect(template.Schema).To(gomega.Equal("https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#"))
+	g.Expect(template.ContentVersion).To(gomega.Equal("1.0.0.0"))
+}
+
+func TestNewSubscriptionDeployment(t *testing.T) {
+	res := zips.Resource{
+		ObjectMeta:     zips.ResourceMeta{},
+		SubscriptionID: "subID",
+		Name:           "name",
+		Location:       "westus2",
+		Type:           "Microsoft.Resources/resourceGroups",
+		APIVersion:     "2019-10-01",
+		Properties:     nil,
+	}
+	rgd, err := zips.NewSubscriptionDeployment("subID", "westus2", "dep", res)
+	g := gomega.NewGomegaWithT(t)
+	g.Expect(err).ToNot(gomega.HaveOccurred())
+	g.Expect(rgd.Scope).To(gomega.Equal(zips.SubscriptionScope))
+	template := rgd.Properties.Template
+	g.Expect(template.Schema).To(gomega.Equal("https://schema.management.azure.com/schemas/2018-05-01/subscriptionDeploymentTemplate.json#"))
+	g.Expect(template.ContentVersion).To(gomega.Equal("1.0.0.0"))
+}
+
+func TestDeployment_Marshalling(t *testing.T) {
+	g := gomega.NewGomegaWithT(t)
+	bits, err := ioutil.ReadFile("./testdata/resource_group_deployment.json")
+	g.Expect(err).ToNot(gomega.HaveOccurred())
+	var d zips.Deployment
+	g.Expect(json.Unmarshal(bits, &d)).ToNot(gomega.HaveOccurred())
+	g.Expect(d.Location).To(gomega.BeEmpty())
+	ts, err := time.Parse(time.RFC3339, "2019-03-01T00:00:00Z")
+	g.Expect(err).ToNot(gomega.HaveOccurred())
+	expectedProps := &zips.DeploymentProperties{
+		DeploymentStatus: zips.DeploymentStatus{
+			ProvisioningState: "Accepted",
+			Timestamp:         &date.Time{Time: ts},
+			Duration:          &duration.ISO8601{Duration: 820488100},
+			CorrelationID:     "correlationID",
+		},
+		DeploymentSpec: zips.DeploymentSpec{
+			Mode:     zips.CompleteDeploymentMode,
+			Template: nil,
+		},
+	}
+	g.Expect(d.Properties).To(gomega.Equal(expectedProps))
+}

--- a/pkg/zips/zips.go
+++ b/pkg/zips/zips.go
@@ -28,7 +28,10 @@ type (
 
 	Applier interface {
 		Apply(ctx context.Context, res Resource) (Resource, error)
-		Delete(ctx context.Context, res Resource) error
+		DeleteApply(ctx context.Context, deploymentID string) error
+		BeginDelete(ctx context.Context, res Resource) (Resource, error)
+		GetResource(ctx context.Context, res Resource) (Resource, error)
+		HeadResource(ctx context.Context, res Resource) (bool, error)
 	}
 
 	ResourceMeta struct {
@@ -39,7 +42,7 @@ type (
 		ObjectMeta        ResourceMeta      `json:"-"`
 		ResourceGroup     string            `json:"-"` // resource group should not be serialized as part of the resource. This indicates that this should be within a resource group or at a subscription level deployment.
 		SubscriptionID    string            `json:"-"`
-		ProvisioningState string            `json:"-"`
+		ProvisioningState ProvisioningState `json:"-"`
 		DeploymentID      string            `json:"-"`
 		ID                string            `json:"id,omitempty"`
 		Name              string            `json:"name,omitempty"`


### PR DESCRIPTION
The current reconciler is synchronous, which is rather heavy. With this PR the reconciler becomes async. 

This became a great opportunity to move to a more resourceful client library. This PR only depends on go-autorest for authentication. There are no dependencies on the Azure Go SDK for interacting with ARM.

fixes #29 