### PR TITLE
Support cancellation via Ctrl-C

### DIFF
--- a/hack/generator/cmd/gen/gen.go
+++ b/hack/generator/cmd/gen/gen.go
@@ -7,6 +7,7 @@ package gen
 
 import (
 	"context"
+	"net/http"
 
 	"github.com/Azure/k8s-infra/hack/generator/pkg/codegen"
 	"github.com/Azure/k8s-infra/hack/generator/pkg/xcobra"
@@ -15,12 +16,29 @@ import (
 	"k8s.io/klog/v2"
 )
 
+type cancellableTransport struct {
+	ctx   context.Context
+	inner http.RoundTripper
+}
+
+func (transport *cancellableTransport) RoundTrip(request *http.Request) (*http.Response, error) {
+	if transport.ctx.Err() != nil {
+		return nil, transport.ctx.Err()
+	}
+
+	return transport.inner.RoundTrip(request)
+}
+
 // NewGenCommand creates a new cobra Command when invoked from the command line
 func NewGenCommand() (*cobra.Command, error) {
 	cmd := &cobra.Command{
 		Use:   "gen",
 		Short: "generate K8s infrastructure resources from Azure deployment template schema",
 		Run: xcobra.RunWithCtx(func(ctx context.Context, cmd *cobra.Command, args []string) error {
+
+			// HACK HACK HACK: make all HTTP clients cancellable as gojsonschema doesn't permit
+			// either cancellation or overriding the HTTP fetch
+			http.DefaultTransport = &cancellableTransport{ctx, http.DefaultTransport}
 
 			cg, err := codegen.NewCodeGenerator("azure-cloud.yaml")
 			if err != nil {

--- a/hack/generator/cmd/gen/gen.go
+++ b/hack/generator/cmd/gen/gen.go
@@ -24,7 +24,7 @@ type cancellableTransport struct {
 var _ http.RoundTripper = &cancellableTransport{} // interface assertion
 
 func (transport *cancellableTransport) RoundTrip(request *http.Request) (*http.Response, error) {
-	if transport.ctx.Err() != nil {
+	if transport.ctx.Err() != nil { // check for cancellation
 		return nil, transport.ctx.Err()
 	}
 

--- a/hack/generator/cmd/gen/gen.go
+++ b/hack/generator/cmd/gen/gen.go
@@ -21,6 +21,8 @@ type cancellableTransport struct {
 	inner http.RoundTripper
 }
 
+var _ http.RoundTripper = &cancellableTransport{} // interface assertion
+
 func (transport *cancellableTransport) RoundTrip(request *http.Request) (*http.Response, error) {
 	if transport.ctx.Err() != nil {
 		return nil, transport.ctx.Err()

--- a/hack/generator/pkg/codegen/code_generator.go
+++ b/hack/generator/pkg/codegen/code_generator.go
@@ -11,6 +11,7 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
+	"net/http"
 	"os"
 	"path"
 	"path/filepath"
@@ -52,13 +53,13 @@ func NewCodeGenerator(configurationFile string) (*CodeGenerator, error) {
 // Generate produces the Go code corresponding to the configured JSON schema in the given output folder
 func (generator *CodeGenerator) Generate(ctx context.Context, outputFolder string) error {
 	klog.V(0).Infof("Loading JSON schema %v", generator.configuration.SchemaURL)
-	schema, err := loadSchema(generator.configuration.SchemaURL)
+	schema, err := loadSchema(ctx, generator.configuration.SchemaURL)
 	if err != nil {
 		return fmt.Errorf("error loading schema from '%v' (%w)", generator.configuration.SchemaURL, err)
 	}
 
 	klog.V(0).Infof("Cleaning output folder '%v'", outputFolder)
-	err = deleteGeneratedCodeFromFolder(outputFolder)
+	err = deleteGeneratedCodeFromFolder(ctx, outputFolder)
 	if err != nil {
 		return fmt.Errorf("error cleaning output folder '%v' (%w)", outputFolder, err)
 	}
@@ -93,6 +94,9 @@ func (generator *CodeGenerator) Generate(ctx context.Context, outputFolder strin
 	// emit each package
 	klog.V(0).Infof("Writing output files into %v", outputFolder)
 	for _, pkg := range packages {
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
 
 		// create directory if not already there
 		outputDir := filepath.Join(outputFolder, pkg.GroupName, pkg.PackageName)
@@ -282,9 +286,24 @@ func loadConfiguration(configurationFile string) (*config.Configuration, error) 
 	return result, nil
 }
 
-func loadSchema(source string) (*gojsonschema.Schema, error) {
+type cancellableFS struct {
+	ctx context.Context
+}
+
+func (fs *cancellableFS) Open(source string) (http.File, error) {
+	if fs.ctx.Err() != nil {
+		return nil, fs.ctx.Err()
+	}
+
+	return os.Open(source)
+}
+
+func loadSchema(ctx context.Context, source string) (*gojsonschema.Schema, error) {
 	sl := gojsonschema.NewSchemaLoader()
-	schema, err := sl.Compile(gojsonschema.NewReferenceLoader(source))
+	// note that we "configure" the DefaultClient in gen.go to cancel HTTP calls
+	// the cancellableFS here only handles actual FS calls
+	loader := gojsonschema.NewReferenceLoaderFileSystem(source, &cancellableFS{ctx})
+	schema, err := sl.Compile(loader)
 	if err != nil {
 		return nil, fmt.Errorf("error loading schema from '%v' (%w)", source, err)
 	}
@@ -292,7 +311,7 @@ func loadSchema(source string) (*gojsonschema.Schema, error) {
 	return schema, nil
 }
 
-func deleteGeneratedCodeFromFolder(outputFolder string) error {
+func deleteGeneratedCodeFromFolder(ctx context.Context, outputFolder string) error {
 	globPattern := path.Join(outputFolder, "**", "*", "*"+astmodel.CodeGeneratedFileSuffix) + "*"
 
 	files, err := filepath.Glob(globPattern)
@@ -303,6 +322,10 @@ func deleteGeneratedCodeFromFolder(outputFolder string) error {
 	var errs []error
 
 	for _, file := range files {
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
+
 		isGenerated, err := isFileGenerated(file)
 
 		if err != nil {
@@ -317,7 +340,7 @@ func deleteGeneratedCodeFromFolder(outputFolder string) error {
 		}
 	}
 
-	err = deleteEmptyDirectories(outputFolder)
+	err = deleteEmptyDirectories(ctx, outputFolder)
 	if err != nil {
 		errs = append(errs, err)
 	}
@@ -355,7 +378,7 @@ func isFileGenerated(filename string) (bool, error) {
 	return false, nil
 }
 
-func deleteEmptyDirectories(path string) error {
+func deleteEmptyDirectories(ctx context.Context, path string) error {
 	if _, err := os.Stat(path); os.IsNotExist(err) {
 		return nil
 	}
@@ -367,6 +390,10 @@ func deleteEmptyDirectories(path string) error {
 	walkFunction := func(path string, info os.FileInfo, err error) error {
 		if err != nil {
 			return err
+		}
+
+		if ctx.Err() != nil {
+			return ctx.Err()
 		}
 
 		if info.IsDir() {
@@ -393,6 +420,10 @@ func deleteEmptyDirectories(path string) error {
 
 	// Now clean things up
 	for _, dir := range dirs {
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
+
 		files, err := ioutil.ReadDir(dir)
 		if err != nil {
 			errs = append(errs, fmt.Errorf("error reading directory '%v' (%w)", dir, err))

--- a/hack/generator/pkg/codegen/code_generator.go
+++ b/hack/generator/pkg/codegen/code_generator.go
@@ -94,7 +94,7 @@ func (generator *CodeGenerator) Generate(ctx context.Context, outputFolder strin
 	// emit each package
 	klog.V(0).Infof("Writing output files into %v", outputFolder)
 	for _, pkg := range packages {
-		if ctx.Err() != nil {
+		if ctx.Err() != nil { // check for cancellation
 			return ctx.Err()
 		}
 
@@ -286,12 +286,12 @@ func loadConfiguration(configurationFile string) (*config.Configuration, error) 
 	return result, nil
 }
 
-type cancellableFS struct {
+type cancellableFilesystem struct {
 	ctx context.Context
 }
 
-func (fs *cancellableFS) Open(source string) (http.File, error) {
-	if fs.ctx.Err() != nil {
+func (fs *cancellableFilesystem) Open(source string) (http.File, error) {
+	if fs.ctx.Err() != nil { // check for cancellation
 		return nil, fs.ctx.Err()
 	}
 
@@ -302,7 +302,7 @@ func loadSchema(ctx context.Context, source string) (*gojsonschema.Schema, error
 	sl := gojsonschema.NewSchemaLoader()
 	// note that we "configure" the DefaultClient in gen.go to cancel HTTP calls
 	// the cancellableFS here only handles actual FS calls
-	loader := gojsonschema.NewReferenceLoaderFileSystem(source, &cancellableFS{ctx})
+	loader := gojsonschema.NewReferenceLoaderFileSystem(source, &cancellableFilesystem{ctx})
 	schema, err := sl.Compile(loader)
 	if err != nil {
 		return nil, fmt.Errorf("error loading schema from '%v' (%w)", source, err)
@@ -322,7 +322,7 @@ func deleteGeneratedCodeFromFolder(ctx context.Context, outputFolder string) err
 	var errs []error
 
 	for _, file := range files {
-		if ctx.Err() != nil {
+		if ctx.Err() != nil { // check for cancellation
 			return ctx.Err()
 		}
 
@@ -392,7 +392,7 @@ func deleteEmptyDirectories(ctx context.Context, path string) error {
 			return err
 		}
 
-		if ctx.Err() != nil {
+		if ctx.Err() != nil { // check for cancellation
 			return ctx.Err()
 		}
 
@@ -420,7 +420,7 @@ func deleteEmptyDirectories(ctx context.Context, path string) error {
 
 	// Now clean things up
 	for _, dir := range dirs {
-		if ctx.Err() != nil {
+		if ctx.Err() != nil { // check for cancellation
 			return ctx.Err()
 		}
 

--- a/hack/generator/pkg/jsonast/jsonast.go
+++ b/hack/generator/pkg/jsonast/jsonast.go
@@ -12,11 +12,10 @@ import (
 	"regexp"
 	"strings"
 
-	"github.com/Azure/k8s-infra/hack/generator/pkg/config"
-
 	"k8s.io/klog/v2"
 
 	"github.com/Azure/k8s-infra/hack/generator/pkg/astmodel"
+	"github.com/Azure/k8s-infra/hack/generator/pkg/config"
 	"github.com/devigned/tab"
 	"github.com/xeipuuv/gojsonschema"
 )

--- a/hack/generator/pkg/jsonast/jsonast.go
+++ b/hack/generator/pkg/jsonast/jsonast.go
@@ -110,7 +110,7 @@ func (scanner *SchemaScanner) AddTypeHandler(schemaType SchemaType, handler Type
 
 // RunHandler triggers the appropriate handler for the specified schemaType
 func (scanner *SchemaScanner) RunHandler(ctx context.Context, schemaType SchemaType, schema *gojsonschema.SubSchema) (astmodel.Type, error) {
-	if ctx.Err() != nil {
+	if ctx.Err() != nil { // check for cancellation
 		return nil, ctx.Err()
 	}
 

--- a/hack/generator/pkg/jsonast/jsonast.go
+++ b/hack/generator/pkg/jsonast/jsonast.go
@@ -8,10 +8,11 @@ package jsonast
 import (
 	"context"
 	"fmt"
-	"github.com/Azure/k8s-infra/hack/generator/pkg/config"
 	"net/url"
 	"regexp"
 	"strings"
+
+	"github.com/Azure/k8s-infra/hack/generator/pkg/config"
 
 	"k8s.io/klog/v2"
 
@@ -109,6 +110,10 @@ func (scanner *SchemaScanner) AddTypeHandler(schemaType SchemaType, handler Type
 
 // RunHandler triggers the appropriate handler for the specified schemaType
 func (scanner *SchemaScanner) RunHandler(ctx context.Context, schemaType SchemaType, schema *gojsonschema.SubSchema) (astmodel.Type, error) {
+	if ctx.Err() != nil {
+		return nil, ctx.Err()
+	}
+
 	handler := scanner.TypeHandlers[schemaType]
 	return handler(ctx, scanner, schema)
 }

--- a/hack/generator/pkg/xcobra/context.go
+++ b/hack/generator/pkg/xcobra/context.go
@@ -43,8 +43,10 @@ func RunWithCtx(run func(ctx context.Context, cmd *cobra.Command, args []string)
 	signal.Notify(signalChan, os.Interrupt, syscall.SIGTERM)
 
 	go func() {
-		<-signalChan
-		cancel()
+		if sig, ok := <-signalChan; ok {
+			fmt.Fprintf(os.Stderr, "Received %v, cancelling...\n", sig)
+			cancel()
+		}
 	}()
 
 	return func(cmd *cobra.Command, args []string) {


### PR DESCRIPTION
The support for signal handling was already hooked up but we didn’t check for cancellation anywhere.

With this change we check for cancellation:

* During JSON Schema loading: for each HTTP request or file open.
* While cleaning the output directory: once per file or directory to be cleaned, also while walking the tree.
* While converting the JSON AST: once per handler.
* While emitting the output files: once per package.

The JSON Schema library doesn’t support cancellation so this is implemented there by supplying a filesystem implementation that supports cancellation; there is no way to supply an implementation for the HTTP requests so instead we add cancellation to the global HTTP transport (in `gen.go`). We should try and push a change upstream to either add cancellation overall or allow overriding the HTTP client/transport.

Fixes #116.