### PR TITLE
Use map for struct fields

### DIFF
--- a/hack/generator/pkg/astmodel/file_definition_test.go
+++ b/hack/generator/pkg/astmodel/file_definition_test.go
@@ -28,7 +28,7 @@ func NewTestStruct(name string, fields ...string) StructDefinition {
 	}
 
 	ref := NewTypeName(*NewLocalPackageReference("group", "2020-01-01"), name)
-	definition := NewStructDefinition(ref, NewStructType(fs...), false)
+	definition := NewStructDefinition(ref, NewStructType().WithFields(fs...), false)
 
 	return *definition
 }

--- a/hack/generator/pkg/astmodel/one_of_json_marshal_function.go
+++ b/hack/generator/pkg/astmodel/one_of_json_marshal_function.go
@@ -85,7 +85,7 @@ func (f *OneOfJSONMarshalFunction) AsFunc(
 
 	var statements []ast.Stmt
 
-	for _, field := range f.oneOfStruct.fields {
+	for _, field := range f.oneOfStruct.Fields() {
 		fieldSelectorExpr := &ast.SelectorExpr{
 			X:   ast.NewIdent(receiverName),
 			Sel: ast.NewIdent(string(field.fieldName)),

--- a/hack/generator/pkg/astmodel/struct_definition.go
+++ b/hack/generator/pkg/astmodel/struct_definition.go
@@ -48,16 +48,6 @@ func (definition *StructDefinition) WithDescription(description *string) TypeDef
 	return &result
 }
 
-// Field provides indexed access to our fields
-func (definition *StructDefinition) Field(index int) FieldDefinition {
-	return *definition.StructType.fields[index]
-}
-
-// FieldCount indicates how many fields are contained
-func (definition *StructDefinition) FieldCount() int {
-	return len(definition.StructType.fields)
-}
-
 // AsDeclarations generates an AST node representing this struct definition
 func (definition *StructDefinition) AsDeclarations(codeGenerationContext *CodeGenerationContext) []ast.Decl {
 	var identifier *ast.Ident

--- a/hack/generator/pkg/astmodel/struct_definition_test.go
+++ b/hack/generator/pkg/astmodel/struct_definition_test.go
@@ -22,7 +22,7 @@ func Test_NewStructDefinition_GivenValues_InitializesFields(t *testing.T) {
 	knownAsField := createStringField("knownAs", "Commonly known as")
 
 	ref := NewTypeName(*NewLocalPackageReference(group, version), name)
-	definition := NewStructDefinition(ref, NewStructType(fullNameField, familyNameField, knownAsField), false)
+	definition := NewStructDefinition(ref, NewStructType().WithFields(fullNameField, familyNameField, knownAsField), false)
 
 	definitionGroup, definitionPackage, err := definition.Name().PackageReference.GroupAndPackage()
 	g.Expect(err).ShouldNot(HaveOccurred())

--- a/hack/generator/pkg/astmodel/struct_definition_test.go
+++ b/hack/generator/pkg/astmodel/struct_definition_test.go
@@ -18,7 +18,7 @@ func Test_NewStructDefinition_GivenValues_InitializesFields(t *testing.T) {
 	const group = "group"
 	const version = "2020-01-01"
 	fullNameField := createStringField("fullName", "Full legal name")
-	familyNameField := createStringField("familiyName", "Shared family name")
+	familyNameField := createStringField("familyName", "Shared family name")
 	knownAsField := createStringField("knownAs", "Commonly known as")
 
 	ref := NewTypeName(*NewLocalPackageReference(group, version), name)

--- a/hack/generator/pkg/astmodel/struct_type.go
+++ b/hack/generator/pkg/astmodel/struct_type.go
@@ -31,12 +31,16 @@ func NewStructType() *StructType {
 }
 
 // Fields returns all our field definitions
-// A copy of the slice is returned to preserve immutability
+// A sorted copy of the slice is returned to preserve immutability and provide determinism
 func (structType *StructType) Fields() []*FieldDefinition {
 	var result []*FieldDefinition
 	for _, field := range structType.fields {
 		result = append(result, field)
 	}
+
+	sort.Slice(result, func(left int, right int) bool {
+		return result[left].fieldName < result[right].fieldName
+	})
 
 	return result
 }

--- a/hack/generator/pkg/astmodel/struct_type.go
+++ b/hack/generator/pkg/astmodel/struct_type.go
@@ -12,7 +12,7 @@ import (
 
 // StructType represents an (unnamed) struct type
 type StructType struct {
-	fields    []*FieldDefinition
+	fields    map[FieldName]*FieldDefinition
 	functions map[string]Function
 }
 
@@ -23,18 +23,22 @@ var EmptyStructType = NewStructType()
 var _ Type = (*StructType)(nil)
 
 // NewStructType is a factory method for creating a new StructTypeDefinition
-func NewStructType(fields ...*FieldDefinition) *StructType {
-	sort.Slice(fields, func(left int, right int) bool {
-		return fields[left].fieldName < fields[right].fieldName
-	})
-
-	return &StructType{fields, make(map[string]Function)}
+func NewStructType() *StructType {
+	return &StructType{
+		fields:    make(map[FieldName]*FieldDefinition),
+		functions: make(map[string]Function),
+	}
 }
 
 // Fields returns all our field definitions
 // A copy of the slice is returned to preserve immutability
 func (structType *StructType) Fields() []*FieldDefinition {
-	return append(structType.fields[:0:0], structType.fields...)
+	var result []*FieldDefinition
+	for _, field := range structType.fields {
+		result = append(result, field)
+	}
+
+	return result
 }
 
 // AsType implements Type for StructType
@@ -98,19 +102,14 @@ func (structType *StructType) Equals(t Type) bool {
 			return false
 		}
 
-		ourFields := make(map[FieldName]*FieldDefinition)
-		for _, f := range structType.fields {
-			ourFields[f.fieldName] = f
-		}
-
-		for _, f := range st.fields {
-			ourfield, ok := ourFields[f.fieldName]
+		for n, f := range st.fields {
+			ourField, ok := structType.fields[n]
 			if !ok {
 				// Didn't find the field, not equal
 				return false
 			}
 
-			if !ourfield.Equals(f) {
+			if !ourField.Equals(f) {
 				// Different field, even though same name; not-equal
 				return false
 			}
@@ -167,12 +166,32 @@ func (structType *StructType) CreateDefinitions(name *TypeName, idFactory Identi
 		newFields = append(newFields, field.WithType(newFieldType))
 	}
 
-	newStructType := NewStructType(newFields...)
+	newStructType := NewStructType().WithFields(newFields...)
 	for functionName, function := range structType.functions {
 		newStructType.functions[functionName] = function
 	}
 
 	return NewStructDefinition(name, newStructType, isResource), otherTypes
+}
+
+// WithField creates a new StructType with another field attached to it
+func (structType *StructType) WithField(field *FieldDefinition) *StructType {
+	// Create a copy of structType to preserve immutability
+	result := structType.copy()
+	result.fields[field.fieldName] = field
+
+	return result
+}
+
+// WithFields creates a new StructType with additional fields attached to it
+func (structType *StructType) WithFields(fields ...*FieldDefinition) *StructType {
+	// Create a copy of structType to preserve immutability
+	result := structType.copy()
+	for _, f := range fields {
+		result.fields[f.fieldName] = f
+	}
+
+	return result
 }
 
 // WithFunction creates a new StructType with a function (method) attached to it
@@ -185,7 +204,11 @@ func (structType *StructType) WithFunction(name string, function Function) *Stru
 }
 
 func (structType *StructType) copy() *StructType {
-	result := NewStructType(structType.fields...)
+	result := NewStructType()
+
+	for key, value := range structType.fields {
+		result.fields[key] = value
+	}
 
 	for key, value := range structType.functions {
 		result.functions[key] = value

--- a/hack/generator/pkg/astmodel/struct_type.go
+++ b/hack/generator/pkg/astmodel/struct_type.go
@@ -31,7 +31,7 @@ func NewStructType() *StructType {
 }
 
 // Fields returns all our field definitions
-// A sorted copy of the slice is returned to preserve immutability and provide determinism
+// A sorted slice is returned to preserve immutability and provide determinism
 func (structType *StructType) Fields() []*FieldDefinition {
 	var result []*FieldDefinition
 	for _, field := range structType.fields {

--- a/hack/generator/pkg/astmodel/struct_type_test.go
+++ b/hack/generator/pkg/astmodel/struct_type_test.go
@@ -18,11 +18,11 @@ func TestStructType_Equals_WhenGivenType_ReturnsExpectedResult(t *testing.T) {
 	knownAsField := NewFieldDefinition("KnownAs", "known-as", StringType)
 	genderField := NewFieldDefinition("Gender", "gender", StringType)
 
-	personType := NewStructType(fullNameField, familyNameField, knownAsField)
-	otherPersonType := NewStructType(fullNameField, familyNameField, knownAsField)
-	reorderedType := NewStructType(knownAsField, familyNameField, fullNameField)
-	shorterType := NewStructType(knownAsField, fullNameField)
-	longerType := NewStructType(fullNameField, familyNameField, knownAsField, genderField)
+	personType := NewStructType().WithFields(fullNameField, familyNameField, knownAsField)
+	otherPersonType := NewStructType().WithFields(fullNameField, familyNameField, knownAsField)
+	reorderedType := NewStructType().WithFields(knownAsField, familyNameField, fullNameField)
+	shorterType := NewStructType().WithFields(knownAsField, fullNameField)
+	longerType := NewStructType().WithFields(fullNameField, familyNameField, knownAsField, genderField)
 	mapType := NewMapType(StringType, personType)
 
 	cases := []struct {

--- a/hack/generator/pkg/jsonast/jsonast.go
+++ b/hack/generator/pkg/jsonast/jsonast.go
@@ -270,7 +270,7 @@ func objectHandler(ctx context.Context, scanner *SchemaScanner, schema *gojsonsc
 		return fields[0].FieldType(), nil
 	}
 
-	structDefinition := astmodel.NewStructType(fields...)
+	structDefinition := astmodel.NewStructType().WithFields(fields...)
 	return structDefinition, nil
 }
 
@@ -498,7 +498,7 @@ func allOfHandler(ctx context.Context, scanner *SchemaScanner, schema *gojsonsch
 		}
 	}
 
-	result := astmodel.NewStructType(fields...)
+	result := astmodel.NewStructType().WithFields(fields...)
 	return result, nil
 }
 
@@ -596,7 +596,7 @@ func generateOneOfUnionType(ctx context.Context, subschemas []*gojsonschema.SubS
 		}
 	}
 
-	structType := astmodel.NewStructType(fields...)
+	structType := astmodel.NewStructType().WithFields(fields...)
 	structType = structType.WithFunction(
 		"MarshalJSON",
 		astmodel.NewOneOfJSONMarshalFunction(structType, scanner.idFactory))


### PR DESCRIPTION
A minor change for consistency between `functions` and `fields`, treating both as maps.

* Simplifies equality comparison a little
* Improves symmetry between fields and functions
* Removes the wart that `NewStructType()` accepted fields but not functions

Grew out of a branch I have where I'm trying to simplify code for easier comprehension.