### PR TITLE
Create PackageDefinition to hold all definitions

### DIFF
--- a/hack/generator/pkg/astmodel/definition.go
+++ b/hack/generator/pkg/astmodel/definition.go
@@ -7,16 +7,27 @@ package astmodel
 
 import "go/ast"
 
+type HasImports interface {
+	// RequiredImports returns a list of packages required by this
+	RequiredImports() []PackageReference
+}
+
 // Definition represents models that can render into Go code
 type Definition interface {
-	// AsAst() renders a definition into a Go abstract syntax tree
-	AsAst() ast.Node
+	HasImports
+
+	// FileNameHint returns what a file that contains this definition (if any) should be called
+	// this is not always used as we might combine multiple definitions into one file
+	FileNameHint() string
+
+	// AsDecalaration() renders a definition into a Go abstract syntax tree
+	AsDeclaration() ast.Decl
 }
 
 // Type represents something that is a Go type
 type Type interface {
-	// RequiredImports returns a list of packages required by this type
-	RequiredImports() []PackageReference
+	HasImports
+
 	// AsType renders the current instance as a Go abstract syntax tree
 	AsType() ast.Expr
 }

--- a/hack/generator/pkg/astmodel/fieldDefinition.go
+++ b/hack/generator/pkg/astmodel/fieldDefinition.go
@@ -19,9 +19,6 @@ type FieldDefinition struct {
 	description string
 }
 
-// FieldDefinition must implement Definition
-var _ Definition = (*FieldDefinition)(nil)
-
 // NewFieldDefinition is a factory method for creating a new FieldDefinition
 // name is the name for the new field (mandatory)
 // fieldType is the type for the new field (mandatory)
@@ -67,13 +64,8 @@ func (field *FieldDefinition) WithDescription(description *string) *FieldDefinit
 	return &result
 }
 
-// AsAst generates an AST node representing this field definition
-func (field FieldDefinition) AsAst() ast.Node {
-	return field.AsField()
-}
-
 // AsField generates an AST field node representing this field definition
-func (field FieldDefinition) AsField() *ast.Field {
+func (field *FieldDefinition) AsField() *ast.Field {
 
 	// TODO: add field tags for api hints / json binding
 	result := &ast.Field{

--- a/hack/generator/pkg/astmodel/fieldDefinition_test.go
+++ b/hack/generator/pkg/astmodel/fieldDefinition_test.go
@@ -49,7 +49,7 @@ func Test_FieldDefinitionAsAst_GivenValidField_ReturnsNonNilResult(t *testing.T)
 	g := NewGomegaWithT(t)
 
 	field := NewFieldDefinition("FullName", "fullName", StringType)
-	node := field.AsAst()
+	node := field.AsField()
 
 	g.Expect(node).NotTo(BeNil())
 }

--- a/hack/generator/pkg/astmodel/fileDefinition.go
+++ b/hack/generator/pkg/astmodel/fileDefinition.go
@@ -16,23 +16,16 @@ import (
 
 // FileDefinition is the content of a file we're generating
 type FileDefinition struct {
-	// Name for the package
+	// the package this file is in
 	PackageReference
-
-	// Structs to include in this file
-	structs []*StructDefinition
+	// definitions to include in this file
+	definitions []Definition
 }
 
-// FileDefinition must implement Definition
-var _ Definition = &FileDefinition{}
-
-// NewFileDefinition creates a file definition containing specified structs
-func NewFileDefinition(structs ...*StructDefinition) *FileDefinition {
-	// TODO: check that all structs are from same package
-	return &FileDefinition{
-		PackageReference: structs[0].PackageReference,
-		structs:          structs,
-	}
+// NewFileDefinition creates a file definition containing specified definitions
+func NewFileDefinition(packageRef PackageReference, definitions ...Definition) *FileDefinition {
+	// TODO: check that all definitions are from same package
+	return &FileDefinition{packageRef, definitions}
 }
 
 // AsAst generates an AST node representing this file
@@ -40,7 +33,7 @@ func (file *FileDefinition) AsAst() ast.Node {
 
 	// Create import header:
 	var requiredImports = make(map[PackageReference]bool) // fake set type
-	for _, s := range file.structs {
+	for _, s := range file.definitions {
 		for _, requiredImport := range s.RequiredImports() {
 			// no need to import the current package
 			if requiredImport != file.PackageReference {
@@ -67,8 +60,8 @@ func (file *FileDefinition) AsAst() ast.Node {
 		decls = append(decls, &ast.GenDecl{Tok: token.IMPORT, Specs: importSpecs})
 	}
 
-	// Emit all structs:
-	for _, s := range file.structs {
+	// Emit all definitions:
+	for _, s := range file.definitions {
 		decls = append(decls, s.AsDeclaration())
 	}
 

--- a/hack/generator/pkg/astmodel/fileDefinition_test.go
+++ b/hack/generator/pkg/astmodel/fileDefinition_test.go
@@ -15,10 +15,10 @@ func Test_NewFileDefinition_GivenValues_InitializesFields(t *testing.T) {
 	g := NewGomegaWithT(t)
 
 	person := NewTestStruct("Person", "fullName", "knownAs", "familyName")
-	file := NewFileDefinition(&person)
+	file := NewFileDefinition(person.PackageReference, &person)
 
 	g.Expect(file.PackageReference).To(Equal(person.PackageReference))
-	g.Expect(file.structs).To(HaveLen(1))
+	g.Expect(file.definitions).To(HaveLen(1))
 }
 
 func NewTestStruct(name string, fields ...string) StructDefinition {

--- a/hack/generator/pkg/astmodel/packagedefinition.go
+++ b/hack/generator/pkg/astmodel/packagedefinition.go
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) Microsoft Corporation.
+ * Licensed under the MIT license.
+ */
+
+package astmodel
+
+import (
+	"log"
+	"path/filepath"
+)
+
+type PackageDefinition struct {
+	PackageReference
+
+	definitions []Definition
+}
+
+func NewPackageDefinition(reference PackageReference) *PackageDefinition {
+	return &PackageDefinition{reference, nil}
+}
+
+func (pkgDef *PackageDefinition) AddDefinition(def Definition) {
+	pkgDef.definitions = append(pkgDef.definitions, def)
+}
+
+func (pkgDef *PackageDefinition) EmitDefinitions(outputDir string) {
+
+	// emit each definition
+	for _, def := range pkgDef.definitions {
+		genFile := NewFileDefinition(pkgDef.PackageReference, def)
+		outputFile := filepath.Join(outputDir, def.FileNameHint()+"_types.go")
+		log.Printf("Writing '%s'\n", outputFile)
+		genFile.SaveTo(outputFile)
+	}
+}

--- a/hack/generator/pkg/astmodel/structDefinition.go
+++ b/hack/generator/pkg/astmodel/structDefinition.go
@@ -98,11 +98,6 @@ func (definition *StructDefinition) FieldCount() int {
 	return len(definition.fields)
 }
 
-// AsAst generates an AST node representing this field definition
-func (definition *StructDefinition) AsAst() ast.Node {
-	return definition.AsDeclaration()
-}
-
 func (definition *StructDefinition) RequiredImports() []PackageReference {
 	var result []PackageReference
 	for _, field := range definition.fields {
@@ -114,8 +109,12 @@ func (definition *StructDefinition) RequiredImports() []PackageReference {
 	return result
 }
 
+func (definition *StructDefinition) FileNameHint() string {
+	return definition.Name()
+}
+
 // AsDeclaration generates an AST node representing this struct definition
-func (definition *StructDefinition) AsDeclaration() *ast.GenDecl {
+func (definition *StructDefinition) AsDeclaration() ast.Decl {
 
 	identifier := ast.NewIdent(definition.name)
 

--- a/hack/generator/pkg/astmodel/structDefinition_test.go
+++ b/hack/generator/pkg/astmodel/structDefinition_test.go
@@ -35,7 +35,7 @@ func Test_StructDefinitionAsAst_GivenValidStruct_ReturnsNonNilResult(t *testing.
 
 	ref := NewStructReference("name", "group", "2020-01-01")
 	field := NewStructDefinition(ref)
-	node := field.AsAst()
+	node := field.AsDeclaration()
 
 	g.Expect(node).NotTo(BeNil())
 }

--- a/hack/generator/pkg/jsonast/jsonast_test.go
+++ b/hack/generator/pkg/jsonast/jsonast_test.go
@@ -38,7 +38,7 @@ func runGoldenTest(t *testing.T, path string) {
 	nodes, err := scanner.ToNodes(context.TODO(), schema.Root())
 
 	buf := &bytes.Buffer{}
-	format.Node(buf, token.NewFileSet(), nodes.AsAst())
+	format.Node(buf, token.NewFileSet(), nodes.AsDeclaration())
 
 	g.Assert(t, testName, buf.Bytes())
 }


### PR DESCRIPTION
At the same time generalize Definition so that we will be able to add
other (non-struct) definitions like enums in the future.