### PR TITLE
TypeName references (in structs, maps, etc) must use package reference if not from the current package

### DIFF
--- a/hack/generator/azure-cloud.yaml
+++ b/hack/generator/azure-cloud.yaml
@@ -6,3 +6,6 @@ typefilters:
   - action: exclude
     version: '*preview'
     because: preview SDK versions are excluded by default
+  - action: exclude
+    group: 'deploymenttemplate'
+    because: this is the "container" group that holds references to all of the other groups and as such doesn't make sense to generate

--- a/hack/generator/pkg/astmodel/array_type.go
+++ b/hack/generator/pkg/astmodel/array_type.go
@@ -23,14 +23,14 @@ func NewArrayType(element Type) *ArrayType {
 var _ Type = (*ArrayType)(nil)
 
 // AsType renders the Go abstract syntax tree for an array type
-func (array *ArrayType) AsType() ast.Expr {
+func (array *ArrayType) AsType(codeGenerationContext *CodeGenerationContext) ast.Expr {
 	return &ast.ArrayType{
-		Elt: array.element.AsType(),
+		Elt: array.element.AsType(codeGenerationContext),
 	}
 }
 
 // RequiredImports returns a list of packages required by this
-func (array *ArrayType) RequiredImports() []PackageReference {
+func (array *ArrayType) RequiredImports() []*PackageReference {
 	return array.element.RequiredImports()
 }
 

--- a/hack/generator/pkg/astmodel/code_generation_context.go
+++ b/hack/generator/pkg/astmodel/code_generation_context.go
@@ -10,21 +10,26 @@ package astmodel
 // in which the field declaration occurs - for example in a file with two conflicting package references
 // a disambiguation must occur and field types must ensure they correctly refer to the disambiguated types
 type CodeGenerationContext struct {
-	packageReferences map[PackageReference]struct{}
-	currentPackage    *PackageReference
+	packageImports map[PackageReference]PackageImport
+	currentPackage *PackageReference
 }
 
 // New CodeGenerationContext creates a new immutable code generation context
-func NewCodeGenerationContext(currentPackage *PackageReference, packageReferences map[PackageReference]struct{}) *CodeGenerationContext {
-	return &CodeGenerationContext{currentPackage: currentPackage, packageReferences: packageReferences}
+func NewCodeGenerationContext(currentPackage *PackageReference, packageImports map[PackageImport]struct{}) *CodeGenerationContext {
+	packageImportsMap := make(map[PackageReference]PackageImport)
+	for imp := range packageImports {
+		packageImportsMap[imp.PackageReference] = imp
+	}
+
+	return &CodeGenerationContext{currentPackage: currentPackage, packageImports: packageImportsMap}
 }
 
-// PackageReferences returns the set of package references in the current context
-func (codeGenContext *CodeGenerationContext) PackageReferences() map[PackageReference]struct{} {
+// PackageImports returns the set of package references in the current context
+func (codeGenContext *CodeGenerationContext) PackageImports() map[PackageReference]PackageImport {
 	// return a copy of the map to ensure immutability
-	result := make(map[PackageReference]struct{})
+	result := make(map[PackageReference]PackageImport)
 
-	for key, value := range codeGenContext.packageReferences {
+	for key, value := range codeGenContext.packageImports {
 		result[key] = value
 	}
 	return result

--- a/hack/generator/pkg/astmodel/code_generation_context.go
+++ b/hack/generator/pkg/astmodel/code_generation_context.go
@@ -14,8 +14,6 @@ type CodeGenerationContext struct {
 	currentPackage    *PackageReference
 }
 
-// TODO: How picky about immutability should we be -- should we put this in its own package?
-
 // New CodeGenerationContext creates a new immutable code generation context
 func NewCodeGenerationContext(currentPackage *PackageReference, packageReferences map[PackageReference]struct{}) *CodeGenerationContext {
 	return &CodeGenerationContext{currentPackage: currentPackage, packageReferences: packageReferences}

--- a/hack/generator/pkg/astmodel/code_generation_context.go
+++ b/hack/generator/pkg/astmodel/code_generation_context.go
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) Microsoft Corporation.
+ * Licensed under the MIT license.
+ */
+
+package astmodel
+
+// CodeGenerationContext stores context about the location code-generation is occurring.
+// This is required because some things (such as specific field types) are impacted by the context
+// in which the field declaration occurs - for example in a file with two conflicting package references
+// a disambiguation must occur and field types must ensure they correctly refer to the disambiguated types
+type CodeGenerationContext struct {
+	packageReferences map[PackageReference]struct{}
+	currentPackage    *PackageReference
+}
+
+// TODO: How picky about immutability should we be -- should we put this in its own package?
+
+// New CodeGenerationContext creates a new immutable code generation context
+func NewCodeGenerationContext(currentPackage *PackageReference, packageReferences map[PackageReference]struct{}) *CodeGenerationContext {
+	return &CodeGenerationContext{currentPackage: currentPackage, packageReferences: packageReferences}
+}
+
+// PackageReferences returns the set of package references in the current context
+func (codeGenContext *CodeGenerationContext) PackageReferences() map[PackageReference]struct{} {
+	// return a copy of the map to ensure immutability
+	result := make(map[PackageReference]struct{})
+
+	for key, value := range codeGenContext.packageReferences {
+		result[key] = value
+	}
+	return result
+}

--- a/hack/generator/pkg/astmodel/enum_definition.go
+++ b/hack/generator/pkg/astmodel/enum_definition.go
@@ -41,7 +41,7 @@ func (enum *EnumDefinition) WithDescription(description *string) TypeDefiner {
 }
 
 // AsDeclarations generates the Go code representing this definition
-func (enum *EnumDefinition) AsDeclarations() []ast.Decl {
+func (enum *EnumDefinition) AsDeclarations(codeGenerationContext *CodeGenerationContext) []ast.Decl {
 	var specs []ast.Spec
 	for _, v := range enum.baseType.Options() {
 		s := enum.createValueDeclaration(v)
@@ -55,18 +55,18 @@ func (enum *EnumDefinition) AsDeclarations() []ast.Decl {
 	}
 
 	result := []ast.Decl{
-		enum.createBaseDeclaration(),
+		enum.createBaseDeclaration(codeGenerationContext),
 		declaration}
 
 	return result
 }
 
-func (enum *EnumDefinition) createBaseDeclaration() ast.Decl {
+func (enum *EnumDefinition) createBaseDeclaration(codeGenerationContext *CodeGenerationContext) ast.Decl {
 	identifier := ast.NewIdent(enum.typeName.name)
 
 	typeSpecification := &ast.TypeSpec{
 		Name: identifier,
-		Type: enum.baseType.BaseType.AsType(),
+		Type: enum.baseType.BaseType.AsType(codeGenerationContext),
 	}
 
 	declaration := &ast.GenDecl{

--- a/hack/generator/pkg/astmodel/enum_type.go
+++ b/hack/generator/pkg/astmodel/enum_type.go
@@ -35,7 +35,7 @@ func NewEnumType(baseType *PrimitiveType, options []EnumValue) *EnumType {
 // AsType implements Type for EnumType
 func (enum *EnumType) AsType(codeGenerationContext *CodeGenerationContext) ast.Expr {
 	// this should "never" happen as we name all enums; warn about it if it does
-	klog.Warning("emitting unnamed enum, something’s awry")
+	klog.Warning("Emitting unnamed enum, something’s awry")
 	return enum.BaseType.AsType(codeGenerationContext)
 }
 

--- a/hack/generator/pkg/astmodel/enum_type.go
+++ b/hack/generator/pkg/astmodel/enum_type.go
@@ -33,10 +33,10 @@ func NewEnumType(baseType *PrimitiveType, options []EnumValue) *EnumType {
 }
 
 // AsType implements Type for EnumType
-func (enum *EnumType) AsType() ast.Expr {
+func (enum *EnumType) AsType(codeGenerationContext *CodeGenerationContext) ast.Expr {
 	// this should "never" happen as we name all enums; warn about it if it does
 	klog.Warning("emitting unnamed enum, something’s awry")
-	return enum.BaseType.AsType()
+	return enum.BaseType.AsType(codeGenerationContext)
 }
 
 // References indicates whether this Type includes any direct references to the given Type
@@ -70,7 +70,7 @@ func (enum *EnumType) Equals(t Type) bool {
 }
 
 // RequiredImports indicates that Enums never need additional imports
-func (enum *EnumType) RequiredImports() []PackageReference {
+func (enum *EnumType) RequiredImports() []*PackageReference {
 	return nil
 }
 

--- a/hack/generator/pkg/astmodel/field_definition.go
+++ b/hack/generator/pkg/astmodel/field_definition.go
@@ -95,12 +95,12 @@ func (field *FieldDefinition) MakeOptional() *FieldDefinition {
 }
 
 // AsField generates an AST field node representing this field definition
-func (field *FieldDefinition) AsField() *ast.Field {
+func (field *FieldDefinition) AsField(codeGenerationContext *CodeGenerationContext) *ast.Field {
 
 	result := &ast.Field{
 		Doc:   &ast.CommentGroup{},
 		Names: []*ast.Ident{ast.NewIdent(string(field.fieldName))},
-		Type:  field.FieldType().AsType(),
+		Type:  field.FieldType().AsType(codeGenerationContext),
 		Tag: &ast.BasicLit{
 			Kind:  token.STRING,
 			Value: fmt.Sprintf("`json:%q`", field.jsonName),

--- a/hack/generator/pkg/astmodel/field_definition.go
+++ b/hack/generator/pkg/astmodel/field_definition.go
@@ -127,7 +127,7 @@ func (field *FieldDefinition) AsField(codeGenerationContext *CodeGenerationConte
 
 	// generate doc comment:
 	if field.description != "" {
-		addDocComment(fmt.Sprintf("/* %s: %s */", field.fieldName, field.description))
+		addDocComment(fmt.Sprintf("/*%s: %s*/", field.fieldName, field.description))
 	}
 
 	return result

--- a/hack/generator/pkg/astmodel/field_definition_test.go
+++ b/hack/generator/pkg/astmodel/field_definition_test.go
@@ -49,8 +49,7 @@ func Test_FieldDefinitionAsAst_GivenValidField_ReturnsNonNilResult(t *testing.T)
 	g := NewGomegaWithT(t)
 
 	field := NewFieldDefinition("FullName", "fullName", StringType)
-	//cgCtx = NewCodeGenerationContext()
-	node := field.AsField(nil) // TODO: ?
+	node := field.AsField(nil)
 
 	g.Expect(node).NotTo(BeNil())
 }

--- a/hack/generator/pkg/astmodel/field_definition_test.go
+++ b/hack/generator/pkg/astmodel/field_definition_test.go
@@ -49,7 +49,8 @@ func Test_FieldDefinitionAsAst_GivenValidField_ReturnsNonNilResult(t *testing.T)
 	g := NewGomegaWithT(t)
 
 	field := NewFieldDefinition("FullName", "fullName", StringType)
-	node := field.AsField()
+	//cgCtx = NewCodeGenerationContext()
+	node := field.AsField(nil) // TODO: ?
 
 	g.Expect(node).NotTo(BeNil())
 }

--- a/hack/generator/pkg/astmodel/file_definition.go
+++ b/hack/generator/pkg/astmodel/file_definition.go
@@ -65,7 +65,8 @@ func (file *FileDefinition) generateImports() map[PackageImport]struct{} {
 		for otherImp := range requiredImports {
 			if !imp.Equals(&otherImp) && imp.PackageName() == otherImp.PackageName() {
 				klog.Warningf(
-					"Import %v (named %v) and import %v (named %v) conflict",
+					"File %v: import %v (named %v) and import %v (named %v) conflict",
+					file.packageReference.PackagePath(),
 					imp.PackageReference.PackagePath(),
 					imp.PackageName(),
 					otherImp.PackageReference.PackagePath(),

--- a/hack/generator/pkg/astmodel/file_definition.go
+++ b/hack/generator/pkg/astmodel/file_definition.go
@@ -21,13 +21,13 @@ import (
 // FileDefinition is the content of a file we're generating
 type FileDefinition struct {
 	// the package this file is in
-	PackageReference
+	packageReference *PackageReference
 	// definitions to include in this file
 	definitions []TypeDefiner
 }
 
 // NewFileDefinition creates a file definition containing specified definitions
-func NewFileDefinition(packageRef PackageReference, definitions ...TypeDefiner) *FileDefinition {
+func NewFileDefinition(packageRef *PackageReference, definitions ...TypeDefiner) *FileDefinition {
 
 	sort.Slice(definitions, func(i, j int) bool {
 		return definitions[i].Name().name < definitions[j].Name().name
@@ -37,37 +37,31 @@ func NewFileDefinition(packageRef PackageReference, definitions ...TypeDefiner) 
 	return &FileDefinition{packageRef, definitions}
 }
 
-func (file *FileDefinition) generateImportSpecs() []ast.Spec {
+// generateImports products the definitive set of imports for use in this file and
+// disambiguates any conflicts
+func (file *FileDefinition) generateImports() map[PackageReference]struct{} {
+	metav1Import := NewPackageReference("k8s.io/apimachinery/pkg/apis/meta/v1").WithName("metav1")
 
-	metav1 := ast.NewIdent("metav1")
-	importSpecs := []ast.Spec{
-		&ast.ImportSpec{
-			Name: metav1,
-			Path: &ast.BasicLit{
-				Kind:  token.STRING,
-				Value: "\"k8s.io/apimachinery/pkg/apis/meta/v1\"",
-			},
-		},
-	}
+	var requiredImports = make(map[PackageReference]struct{}) // fake set type
+	requiredImports[*metav1Import] = struct{}{}
 
-	var requiredImports = make(map[PackageReference]bool) // fake set type
 	for _, s := range file.definitions {
 		for _, requiredImport := range s.Type().RequiredImports() {
 			// no need to import the current package
-			if requiredImport != file.PackageReference {
-				requiredImports[requiredImport] = true
+			if !requiredImport.Equals(file.packageReference) {
+				requiredImports[*requiredImport] = struct{}{}
 			}
 		}
 	}
 
-	for requiredImport := range requiredImports {
-		importSpecs = append(importSpecs, &ast.ImportSpec{
-			Name: nil,
-			Path: &ast.BasicLit{
-				Kind:  token.STRING,
-				Value: "\"" + requiredImport.PackagePath() + "\"",
-			},
-		})
+	// TODO: handle conflicting names
+	return requiredImports
+}
+
+func (file *FileDefinition) generateImportSpecs(references map[PackageReference]struct{}) []ast.Spec {
+	var importSpecs []ast.Spec
+	for requiredImport := range references {
+		importSpecs = append(importSpecs, requiredImport.AsImportSpec())
 	}
 
 	return importSpecs
@@ -78,12 +72,18 @@ func (file *FileDefinition) AsAst() ast.Node {
 
 	var decls []ast.Decl
 
+	// Determine imports
+	packageReferences := file.generateImports()
+
+	// Create context from imports
+	codeGenContext := NewCodeGenerationContext(file.packageReference, packageReferences)
+
 	// Create import header:
-	decls = append(decls, &ast.GenDecl{Tok: token.IMPORT, Specs: file.generateImportSpecs()})
+	decls = append(decls, &ast.GenDecl{Tok: token.IMPORT, Specs: file.generateImportSpecs(packageReferences)})
 
 	// Emit all definitions:
 	for _, s := range file.definitions {
-		decls = append(decls, s.AsDeclarations()...)
+		decls = append(decls, s.AsDeclarations(codeGenContext)...)
 	}
 
 	// Emit struct registration for each resource:
@@ -92,7 +92,7 @@ func (file *FileDefinition) AsAst() ast.Node {
 		if structDefn, ok := defn.(*StructDefinition); ok && structDefn.IsResource() {
 			exprs = append(exprs, &ast.UnaryExpr{
 				Op: token.AND,
-				X:  &ast.CompositeLit{Type: structDefn.Name().AsType()},
+				X:  &ast.CompositeLit{Type: structDefn.Name().AsType(codeGenContext)},
 			})
 		}
 	}
@@ -125,7 +125,7 @@ func (file *FileDefinition) AsAst() ast.Node {
 		Doc: &ast.CommentGroup{
 			List: header,
 		},
-		Name:    ast.NewIdent(file.PackageName()),
+		Name:    ast.NewIdent(file.packageReference.PackageName()),
 		Decls:   decls,
 		Package: token.Pos(headerLen),
 	}

--- a/hack/generator/pkg/astmodel/file_definition.go
+++ b/hack/generator/pkg/astmodel/file_definition.go
@@ -54,7 +54,23 @@ func (file *FileDefinition) generateImports() map[PackageReference]struct{} {
 		}
 	}
 
-	// TODO: handle conflicting names
+	// TODO: Do something about conflicting imports
+
+	// Determine if there are any conflicting imports -- these are imports with the same "name"
+	// but a different package path
+	for imp, _ := range requiredImports {
+		for otherImp, _ := range requiredImports {
+			if !imp.Equals(&otherImp) && imp.PackageName() == otherImp.PackageName() {
+				klog.Warningf(
+					"Import %v (named %v) and import %v (named %v) conflict",
+					imp.PackagePath(),
+					imp.PackageName(),
+					otherImp.PackagePath(),
+					otherImp.PackageName())
+			}
+		}
+	}
+
 	return requiredImports
 }
 

--- a/hack/generator/pkg/astmodel/file_definition_test.go
+++ b/hack/generator/pkg/astmodel/file_definition_test.go
@@ -15,9 +15,9 @@ func Test_NewFileDefinition_GivenValues_InitializesFields(t *testing.T) {
 	g := NewGomegaWithT(t)
 
 	person := NewTestStruct("Person", "fullName", "knownAs", "familyName")
-	file := NewFileDefinition(person.Name().PackageReference, &person)
+	file := NewFileDefinition(&person.Name().PackageReference, &person)
 
-	g.Expect(file.PackageReference).To(Equal(person.Name().PackageReference))
+	g.Expect(*file.packageReference).To(Equal(person.Name().PackageReference))
 	g.Expect(file.definitions).To(HaveLen(1))
 }
 
@@ -27,7 +27,7 @@ func NewTestStruct(name string, fields ...string) StructDefinition {
 		fs = append(fs, NewFieldDefinition(FieldName(n), n, StringType))
 	}
 
-	ref := NewTypeName(NewLocalPackageReference("group", "2020-01-01"), name)
+	ref := NewTypeName(*NewLocalPackageReference("group", "2020-01-01"), name)
 	definition := NewStructDefinition(ref, NewStructType(fs...), false)
 
 	return *definition

--- a/hack/generator/pkg/astmodel/function.go
+++ b/hack/generator/pkg/astmodel/function.go
@@ -11,12 +11,12 @@ import (
 
 // Function represents something that is an (unnamed) Go function
 type Function interface {
-	RequiredImports() []PackageReference
+	RequiredImports() []*PackageReference
 
 	References(name *TypeName) bool
 
 	// AsFunc renders the current instance as a Go abstract syntax tree
-	AsFunc(receiver *TypeName, methodName string) *ast.FuncDecl
+	AsFunc(codeGenerationContext *CodeGenerationContext, receiver *TypeName, methodName string) *ast.FuncDecl
 
 	// Equals determines if this Function is equal to another one
 	Equals(f Function) bool

--- a/hack/generator/pkg/astmodel/map_type.go
+++ b/hack/generator/pkg/astmodel/map_type.go
@@ -29,16 +29,16 @@ func NewStringMapType(value Type) *MapType {
 var _ Type = (*MapType)(nil)
 
 // AsType implements Type for MapType to create the abstract syntax tree for a map
-func (m *MapType) AsType() ast.Expr {
+func (m *MapType) AsType(codeGenerationContext *CodeGenerationContext) ast.Expr {
 	return &ast.MapType{
-		Key:   m.key.AsType(),
-		Value: m.value.AsType(),
+		Key:   m.key.AsType(codeGenerationContext),
+		Value: m.value.AsType(codeGenerationContext),
 	}
 }
 
 // RequiredImports returns a list of packages required by this
-func (m *MapType) RequiredImports() []PackageReference {
-	var result []PackageReference
+func (m *MapType) RequiredImports() []*PackageReference {
+	var result []*PackageReference
 	result = append(result, m.key.RequiredImports()...)
 	result = append(result, m.value.RequiredImports()...)
 	return result

--- a/hack/generator/pkg/astmodel/one_of_json_marshal_function.go
+++ b/hack/generator/pkg/astmodel/one_of_json_marshal_function.go
@@ -42,7 +42,11 @@ func (f *OneOfJSONMarshalFunction) References(name *TypeName) bool {
 }
 
 // AsFunc returns the function as a go ast
-func (f *OneOfJSONMarshalFunction) AsFunc(receiver *TypeName, methodName string) *ast.FuncDecl {
+func (f *OneOfJSONMarshalFunction) AsFunc(
+	codeGenerationContext *CodeGenerationContext,
+	receiver *TypeName,
+	methodName string) *ast.FuncDecl {
+
 	receiverName := f.idFactory.CreateIdentifier(receiver.name, NotExported)
 
 	header, _ := createComments(
@@ -59,7 +63,7 @@ func (f *OneOfJSONMarshalFunction) AsFunc(receiver *TypeName, methodName string)
 		Recv: &ast.FieldList{
 			List: []*ast.Field{
 				{
-					Type:  receiver.AsType(),
+					Type:  receiver.AsType(codeGenerationContext),
 					Names: []*ast.Ident{ast.NewIdent(receiverName)},
 				},
 			},
@@ -131,8 +135,8 @@ func (f *OneOfJSONMarshalFunction) AsFunc(receiver *TypeName, methodName string)
 }
 
 // RequiredImports returns a list of packages required by this
-func (f *OneOfJSONMarshalFunction) RequiredImports() []PackageReference {
-	return []PackageReference{
-		{"encoding/json"},
+func (f *OneOfJSONMarshalFunction) RequiredImports() []*PackageReference {
+	return []*PackageReference{
+		NewPackageReference("encoding/json"),
 	}
 }

--- a/hack/generator/pkg/astmodel/optional_type.go
+++ b/hack/generator/pkg/astmodel/optional_type.go
@@ -23,14 +23,14 @@ func NewOptionalType(element Type) *OptionalType {
 var _ Type = (*OptionalType)(nil)
 
 // AsType renders the Go abstract syntax tree for an optional type
-func (optional *OptionalType) AsType() ast.Expr {
+func (optional *OptionalType) AsType(codeGenerationContext *CodeGenerationContext) ast.Expr {
 	return &ast.StarExpr{
-		X: optional.element.AsType(),
+		X: optional.element.AsType(codeGenerationContext),
 	}
 }
 
 // RequiredImports returns the imports required by the 'element' type
-func (optional *OptionalType) RequiredImports() []PackageReference {
+func (optional *OptionalType) RequiredImports() []*PackageReference {
 	return optional.element.RequiredImports()
 }
 

--- a/hack/generator/pkg/astmodel/package_definition.go
+++ b/hack/generator/pkg/astmodel/package_definition.go
@@ -64,7 +64,7 @@ func (pkgDef *PackageDefinition) DefinitionCount() int {
 
 func emitFiles(filesToGenerate map[string][]TypeDefiner, outputDir string) error {
 	for fileName, defs := range filesToGenerate {
-		genFile := NewFileDefinition(defs[0].Name().PackageReference, defs...)
+		genFile := NewFileDefinition(&defs[0].Name().PackageReference, defs...)
 		outputFile := filepath.Join(outputDir, fileName+"_types.go")
 		klog.V(5).Infof("Writing '%s'\n", outputFile)
 		err := genFile.SaveToFile(outputFile)

--- a/hack/generator/pkg/astmodel/package_import.go
+++ b/hack/generator/pkg/astmodel/package_import.go
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) Microsoft Corporation.
+ * Licensed under the MIT license.
+ */
+
+package astmodel
+
+import (
+	"go/ast"
+	"go/token"
+)
+
+// PackageReference indicates which package
+// a struct belongs to.
+type PackageImport struct {
+	PackageReference PackageReference // This is used as the key in a map so can't be pointer
+	name             *string
+}
+
+// NewPackageImport creates a new package import from a reference
+func NewPackageImport(packageReference PackageReference) *PackageImport {
+	return &PackageImport{
+		PackageReference: packageReference,
+	}
+}
+
+// WithName creates a new package reference with a friendly name
+func (pi *PackageImport) WithName(name string) *PackageImport {
+	result := NewPackageImport(pi.PackageReference)
+	result.name = &name
+
+	return result
+}
+
+func (pi *PackageImport) AsImportSpec() *ast.ImportSpec {
+	var name *ast.Ident
+	if pi.name != nil {
+		name = ast.NewIdent(*pi.name)
+	}
+
+	return &ast.ImportSpec{
+		Name: name,
+		Path: &ast.BasicLit{
+			Kind:  token.STRING,
+			Value: "\"" + pi.PackageReference.PackagePath() + "\"",
+		},
+	}
+}
+
+// PackageName is the package name of the package reference
+func (pi *PackageImport) PackageName() string {
+	if pi.name != nil {
+		return *pi.name
+	}
+
+	return pi.PackageReference.PackageName()
+}
+
+// Equals returns true if the passed package reference references the same package, false otherwise
+func (pi *PackageImport) Equals(ref *PackageImport) bool {
+	return pi.PackageReference.Equals(&ref.PackageReference) && pi.name == ref.name
+}

--- a/hack/generator/pkg/astmodel/package_reference.go
+++ b/hack/generator/pkg/astmodel/package_reference.go
@@ -7,8 +7,6 @@ package astmodel
 
 import (
 	"fmt"
-	"go/ast"
-	"go/token"
 	"strings"
 )
 
@@ -20,7 +18,6 @@ const (
 // a struct belongs to.
 type PackageReference struct {
 	packagePath string
-	name        *string
 }
 
 // NewLocalPackageReference Creates a new local package reference from a group and package name
@@ -32,14 +29,6 @@ func NewLocalPackageReference(groupName string, packageName string) *PackageRefe
 // NewPackageReference creates a new package reference from a path
 func NewPackageReference(packagePath string) *PackageReference {
 	return &PackageReference{packagePath: packagePath}
-}
-
-// WithName creates a new package reference with a friendly name
-func (pr *PackageReference) WithName(name string) *PackageReference {
-	result := NewPackageReference(pr.packagePath)
-	result.name = &name
-
-	return result
 }
 
 func (pr *PackageReference) isLocalPackage() bool {
@@ -71,32 +60,13 @@ func (pr *PackageReference) PackagePath() string {
 	return pr.packagePath
 }
 
-func (pr *PackageReference) AsImportSpec() *ast.ImportSpec {
-	var name *ast.Ident
-	if pr.name != nil {
-		name = ast.NewIdent(*pr.name)
-	}
-
-	return &ast.ImportSpec{
-		Name: name,
-		Path: &ast.BasicLit{
-			Kind:  token.STRING,
-			Value: "\"" + pr.PackagePath() + "\"",
-		},
-	}
-}
-
 // PackageName is the package name of the package reference
 func (pr *PackageReference) PackageName() string {
-	if pr.name != nil {
-		return *pr.name
-	}
-
 	l := strings.Split(pr.packagePath, "/")
 	return l[len(l)-1]
 }
 
 // Equals returns true if the passed package reference references the same package, false otherwise
 func (pr *PackageReference) Equals(ref *PackageReference) bool {
-	return pr.packagePath == ref.packagePath && pr.name == ref.name
+	return pr.packagePath == ref.packagePath
 }

--- a/hack/generator/pkg/astmodel/package_reference.go
+++ b/hack/generator/pkg/astmodel/package_reference.go
@@ -7,6 +7,8 @@ package astmodel
 
 import (
 	"fmt"
+	"go/ast"
+	"go/token"
 	"strings"
 )
 
@@ -18,12 +20,26 @@ const (
 // a struct belongs to.
 type PackageReference struct {
 	packagePath string
+	name        *string
 }
 
 // NewLocalPackageReference Creates a new local package reference from a group and package name
-func NewLocalPackageReference(groupName string, packageName string) PackageReference {
+func NewLocalPackageReference(groupName string, packageName string) *PackageReference {
 	url := localPathPrefix + groupName + "/" + packageName
-	return PackageReference{packagePath: url}
+	return &PackageReference{packagePath: url}
+}
+
+// NewPackageReference creates a new package reference from a path
+func NewPackageReference(packagePath string) *PackageReference {
+	return &PackageReference{packagePath: packagePath}
+}
+
+// WithName creates a new package reference with a friendly name
+func (pr *PackageReference) WithName(name string) *PackageReference {
+	result := NewPackageReference(pr.packagePath)
+	result.name = &name
+
+	return result
 }
 
 func (pr *PackageReference) isLocalPackage() bool {
@@ -55,13 +71,32 @@ func (pr *PackageReference) PackagePath() string {
 	return pr.packagePath
 }
 
+func (pr *PackageReference) AsImportSpec() *ast.ImportSpec {
+	var name *ast.Ident
+	if pr.name != nil {
+		name = ast.NewIdent(*pr.name)
+	}
+
+	return &ast.ImportSpec{
+		Name: name,
+		Path: &ast.BasicLit{
+			Kind:  token.STRING,
+			Value: "\"" + pr.PackagePath() + "\"",
+		},
+	}
+}
+
 // PackageName is the package name of the package reference
 func (pr *PackageReference) PackageName() string {
+	if pr.name != nil {
+		return *pr.name
+	}
+
 	l := strings.Split(pr.packagePath, "/")
 	return l[len(l)-1]
 }
 
 // Equals returns true if the passed package reference references the same package, false otherwise
 func (pr *PackageReference) Equals(ref *PackageReference) bool {
-	return pr.packagePath == ref.packagePath
+	return pr.packagePath == ref.packagePath && pr.name == ref.name
 }

--- a/hack/generator/pkg/astmodel/primitive_type.go
+++ b/hack/generator/pkg/astmodel/primitive_type.go
@@ -33,12 +33,12 @@ var AnyType = &PrimitiveType{"interface{}"}
 var _ Type = (*PrimitiveType)(nil)
 
 // AsType implements Type for PrimitiveType returning an abstract syntax tree
-func (prim *PrimitiveType) AsType() ast.Expr {
+func (prim *PrimitiveType) AsType(codeGenerationContext *CodeGenerationContext) ast.Expr {
 	return ast.NewIdent(prim.name)
 }
 
 // RequiredImports returns a list of package required by this
-func (prim *PrimitiveType) RequiredImports() []PackageReference {
+func (prim *PrimitiveType) RequiredImports() []*PackageReference {
 	return nil
 }
 

--- a/hack/generator/pkg/astmodel/simple_type_definer.go
+++ b/hack/generator/pkg/astmodel/simple_type_definer.go
@@ -38,7 +38,7 @@ func (std *SimpleTypeDefiner) WithDescription(desc *string) TypeDefiner {
 	return &result
 }
 
-func (std *SimpleTypeDefiner) AsDeclarations() []ast.Decl {
+func (std *SimpleTypeDefiner) AsDeclarations(codeGenerationContext *CodeGenerationContext) []ast.Decl {
 	var docComments *ast.CommentGroup
 	if std.description != nil {
 		docComments = &ast.CommentGroup{
@@ -57,7 +57,7 @@ func (std *SimpleTypeDefiner) AsDeclarations() []ast.Decl {
 			Specs: []ast.Spec{
 				&ast.TypeSpec{
 					Name: ast.NewIdent(std.name.name),
-					Type: std.theType.AsType(),
+					Type: std.theType.AsType(codeGenerationContext),
 				},
 			},
 		},

--- a/hack/generator/pkg/astmodel/struct_definition.go
+++ b/hack/generator/pkg/astmodel/struct_definition.go
@@ -59,7 +59,7 @@ func (definition *StructDefinition) FieldCount() int {
 }
 
 // AsDeclarations generates an AST node representing this struct definition
-func (definition *StructDefinition) AsDeclarations() []ast.Decl {
+func (definition *StructDefinition) AsDeclarations(codeGenerationContext *CodeGenerationContext) []ast.Decl {
 	var identifier *ast.Ident
 	if definition.IsResource() {
 		// if it's a resource then this is the Spec type and we will generate
@@ -71,7 +71,7 @@ func (definition *StructDefinition) AsDeclarations() []ast.Decl {
 
 	typeSpecification := &ast.TypeSpec{
 		Name: identifier,
-		Type: definition.StructType.AsType(),
+		Type: definition.StructType.AsType(codeGenerationContext),
 	}
 
 	declaration := &ast.GenDecl{
@@ -128,15 +128,15 @@ func (definition *StructDefinition) AsDeclarations() []ast.Decl {
 	}
 
 	// Append the methods
-	declarations = append(declarations, definition.generateMethodDecls()...)
+	declarations = append(declarations, definition.generateMethodDecls(codeGenerationContext)...)
 
 	return declarations
 }
 
-func (definition *StructDefinition) generateMethodDecls() []ast.Decl {
+func (definition *StructDefinition) generateMethodDecls(codeGenerationContext *CodeGenerationContext) []ast.Decl {
 	var result []ast.Decl
 	for methodName, function := range definition.StructType.functions {
-		funcDef := function.AsFunc(definition.Name(), methodName)
+		funcDef := function.AsFunc(codeGenerationContext, definition.Name(), methodName)
 		result = append(result, funcDef)
 	}
 

--- a/hack/generator/pkg/astmodel/struct_definition_test.go
+++ b/hack/generator/pkg/astmodel/struct_definition_test.go
@@ -21,7 +21,7 @@ func Test_NewStructDefinition_GivenValues_InitializesFields(t *testing.T) {
 	familyNameField := createStringField("familiyName", "Shared family name")
 	knownAsField := createStringField("knownAs", "Commonly known as")
 
-	ref := NewTypeName(NewLocalPackageReference(group, version), name)
+	ref := NewTypeName(*NewLocalPackageReference(group, version), name)
 	definition := NewStructDefinition(ref, NewStructType(fullNameField, familyNameField, knownAsField), false)
 
 	definitionGroup, definitionPackage, err := definition.Name().PackageReference.GroupAndPackage()
@@ -36,9 +36,9 @@ func Test_NewStructDefinition_GivenValues_InitializesFields(t *testing.T) {
 func Test_StructDefinitionAsAst_GivenValidStruct_ReturnsNonNilResult(t *testing.T) {
 	g := NewGomegaWithT(t)
 
-	ref := NewTypeName(NewLocalPackageReference("group", "2020-01-01"), "name")
+	ref := NewTypeName(*NewLocalPackageReference("group", "2020-01-01"), "name")
 	field := NewStructDefinition(ref, NewStructType(), false)
-	node := field.AsDeclarations()
+	node := field.AsDeclarations(nil) // TODO:
 
 	g.Expect(node).NotTo(BeNil())
 }

--- a/hack/generator/pkg/astmodel/struct_definition_test.go
+++ b/hack/generator/pkg/astmodel/struct_definition_test.go
@@ -38,7 +38,7 @@ func Test_StructDefinitionAsAst_GivenValidStruct_ReturnsNonNilResult(t *testing.
 
 	ref := NewTypeName(*NewLocalPackageReference("group", "2020-01-01"), "name")
 	field := NewStructDefinition(ref, NewStructType(), false)
-	node := field.AsDeclarations(nil) // TODO:
+	node := field.AsDeclarations(nil)
 
 	g.Expect(node).NotTo(BeNil())
 }

--- a/hack/generator/pkg/astmodel/struct_type.go
+++ b/hack/generator/pkg/astmodel/struct_type.go
@@ -38,7 +38,7 @@ func (structType *StructType) Fields() []*FieldDefinition {
 }
 
 // AsType implements Type for StructType
-func (structType *StructType) AsType() ast.Expr {
+func (structType *StructType) AsType(codeGenerationContext *CodeGenerationContext) ast.Expr {
 
 	// Copy the slice of fields and sort it
 	fields := structType.Fields()
@@ -48,7 +48,7 @@ func (structType *StructType) AsType() ast.Expr {
 
 	fieldDefinitions := make([]*ast.Field, len(fields))
 	for i, f := range fields {
-		fieldDefinitions[i] = f.AsField()
+		fieldDefinitions[i] = f.AsField(codeGenerationContext)
 	}
 
 	return &ast.StructType{
@@ -59,8 +59,8 @@ func (structType *StructType) AsType() ast.Expr {
 }
 
 // RequiredImports returns a list of packages required by this
-func (structType *StructType) RequiredImports() []PackageReference {
-	var result []PackageReference
+func (structType *StructType) RequiredImports() []*PackageReference {
+	var result []*PackageReference
 	for _, field := range structType.fields {
 		result = append(result, field.FieldType().RequiredImports()...)
 	}

--- a/hack/generator/pkg/astmodel/type.go
+++ b/hack/generator/pkg/astmodel/type.go
@@ -12,7 +12,7 @@ import (
 // Type represents something that is a Go type
 type Type interface {
 	// RequiredImports returns a list of packages required by this type
-	RequiredImports() []PackageReference
+	RequiredImports() []*PackageReference
 
 	// References determines if this type has a direct reference to the given definition name
 	// For example an Array of Persons references a Person
@@ -20,7 +20,7 @@ type Type interface {
 
 	// AsType renders as a Go abstract syntax tree for a type
 	// (yes this says ast.Expr but that is what the Go 'ast' package uses for types)
-	AsType() ast.Expr
+	AsType(codeGenerationContext *CodeGenerationContext) ast.Expr
 
 	// Equals returns true if the passed type is the same as this one, false otherwise
 	Equals(t Type) bool

--- a/hack/generator/pkg/astmodel/type_definer.go
+++ b/hack/generator/pkg/astmodel/type_definer.go
@@ -22,7 +22,7 @@ type TypeDefiner interface {
 	WithDescription(description *string) TypeDefiner
 
 	// AsDeclarations generates the actual Go declarations
-	AsDeclarations() []ast.Decl
+	AsDeclarations(codeGenerationContext *CodeGenerationContext) []ast.Decl
 }
 
 // FileNameHint returns what a file that contains this definition (if any) should be called

--- a/hack/generator/pkg/astmodel/type_name.go
+++ b/hack/generator/pkg/astmodel/type_name.go
@@ -33,9 +33,9 @@ var _ Type = (*TypeName)(nil)
 // AsType implements Type for TypeName
 func (typeName *TypeName) AsType(codeGenerationContext *CodeGenerationContext) ast.Expr {
 	// If our package is being referenced, we need to ensure we include a selector for that reference
-	if _, ok := codeGenerationContext.PackageReferences()[typeName.PackageReference]; ok {
+	if imp, ok := codeGenerationContext.PackageImports()[typeName.PackageReference]; ok {
 		return &ast.SelectorExpr{
-			X:   ast.NewIdent(typeName.PackageReference.PackageName()),
+			X:   ast.NewIdent(imp.PackageName()),
 			Sel: ast.NewIdent(typeName.Name()),
 		}
 	}

--- a/hack/generator/pkg/astmodel/type_name.go
+++ b/hack/generator/pkg/astmodel/type_name.go
@@ -5,11 +5,14 @@
 
 package astmodel
 
-import "go/ast"
+import (
+	"fmt"
+	"go/ast"
+)
 
 // TypeName is a name associated with another Type (it also is usable as a Type)
 type TypeName struct {
-	PackageReference PackageReference
+	PackageReference PackageReference // Note: This has to be a value and not a ptr because this type is used as the key in a map
 	name             string
 }
 
@@ -28,7 +31,23 @@ func (typeName *TypeName) Name() string {
 var _ Type = (*TypeName)(nil)
 
 // AsType implements Type for TypeName
-func (typeName *TypeName) AsType() ast.Expr {
+func (typeName *TypeName) AsType(codeGenerationContext *CodeGenerationContext) ast.Expr {
+	// If our package is being referenced, we need to ensure we include a selector for that reference
+	if _, ok := codeGenerationContext.PackageReferences()[typeName.PackageReference]; ok {
+		return &ast.SelectorExpr{
+			X:   ast.NewIdent(typeName.PackageReference.PackageName()),
+			Sel: ast.NewIdent(typeName.Name()),
+		}
+	}
+
+	// Sanity assertion that the type we're generating is in the same package that the context is for
+	if !codeGenerationContext.currentPackage.Equals(&typeName.PackageReference) {
+		panic(fmt.Sprintf(
+			"no reference for %v included in package %v",
+			typeName.name,
+			codeGenerationContext.currentPackage))
+	}
+
 	return ast.NewIdent(typeName.name)
 }
 
@@ -38,8 +57,8 @@ func (typeName *TypeName) References(d *TypeName) bool {
 }
 
 // RequiredImports returns all the imports required for this definition
-func (typeName *TypeName) RequiredImports() []PackageReference {
-	return []PackageReference{typeName.PackageReference}
+func (typeName *TypeName) RequiredImports() []*PackageReference {
+	return []*PackageReference{&typeName.PackageReference}
 }
 
 // Equals returns true if the passed type is the same TypeName, false otherwise

--- a/hack/generator/pkg/codegen/configuration_test.go
+++ b/hack/generator/pkg/codegen/configuration_test.go
@@ -16,12 +16,12 @@ import (
 )
 
 // Shared test values:
-var package2019 = astmodel.NewLocalPackageReference("group", "2019-01-01")
+var package2019 = *astmodel.NewLocalPackageReference("group", "2019-01-01")
 var person2019 = astmodel.NewStructDefinition(astmodel.NewTypeName(package2019, "person"), astmodel.EmptyStructType, false)
 var post2019 = astmodel.NewStructDefinition(astmodel.NewTypeName(package2019, "post"), astmodel.EmptyStructType, false)
 var student2019 = astmodel.NewStructDefinition(astmodel.NewTypeName(package2019, "student"), astmodel.EmptyStructType, false)
 
-var package2020 = astmodel.NewLocalPackageReference("group", "2020-01-01")
+var package2020 = *astmodel.NewLocalPackageReference("group", "2020-01-01")
 var address2020 = astmodel.NewStructDefinition(astmodel.NewTypeName(package2020, "address"), astmodel.EmptyStructType, false)
 var person2020 = astmodel.NewStructDefinition(astmodel.NewTypeName(package2020, "person"), astmodel.EmptyStructType, false)
 var professor2020 = astmodel.NewStructDefinition(astmodel.NewTypeName(package2020, "professor"), astmodel.EmptyStructType, false)

--- a/hack/generator/pkg/jsonast/jsonast.go
+++ b/hack/generator/pkg/jsonast/jsonast.go
@@ -548,8 +548,8 @@ func generateOneOfUnionType(ctx context.Context, subschemas []*gojsonschema.SubS
 			// JSON name is unimportant here because we will implement the JSON marshaller anyway,
 			// but we still need it for controller-gen
 			jsonName := scanner.idFactory.CreateIdentifier(concreteType.Name(), astmodel.NotExported)
-			field := astmodel.NewFieldDefinition(fieldName, jsonName, concreteType).MakeOptional()
-			field = field.WithDescription(&fieldDescription)
+			field := astmodel.NewFieldDefinition(
+				fieldName, jsonName, concreteType).MakeOptional().WithDescription(&fieldDescription)
 			fields = append(fields, field)
 		case *astmodel.EnumType:
 			// TODO: This name sucks but what alternative do we have?
@@ -559,8 +559,8 @@ func generateOneOfUnionType(ctx context.Context, subschemas []*gojsonschema.SubS
 			// JSON name is unimportant here because we will implement the JSON marshaller anyway,
 			// but we still need it for controller-gen
 			jsonName := scanner.idFactory.CreateIdentifier(name, astmodel.NotExported)
-			field := astmodel.NewFieldDefinition(fieldName, jsonName, concreteType).MakeOptional()
-			field = field.WithDescription(&fieldDescription)
+			field := astmodel.NewFieldDefinition(
+				fieldName, jsonName, concreteType).MakeOptional().WithDescription(&fieldDescription)
 			fields = append(fields, field)
 		case *astmodel.StructType:
 			// TODO: This name sucks but what alternative do we have?
@@ -570,8 +570,8 @@ func generateOneOfUnionType(ctx context.Context, subschemas []*gojsonschema.SubS
 			// JSON name is unimportant here because we will implement the JSON marshaller anyway,
 			// but we still need it for controller-gen
 			jsonName := scanner.idFactory.CreateIdentifier(name, astmodel.NotExported)
-			field := astmodel.NewFieldDefinition(fieldName, jsonName, concreteType).MakeOptional()
-			field = field.WithDescription(&fieldDescription)
+			field := astmodel.NewFieldDefinition(
+				fieldName, jsonName, concreteType).MakeOptional().WithDescription(&fieldDescription)
 			fields = append(fields, field)
 		case *astmodel.PrimitiveType:
 			var primitiveTypeName string
@@ -588,8 +588,8 @@ func generateOneOfUnionType(ctx context.Context, subschemas []*gojsonschema.SubS
 			// JSON name is unimportant here because we will implement the JSON marshaller anyway,
 			// but we still need it for controller-gen
 			jsonName := scanner.idFactory.CreateIdentifier(name, astmodel.NotExported)
-			field := astmodel.NewFieldDefinition(fieldName, jsonName, concreteType).MakeOptional()
-			field = field.WithDescription(&fieldDescription)
+			field := astmodel.NewFieldDefinition(
+				fieldName, jsonName, concreteType).MakeOptional().WithDescription(&fieldDescription)
 			fields = append(fields, field)
 		default:
 			return nil, fmt.Errorf("unexpected oneOf member, type: %T", t)

--- a/hack/generator/pkg/jsonast/jsonast.go
+++ b/hack/generator/pkg/jsonast/jsonast.go
@@ -533,6 +533,7 @@ func generateOneOfUnionType(ctx context.Context, subschemas []*gojsonschema.SubS
 	// Note that this is required because Kubernetes CRDs do not support OneOf the same way
 	// OpenAPI does, see https://github.com/Azure/k8s-infra/issues/71
 	var fields []*astmodel.FieldDefinition
+	fieldDescription := "mutually exclusive with all other properties"
 
 	for i, t := range results {
 		switch concreteType := t.(type) {
@@ -548,6 +549,7 @@ func generateOneOfUnionType(ctx context.Context, subschemas []*gojsonschema.SubS
 			// but we still need it for controller-gen
 			jsonName := scanner.idFactory.CreateIdentifier(concreteType.Name(), astmodel.NotExported)
 			field := astmodel.NewFieldDefinition(fieldName, jsonName, concreteType).MakeOptional()
+			field = field.WithDescription(&fieldDescription)
 			fields = append(fields, field)
 		case *astmodel.EnumType:
 			// TODO: This name sucks but what alternative do we have?
@@ -558,6 +560,7 @@ func generateOneOfUnionType(ctx context.Context, subschemas []*gojsonschema.SubS
 			// but we still need it for controller-gen
 			jsonName := scanner.idFactory.CreateIdentifier(name, astmodel.NotExported)
 			field := astmodel.NewFieldDefinition(fieldName, jsonName, concreteType).MakeOptional()
+			field = field.WithDescription(&fieldDescription)
 			fields = append(fields, field)
 		case *astmodel.StructType:
 			// TODO: This name sucks but what alternative do we have?
@@ -568,6 +571,7 @@ func generateOneOfUnionType(ctx context.Context, subschemas []*gojsonschema.SubS
 			// but we still need it for controller-gen
 			jsonName := scanner.idFactory.CreateIdentifier(name, astmodel.NotExported)
 			field := astmodel.NewFieldDefinition(fieldName, jsonName, concreteType).MakeOptional()
+			field = field.WithDescription(&fieldDescription)
 			fields = append(fields, field)
 		case *astmodel.PrimitiveType:
 			var primitiveTypeName string
@@ -585,6 +589,7 @@ func generateOneOfUnionType(ctx context.Context, subschemas []*gojsonschema.SubS
 			// but we still need it for controller-gen
 			jsonName := scanner.idFactory.CreateIdentifier(name, astmodel.NotExported)
 			field := astmodel.NewFieldDefinition(fieldName, jsonName, concreteType).MakeOptional()
+			field = field.WithDescription(&fieldDescription)
 			fields = append(fields, field)
 		default:
 			return nil, fmt.Errorf("unexpected oneOf member, type: %T", t)

--- a/hack/generator/pkg/jsonast/jsonast.go
+++ b/hack/generator/pkg/jsonast/jsonast.go
@@ -184,7 +184,7 @@ func (scanner *SchemaScanner) GenerateDefinitions(ctx context.Context, schema *g
 		scanner.idFactory.CreateGroupName(rootGroup),
 		scanner.idFactory.CreatePackageNameFromVersion(rootVersion))
 
-	rootTypeName := astmodel.NewTypeName(rootPackage, rootName)
+	rootTypeName := astmodel.NewTypeName(*rootPackage, rootName)
 
 	_, err = generateDefinitionsFor(ctx, scanner, rootTypeName, false, url, schema)
 	if err != nil {
@@ -392,7 +392,7 @@ func refHandler(ctx context.Context, scanner *SchemaScanner, schema *gojsonschem
 
 	// produce a usable name:
 	typeName := astmodel.NewTypeName(
-		astmodel.NewLocalPackageReference(
+		*astmodel.NewLocalPackageReference(
 			scanner.idFactory.CreateGroupName(group),
 			scanner.idFactory.CreatePackageNameFromVersion(version)),
 		scanner.idFactory.CreateIdentifier(name, astmodel.Exported))

--- a/hack/generator/pkg/jsonast/jsonast_test.go
+++ b/hack/generator/pkg/jsonast/jsonast_test.go
@@ -44,7 +44,7 @@ func runGoldenTest(t *testing.T, path string) {
 
 	// put all definitions in one file, regardless
 	// the package reference isn't really used here
-	fileDef := astmodel.NewFileDefinition(defs[0].Name().PackageReference, defs...)
+	fileDef := astmodel.NewFileDefinition(&defs[0].Name().PackageReference, defs...)
 
 	buf := &bytes.Buffer{}
 	err = fileDef.SaveToWriter(path, buf)

--- a/hack/generator/pkg/jsonast/testdata/OneOf/OneOf_generates_wrapper_for_inner_properties.golden
+++ b/hack/generator/pkg/jsonast/testdata/OneOf/OneOf_generates_wrapper_for_inner_properties.golden
@@ -27,7 +27,9 @@ type Test struct {
 }
 
 type TestProperties struct {
+	/* Bar: mutually exclusive with all other properties */
 	Bar *Bar `json:"bar"`
+	/* Foo: mutually exclusive with all other properties */
 	Foo *Foo `json:"foo"`
 }
 

--- a/hack/generator/pkg/jsonast/testdata/OneOf/OneOf_generates_wrapper_for_inner_properties.golden
+++ b/hack/generator/pkg/jsonast/testdata/OneOf/OneOf_generates_wrapper_for_inner_properties.golden
@@ -27,9 +27,9 @@ type Test struct {
 }
 
 type TestProperties struct {
-	/* Bar: mutually exclusive with all other properties */
+	/*Bar: mutually exclusive with all other properties*/
 	Bar *Bar `json:"bar"`
-	/* Foo: mutually exclusive with all other properties */
+	/*Foo: mutually exclusive with all other properties*/
 	Foo *Foo `json:"foo"`
 }
 

--- a/hack/generator/pkg/jsonast/testdata/OneOf/OneOf_generates_wrapper_type_with_marshal_helper.golden
+++ b/hack/generator/pkg/jsonast/testdata/OneOf/OneOf_generates_wrapper_type_with_marshal_helper.golden
@@ -27,8 +27,11 @@ type Foo struct {
 
 /*Generated from: https://test.test/schemas/2020-01-01/test.json*/
 type Test struct {
+	/* Bar: mutually exclusive with all other properties */
 	Bar *Bar `json:"bar"`
+	/* Baz: mutually exclusive with all other properties */
 	Baz *Baz `json:"baz"`
+	/* Foo: mutually exclusive with all other properties */
 	Foo *Foo `json:"foo"`
 }
 

--- a/hack/generator/pkg/jsonast/testdata/OneOf/OneOf_generates_wrapper_type_with_marshal_helper.golden
+++ b/hack/generator/pkg/jsonast/testdata/OneOf/OneOf_generates_wrapper_type_with_marshal_helper.golden
@@ -27,11 +27,11 @@ type Foo struct {
 
 /*Generated from: https://test.test/schemas/2020-01-01/test.json*/
 type Test struct {
-	/* Bar: mutually exclusive with all other properties */
+	/*Bar: mutually exclusive with all other properties*/
 	Bar *Bar `json:"bar"`
-	/* Baz: mutually exclusive with all other properties */
+	/*Baz: mutually exclusive with all other properties*/
 	Baz *Baz `json:"baz"`
-	/* Foo: mutually exclusive with all other properties */
+	/*Foo: mutually exclusive with all other properties*/
 	Foo *Foo `json:"foo"`
 }
 

--- a/hack/generator/pkg/jsonast/testdata/OneOf/OneOf_generates_wrapper_type_with_named_properties_from_anonymous_types.golden
+++ b/hack/generator/pkg/jsonast/testdata/OneOf/OneOf_generates_wrapper_type_with_named_properties_from_anonymous_types.golden
@@ -13,11 +13,11 @@ type Foo int
 
 /*Generated from: https://test.test/schemas/2020-01-01/test.json*/
 type Test struct {
-	/* Bool1: mutually exclusive with all other properties */
+	/*Bool1: mutually exclusive with all other properties*/
 	Bool1 *bool `json:"bool1"`
-	/* Foo: mutually exclusive with all other properties */
+	/*Foo: mutually exclusive with all other properties*/
 	Foo *Foo `json:"foo"`
-	/* Object2: mutually exclusive with all other properties */
+	/*Object2: mutually exclusive with all other properties*/
 	Object2 *TestObject2 `json:"object2"`
 }
 

--- a/hack/generator/pkg/jsonast/testdata/OneOf/OneOf_generates_wrapper_type_with_named_properties_from_anonymous_types.golden
+++ b/hack/generator/pkg/jsonast/testdata/OneOf/OneOf_generates_wrapper_type_with_named_properties_from_anonymous_types.golden
@@ -13,8 +13,11 @@ type Foo int
 
 /*Generated from: https://test.test/schemas/2020-01-01/test.json*/
 type Test struct {
-	Bool1   *bool        `json:"bool1"`
-	Foo     *Foo         `json:"foo"`
+	/* Bool1: mutually exclusive with all other properties */
+	Bool1 *bool `json:"bool1"`
+	/* Foo: mutually exclusive with all other properties */
+	Foo *Foo `json:"foo"`
+	/* Object2: mutually exclusive with all other properties */
 	Object2 *TestObject2 `json:"object2"`
 }
 

--- a/hack/generator/pkg/jsonast/type_filter_test.go
+++ b/hack/generator/pkg/jsonast/type_filter_test.go
@@ -15,10 +15,10 @@ import (
 )
 
 // Shared test values:
-var person2020 = astmodel.NewStructDefinition(astmodel.NewTypeName(astmodel.NewLocalPackageReference("party", "2020-01-01"), "person"), astmodel.EmptyStructType, false)
-var post2019 = astmodel.NewStructDefinition(astmodel.NewTypeName(astmodel.NewLocalPackageReference("thing", "2019-01-01"), "post"), astmodel.EmptyStructType, false)
-var student2019 = astmodel.NewStructDefinition(astmodel.NewTypeName(astmodel.NewLocalPackageReference("role", "2019-01-01"), "student"), astmodel.EmptyStructType, false)
-var tutor2019 = astmodel.NewStructDefinition(astmodel.NewTypeName(astmodel.NewLocalPackageReference("role", "2019-01-01"), "tutor"), astmodel.EmptyStructType, false)
+var person2020 = astmodel.NewStructDefinition(astmodel.NewTypeName(*astmodel.NewLocalPackageReference("party", "2020-01-01"), "person"), astmodel.EmptyStructType, false)
+var post2019 = astmodel.NewStructDefinition(astmodel.NewTypeName(*astmodel.NewLocalPackageReference("thing", "2019-01-01"), "post"), astmodel.EmptyStructType, false)
+var student2019 = astmodel.NewStructDefinition(astmodel.NewTypeName(*astmodel.NewLocalPackageReference("role", "2019-01-01"), "student"), astmodel.EmptyStructType, false)
+var tutor2019 = astmodel.NewStructDefinition(astmodel.NewTypeName(*astmodel.NewLocalPackageReference("role", "2019-01-01"), "tutor"), astmodel.EmptyStructType, false)
 
 func Test_FilterByGroup_CorrectlySelectsStructs(t *testing.T) {
 	g := NewGomegaWithT(t)


### PR DESCRIPTION
This is for cases where one spec references another - the referenced specification is imported but the generated code was not actually using the module when defining structs, types, etc. Introduced concept of CodeGenerationContext (parameter to AsType/AsDeclarations) to inform various types as to the context they are in so that they can generate correct AST.

