### PR TITLE
Add a header to all generated files

### DIFF
--- a/hack/generator/pkg/astmodel/fileDefinition.go
+++ b/hack/generator/pkg/astmodel/fileDefinition.go
@@ -114,14 +114,11 @@ func (file *FileDefinition) AsAst() ast.Node {
 
 	// We set Package (the offset of the package keyword) so that it follows the header comments
 	result := &ast.File{
+		Doc:     &ast.CommentGroup{header},
 		Name:    ast.NewIdent(file.PackageName()),
 		Decls:   decls,
 		Package: token.Pos(headerLen),
 	}
-
-	result.Doc = &ast.CommentGroup{header}
-
-	result.Comments = append(result.Comments, &ast.CommentGroup{header})
 
 	return result
 }


### PR DESCRIPTION
Adds a header of the following form to all generated files:

```
// Copyright (c) Microsoft Corporation.
// Licensed under the MIT license.
// This is a generated file. Please do not make manual changes.
```

We need the copyright comment to keep our CI system happy once we start committing these files for use; plus we add a reminder that the files shouldn't be manually changed.