### PR TITLE
Ensure related definitions are always created

### DIFF
--- a/hack/generator/pkg/astmodel/array_type.go
+++ b/hack/generator/pkg/astmodel/array_type.go
@@ -52,14 +52,7 @@ func (array *ArrayType) Equals(t Type) bool {
 	return false
 }
 
-// RelatedDefinitions implements the HasRelatedDefinitions interface for ArrayType
-func (array *ArrayType) RelatedDefinitions(ref PackageReference, namehint string, idFactory IdentifierFactory) []Definition {
-	var result []Definition
-
-	if df, ok := array.element.(HasRelatedDefinitions); ok {
-		defns := df.RelatedDefinitions(ref, namehint, idFactory)
-		result = append(result, defns...)
-	}
-
-	return result
+// CreateRelatedDefinitions returns any additional definitions that need to be created
+func (array *ArrayType) CreateRelatedDefinitions(ref PackageReference, namehint string, idFactory IdentifierFactory) []Definition {
+	return array.element.CreateRelatedDefinitions(ref, namehint, idFactory)
 }

--- a/hack/generator/pkg/astmodel/definition.go
+++ b/hack/generator/pkg/astmodel/definition.go
@@ -20,8 +20,16 @@ type ReferenceChecker interface {
 	References(d *DefinitionName) bool
 }
 
+type HasRelatedDefinitions interface {
+	// CreateRelatedDefinitions returns any additional definitions related to this one
+	// (This allows one definition to act as a factory creating others)
+	CreateRelatedDefinitions(ref PackageReference, namehint string, idFactory IdentifierFactory) []Definition
+}
+
 // Definition represents models that can render into Go code
 type Definition interface {
+	HasRelatedDefinitions
+
 	// FileNameHint returns what a file that contains this definition (if any) should be called
 	// this is not always used as we might combine multiple definitions into one file
 	FileNameHint() string
@@ -37,16 +45,13 @@ type Definition interface {
 
 	// Tidy cleans up the definition prior to code generation
 	Tidy()
-
-	// CreateRelatedDefinitions returns any additional definitions related to this one
-	// (This allows one definition to act as a factory creating others)
-	CreateRelatedDefinitions(ref PackageReference, namehint string, idFactory IdentifierFactory) []Definition
 }
 
 // Type represents something that is a Go type
 type Type interface {
 	HasImports
 	ReferenceChecker
+	HasRelatedDefinitions
 
 	// AsType renders the current instance as a Go abstract syntax tree
 	AsType() ast.Expr

--- a/hack/generator/pkg/astmodel/definition.go
+++ b/hack/generator/pkg/astmodel/definition.go
@@ -37,11 +37,10 @@ type Definition interface {
 
 	// Tidy cleans up the definition prior to code generation
 	Tidy()
-}
 
-// A HasRelatedDefinitions is capable of creating additional definitions
-type HasRelatedDefinitions interface {
-	RelatedDefinitions(ref PackageReference, namehint string, idFactory IdentifierFactory) []Definition
+	// CreateRelatedDefinitions returns any additional definitions related to this one
+	// (This allows one definition to act as a factory creating others)
+	CreateRelatedDefinitions(ref PackageReference, namehint string, idFactory IdentifierFactory) []Definition
 }
 
 // Type represents something that is a Go type

--- a/hack/generator/pkg/astmodel/definition.go
+++ b/hack/generator/pkg/astmodel/definition.go
@@ -20,6 +20,7 @@ type ReferenceChecker interface {
 	References(d *DefinitionName) bool
 }
 
+// HasRelatedDefinitions specifies that the type might create additional supporting definitions
 type HasRelatedDefinitions interface {
 	// CreateRelatedDefinitions returns any additional definitions related to this one
 	// (This allows one definition to act as a factory creating others)

--- a/hack/generator/pkg/astmodel/definition_name.go
+++ b/hack/generator/pkg/astmodel/definition_name.go
@@ -50,3 +50,8 @@ func (dn *DefinitionName) Equals(t Type) bool {
 
 	return false
 }
+
+// CreateRelatedDefinitions indicates that a DefinitionName has no related definitions
+func (dn *DefinitionName) CreateRelatedDefinitions(ref PackageReference, namehint string, idFactory IdentifierFactory) []Definition {
+	return nil
+}

--- a/hack/generator/pkg/astmodel/enum_definition.go
+++ b/hack/generator/pkg/astmodel/enum_definition.go
@@ -19,6 +19,7 @@ type EnumDefinition struct {
 
 var _ Definition = (*EnumDefinition)(nil)
 
+// NewEnumDefinition is a factory method for creating new Enum Definitions
 func NewEnumDefinition(name DefinitionName, t *EnumType) *EnumDefinition {
 	return &EnumDefinition{DefinitionName: name, baseType: t}
 }

--- a/hack/generator/pkg/astmodel/enum_type.go
+++ b/hack/generator/pkg/astmodel/enum_type.go
@@ -27,9 +27,6 @@ type EnumValue struct {
 // EnumType must implement the Type interface correctly
 var _ Type = (*EnumType)(nil)
 
-// EnumType must implement the HasRelatedDefinitions interface correctly
-var _ HasRelatedDefinitions = (*EnumType)(nil)
-
 // NewEnumType defines a new enumeration including the legal values
 func NewEnumType(baseType *PrimitiveType, options []EnumValue) *EnumType {
 	return &EnumType{BaseType: baseType, Options: options}

--- a/hack/generator/pkg/astmodel/enum_type.go
+++ b/hack/generator/pkg/astmodel/enum_type.go
@@ -13,8 +13,8 @@ type EnumType struct {
 	BaseType *PrimitiveType
 	// Options is the set of all unique values
 	Options []EnumValue
-	// name is our actual name, only available once generated, assigned by CreateRelatedDefinitions()
-	name string
+	// canonicalName is our actual name, only available once generated, assigned by CreateRelatedDefinitions()
+	canonicalName DefinitionName
 }
 
 // EnumType must implement the Type interface correctly
@@ -27,21 +27,19 @@ func NewEnumType(baseType *PrimitiveType, options []EnumValue) *EnumType {
 
 // AsType implements Type for EnumType
 func (enum *EnumType) AsType() ast.Expr {
-	return ast.NewIdent(enum.name)
+	return ast.NewIdent(enum.canonicalName.name)
 }
 
 // References indicates whether this Type includes any direct references to the given Type?
 func (enum *EnumType) References(d *DefinitionName) bool {
-	return enum.DefinitionName.References(d)
+	return enum.canonicalName.References(d)
 }
 
 // CreateRelatedDefinitions returns a definition for our enumeration, with a name based on the referencing property
 func (enum *EnumType) CreateRelatedDefinitions(ref PackageReference, namehint string, idFactory IdentifierFactory) []Definition {
 	identifier := idFactory.CreateEnumIdentifier(namehint)
-	dn := DefinitionName{PackageReference: ref, name: identifier}
-	definition := NewEnumDefinition(dn, enum)
-
-	enum.name = dn.name
+	enum.canonicalName = DefinitionName{PackageReference: ref, name: identifier}
+	definition := NewEnumDefinition(enum.canonicalName, enum)
 	return []Definition{definition}
 }
 

--- a/hack/generator/pkg/astmodel/enum_value.go
+++ b/hack/generator/pkg/astmodel/enum_value.go
@@ -1,0 +1,1 @@
+package astmodel

--- a/hack/generator/pkg/astmodel/enum_value.go
+++ b/hack/generator/pkg/astmodel/enum_value.go
@@ -1,1 +1,17 @@
 package astmodel
+
+// EnumValue captures a single value of the enumeration
+type EnumValue struct {
+	// Identifier is a Go identifer for the value
+	Identifier string
+	// Value is the actual value expected by ARM
+	Value string
+}
+
+func (value *EnumValue) Equals(v *EnumValue) bool {
+	if value == v {
+		return true
+	}
+
+	return value.Identifier == v.Identifier && value.Value == v.Value
+}

--- a/hack/generator/pkg/astmodel/enum_value.go
+++ b/hack/generator/pkg/astmodel/enum_value.go
@@ -8,6 +8,7 @@ type EnumValue struct {
 	Value string
 }
 
+// Equals tests to see if the passed EnumValue has the same name and value
 func (value *EnumValue) Equals(v *EnumValue) bool {
 	if value == v {
 		return true

--- a/hack/generator/pkg/astmodel/enum_value.go
+++ b/hack/generator/pkg/astmodel/enum_value.go
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) Microsoft Corporation.
+ * Licensed under the MIT license.
+ */
+
 package astmodel
 
 // EnumValue captures a single value of the enumeration

--- a/hack/generator/pkg/astmodel/field_definition.go
+++ b/hack/generator/pkg/astmodel/field_definition.go
@@ -130,3 +130,8 @@ func (field *FieldDefinition) AsField() *ast.Field {
 func (field *FieldDefinition) Equals(f *FieldDefinition) bool {
 	return field == f || (field.fieldName == f.fieldName && field.fieldType.Equals(f.fieldType))
 }
+
+// CreateRelatedDefinitions returns a set of definitions related to this one
+func (field *FieldDefinition) CreateRelatedDefinitions(ref PackageReference, namehint string, idFactory IdentifierFactory) []Definition {
+	return field.fieldType.CreateRelatedDefinitions(ref, namehint, idFactory)
+}

--- a/hack/generator/pkg/astmodel/map_type.go
+++ b/hack/generator/pkg/astmodel/map_type.go
@@ -62,19 +62,12 @@ func (m *MapType) Equals(t Type) bool {
 	return false
 }
 
-// RelatedDefinitions implements the HasRelatedDefinitions interface for MapType
-func (m *MapType) RelatedDefinitions(ref PackageReference, namehint string, idFactory IdentifierFactory) []Definition {
-	var result []Definition
+// CreateRelatedDefinitions returns any definitions required by our key or value types
+func (m *MapType) CreateRelatedDefinitions(ref PackageReference, namehint string, idFactory IdentifierFactory) []Definition {
+	result := m.key.CreateRelatedDefinitions(ref, namehint, idFactory)
 
-	if df, ok := m.key.(HasRelatedDefinitions); ok {
-		defns := df.RelatedDefinitions(ref, namehint, idFactory)
-		result = append(result, defns...)
-	}
-
-	if df, ok := m.value.(HasRelatedDefinitions); ok {
-		defns := df.RelatedDefinitions(ref, namehint, idFactory)
-		result = append(result, defns...)
-	}
+	otherDefinitions := m.value.CreateRelatedDefinitions(ref, namehint, idFactory)
+	result = append(result, otherDefinitions...)
 
 	return result
 }

--- a/hack/generator/pkg/astmodel/optional_type.go
+++ b/hack/generator/pkg/astmodel/optional_type.go
@@ -51,3 +51,8 @@ func (optional *OptionalType) Equals(t Type) bool {
 
 	return false
 }
+
+func (optional *OptionalType) CreateRelatedDefinitions(ref PackageReference, namehint string, idFactory IdentifierFactory) []Definition {
+	return optional.element.CreateRelatedDefinitions(ref, namehint, idFactory)
+}
+

--- a/hack/generator/pkg/astmodel/optional_type.go
+++ b/hack/generator/pkg/astmodel/optional_type.go
@@ -52,6 +52,7 @@ func (optional *OptionalType) Equals(t Type) bool {
 	return false
 }
 
+// CreateRelatedDefinitions returns any additional definitions that need to be created
 func (optional *OptionalType) CreateRelatedDefinitions(ref PackageReference, namehint string, idFactory IdentifierFactory) []Definition {
 	return optional.element.CreateRelatedDefinitions(ref, namehint, idFactory)
 }

--- a/hack/generator/pkg/astmodel/primitive_type.go
+++ b/hack/generator/pkg/astmodel/primitive_type.go
@@ -56,3 +56,7 @@ func (prim *PrimitiveType) Equals(t Type) bool {
 
 	return false
 }
+// CreateRelatedDefinitions states that primitive types don't have any related definitions
+func (prim *PrimitiveType) CreateRelatedDefinitions(ref PackageReference, namehint string, idFactory IdentifierFactory) []Definition {
+	return nil
+}

--- a/hack/generator/pkg/astmodel/struct_definition.go
+++ b/hack/generator/pkg/astmodel/struct_definition.go
@@ -40,9 +40,6 @@ type StructDefinition struct {
 // Ensure StructDefinition implements Definition interface correctly
 var _ Definition = (*StructDefinition)(nil)
 
-// Ensure StructDefinition implements the HasRelatedDefinitions interface correctly
-var _ HasRelatedDefinitions = (*StructDefinition)(nil)
-
 // Reference provides the definition name
 func (definition *StructDefinition) Reference() *DefinitionName {
 	return &definition.DefinitionName

--- a/hack/generator/pkg/astmodel/struct_type.go
+++ b/hack/generator/pkg/astmodel/struct_type.go
@@ -15,11 +15,9 @@ type StructType struct {
 	fields []*FieldDefinition
 }
 
+
 // Ensure StructType implements the Type interface correctly
 var _ Type = (*StructType)(nil)
-
-// Ensure StructType implements the HasRelatedDefinitions interface correctly
-var _ HasRelatedDefinitions = (*StructType)(nil)
 
 // NewStructType is a factory method for creating a new StructTypeDefinition
 func NewStructType(fields ...*FieldDefinition) *StructType {
@@ -112,15 +110,13 @@ func (structType *StructType) Equals(t Type) bool {
 	return false
 }
 
-// RelatedDefinitions implements the HasRelatedDefinitions interface for StructType
-func (structType *StructType) RelatedDefinitions(ref PackageReference, namehint string, idFactory IdentifierFactory) []Definition {
+// CreateRelatedDefinitions implements the HasRelatedDefinitions interface for StructType
+func (structType *StructType) CreateRelatedDefinitions(ref PackageReference, namehint string, idFactory IdentifierFactory) []Definition {
 	var result []Definition
 	for _, f := range structType.fields {
-		if df, ok := f.fieldType.(HasRelatedDefinitions); ok {
-			nh := namehint + "." + string(f.fieldName)
-			defns := df.RelatedDefinitions(ref, nh, idFactory)
-			result = append(result, defns...)
-		}
+		nh := namehint + "." + string(f.fieldName)
+		defns := f.CreateRelatedDefinitions(ref, nh, idFactory)
+		result = append(result, defns...)
 	}
 
 	return result

--- a/hack/generator/pkg/jsonast/jsonast.go
+++ b/hack/generator/pkg/jsonast/jsonast.go
@@ -425,8 +425,8 @@ func refHandler(ctx context.Context, scanner *SchemaScanner, schema *gojsonschem
 		// this will overwrite placeholder added above
 		scanner.AddDefinition(sd)
 
-		// Add any further definitions related to this
-		relatedDefinitions := sd.RelatedDefinitions(structReference.PackageReference, structReference.Name(), scanner.idFactory)
+		// Add any further definitions needed to make this one complete (e.g. enumerations & methods)
+		relatedDefinitions := sd.CreateRelatedDefinitions(structReference.PackageReference, structReference.Name(), scanner.idFactory)
 		for _, d := range relatedDefinitions {
 			scanner.AddDefinition(d)
 		}


### PR DESCRIPTION
Having the `HasRelatedDefinitions` interface optional meant that container types (such as Array and Map) could easily neglect implementation, resulting in definitions being omitted from the generated code.

This PR makes it mandatory for both definitions and types to implement the interface by including it as a part of both `Definition` and `Type`. 

As a necessary part of this, `EnumDefinition` is no longer compatible with `EnumType` - this wasn't actually needed and becomes impossible with the change described above (any struct trying to implement both `Definition` and `Type` experiences a compiler error).
