### PR TITLE
Replace most Equals methods with go-cmp Equal

### DIFF
--- a/hack/generator/go.mod
+++ b/hack/generator/go.mod
@@ -5,6 +5,7 @@ go 1.13
 require (
 	github.com/bmatcuk/doublestar v1.3.1
 	github.com/devigned/tab v0.1.1
+	github.com/google/go-cmp v0.3.0
 	github.com/onsi/gomega v1.8.1
 	github.com/pelletier/go-toml v1.6.0 // indirect
 	github.com/sebdah/goldie/v2 v2.3.0

--- a/hack/generator/go.mod
+++ b/hack/generator/go.mod
@@ -5,7 +5,7 @@ go 1.13
 require (
 	github.com/bmatcuk/doublestar v1.3.1
 	github.com/devigned/tab v0.1.1
-	github.com/google/go-cmp v0.3.0
+	github.com/google/go-cmp v0.5.0
 	github.com/onsi/gomega v1.8.1
 	github.com/pelletier/go-toml v1.6.0 // indirect
 	github.com/sebdah/goldie/v2 v2.3.0
@@ -20,7 +20,6 @@ require (
 	github.com/xeipuuv/gojsonschema v1.2.0
 	golang.org/x/net v0.0.0-20191209160850-c0dbc17a3553 // indirect
 	golang.org/x/sys v0.0.0-20191228213918-04cbcbbfeed8 // indirect
-	golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 // indirect
 	gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 // indirect
 	gopkg.in/ini.v1 v1.51.1 // indirect
 	gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c

--- a/hack/generator/go.sum
+++ b/hack/generator/go.sum
@@ -64,8 +64,9 @@ github.com/golang/protobuf v1.3.2 h1:6nsPYzhq5kReh6QImI3k5qWzO4PEbvbIW2cwSfR/6xs
 github.com/golang/protobuf v1.3.2/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/google/btree v1.0.0/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=
 github.com/google/go-cmp v0.2.0/go.mod h1:oXzfMopK8JAjlY9xF4vHSVASa0yLyX7SntLO5aqRK0M=
-github.com/google/go-cmp v0.3.0 h1:crn/baboCvb5fXaQ0IJ1SGTsTVrWpDsCWC8EGETZijY=
 github.com/google/go-cmp v0.3.0/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
+github.com/google/go-cmp v0.5.0 h1:/QaMHBdZ26BB3SSst0Iwl10Epc+xhTquomWX0oZEB6w=
+github.com/google/go-cmp v0.5.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/google/gofuzz v1.1.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/google/uuid v1.1.1/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=

--- a/hack/generator/go.sum
+++ b/hack/generator/go.sum
@@ -64,6 +64,7 @@ github.com/golang/protobuf v1.3.2 h1:6nsPYzhq5kReh6QImI3k5qWzO4PEbvbIW2cwSfR/6xs
 github.com/golang/protobuf v1.3.2/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/google/btree v1.0.0/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=
 github.com/google/go-cmp v0.2.0/go.mod h1:oXzfMopK8JAjlY9xF4vHSVASa0yLyX7SntLO5aqRK0M=
+github.com/google/go-cmp v0.3.0 h1:crn/baboCvb5fXaQ0IJ1SGTsTVrWpDsCWC8EGETZijY=
 github.com/google/go-cmp v0.3.0/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/google/gofuzz v1.1.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=

--- a/hack/generator/pkg/astmodel/array_type.go
+++ b/hack/generator/pkg/astmodel/array_type.go
@@ -7,8 +7,6 @@ package astmodel
 
 import (
 	"go/ast"
-
-	"github.com/google/go-cmp/cmp"
 )
 
 // ArrayType is used for fields that contain an array of values
@@ -39,19 +37,6 @@ func (array *ArrayType) RequiredImports() []*PackageReference {
 // References this type has to the given type
 func (array *ArrayType) References(d *TypeName) bool {
 	return array.element.References(d)
-}
-
-// Equals returns true if the passed type is an array type with the same kind of elements, false otherwise
-func (array *ArrayType) Equal(t Type) bool {
-	if array == t {
-		return true
-	}
-
-	if et, ok := t.(*ArrayType); ok {
-		return cmp.Equal(array.element, et.element)
-	}
-
-	return false
 }
 
 // CreateInternalDefinitions invokes CreateInternalDefinitions on the inner 'element' type

--- a/hack/generator/pkg/astmodel/array_type.go
+++ b/hack/generator/pkg/astmodel/array_type.go
@@ -40,13 +40,13 @@ func (array *ArrayType) References(d *TypeName) bool {
 }
 
 // Equals returns true if the passed type is an array type with the same kind of elements, false otherwise
-func (array *ArrayType) Equals(t Type) bool {
+func (array *ArrayType) Equal(t Type) bool {
 	if array == t {
 		return true
 	}
 
 	if et, ok := t.(*ArrayType); ok {
-		return array.element.Equals(et.element)
+		return array.element.Equal(et.element)
 	}
 
 	return false

--- a/hack/generator/pkg/astmodel/array_type.go
+++ b/hack/generator/pkg/astmodel/array_type.go
@@ -7,6 +7,8 @@ package astmodel
 
 import (
 	"go/ast"
+
+	"github.com/google/go-cmp/cmp"
 )
 
 // ArrayType is used for fields that contain an array of values
@@ -46,7 +48,7 @@ func (array *ArrayType) Equal(t Type) bool {
 	}
 
 	if et, ok := t.(*ArrayType); ok {
-		return array.element.Equal(et.element)
+		return cmp.Equal(array.element, et.element)
 	}
 
 	return false

--- a/hack/generator/pkg/astmodel/array_type_test.go
+++ b/hack/generator/pkg/astmodel/array_type_test.go
@@ -8,7 +8,6 @@ package astmodel
 import (
 	"testing"
 
-	"github.com/google/go-cmp/cmp"
 	. "github.com/onsi/gomega"
 )
 
@@ -43,7 +42,7 @@ func TestArrayType_Equals_WhenGivenType_ReturnsExpectedResult(t *testing.T) {
 			t.Parallel()
 			g := NewGomegaWithT(t)
 
-			areEqual := cmp.Equal(c.thisType, c.otherType)
+			areEqual := NodesEqual(c.thisType, c.otherType)
 
 			g.Expect(areEqual).To(Equal(c.expected))
 		})

--- a/hack/generator/pkg/astmodel/array_type_test.go
+++ b/hack/generator/pkg/astmodel/array_type_test.go
@@ -8,6 +8,7 @@ package astmodel
 import (
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
 	. "github.com/onsi/gomega"
 )
 
@@ -42,7 +43,7 @@ func TestArrayType_Equals_WhenGivenType_ReturnsExpectedResult(t *testing.T) {
 			t.Parallel()
 			g := NewGomegaWithT(t)
 
-			areEqual := c.thisType.Equal(c.otherType)
+			areEqual := cmp.Equal(c.thisType, c.otherType)
 
 			g.Expect(areEqual).To(Equal(c.expected))
 		})

--- a/hack/generator/pkg/astmodel/array_type_test.go
+++ b/hack/generator/pkg/astmodel/array_type_test.go
@@ -42,7 +42,7 @@ func TestArrayType_Equals_WhenGivenType_ReturnsExpectedResult(t *testing.T) {
 			t.Parallel()
 			g := NewGomegaWithT(t)
 
-			areEqual := c.thisType.Equals(c.otherType)
+			areEqual := c.thisType.Equal(c.otherType)
 
 			g.Expect(areEqual).To(Equal(c.expected))
 		})

--- a/hack/generator/pkg/astmodel/enum_type.go
+++ b/hack/generator/pkg/astmodel/enum_type.go
@@ -9,6 +9,7 @@ import (
 	"go/ast"
 	"sort"
 
+	"github.com/google/go-cmp/cmp"
 	"k8s.io/klog/v2"
 )
 
@@ -47,7 +48,7 @@ func (enum *EnumType) References(tn *TypeName) bool {
 // Equals will return true if the supplied type has the same base type and options
 func (enum *EnumType) Equal(t Type) bool {
 	if e, ok := t.(*EnumType); ok {
-		if !enum.BaseType.Equal(e.BaseType) {
+		if !cmp.Equal(enum.BaseType, e.BaseType) {
 			return false
 		}
 
@@ -57,7 +58,7 @@ func (enum *EnumType) Equal(t Type) bool {
 		}
 
 		for i := range enum.options {
-			if !enum.options[i].Equal(&e.options[i]) {
+			if !cmp.Equal(enum.options[i], &e.options[i]) {
 				return false
 			}
 		}

--- a/hack/generator/pkg/astmodel/enum_type.go
+++ b/hack/generator/pkg/astmodel/enum_type.go
@@ -9,7 +9,6 @@ import (
 	"go/ast"
 	"sort"
 
-	"github.com/google/go-cmp/cmp"
 	"k8s.io/klog/v2"
 )
 
@@ -43,31 +42,6 @@ func (enum *EnumType) AsType(codeGenerationContext *CodeGenerationContext) ast.E
 // References indicates whether this Type includes any direct references to the given Type
 func (enum *EnumType) References(tn *TypeName) bool {
 	return enum.BaseType.References(tn)
-}
-
-// Equals will return true if the supplied type has the same base type and options
-func (enum *EnumType) Equal(t Type) bool {
-	if e, ok := t.(*EnumType); ok {
-		if !cmp.Equal(enum.BaseType, e.BaseType) {
-			return false
-		}
-
-		if len(enum.options) != len(e.options) {
-			// Different number of fields, not equal
-			return false
-		}
-
-		for i := range enum.options {
-			if !cmp.Equal(enum.options[i], &e.options[i]) {
-				return false
-			}
-		}
-
-		// All options match, equal
-		return true
-	}
-
-	return false
 }
 
 // RequiredImports indicates that Enums never need additional imports

--- a/hack/generator/pkg/astmodel/enum_type.go
+++ b/hack/generator/pkg/astmodel/enum_type.go
@@ -45,9 +45,9 @@ func (enum *EnumType) References(tn *TypeName) bool {
 }
 
 // Equals will return true if the supplied type has the same base type and options
-func (enum *EnumType) Equals(t Type) bool {
+func (enum *EnumType) Equal(t Type) bool {
 	if e, ok := t.(*EnumType); ok {
-		if !enum.BaseType.Equals(e.BaseType) {
+		if !enum.BaseType.Equal(e.BaseType) {
 			return false
 		}
 
@@ -57,7 +57,7 @@ func (enum *EnumType) Equals(t Type) bool {
 		}
 
 		for i := range enum.options {
-			if !enum.options[i].Equals(&e.options[i]) {
+			if !enum.options[i].Equal(&e.options[i]) {
 				return false
 			}
 		}

--- a/hack/generator/pkg/astmodel/enum_value.go
+++ b/hack/generator/pkg/astmodel/enum_value.go
@@ -14,7 +14,7 @@ type EnumValue struct {
 }
 
 // Equals tests to see if the passed EnumValue has the same name and value
-func (value *EnumValue) Equals(v *EnumValue) bool {
+func (value *EnumValue) Equal(v *EnumValue) bool {
 	if value == v {
 		return true
 	}

--- a/hack/generator/pkg/astmodel/enum_value.go
+++ b/hack/generator/pkg/astmodel/enum_value.go
@@ -12,12 +12,3 @@ type EnumValue struct {
 	// Value is the actual value expected by ARM
 	Value string
 }
-
-// Equals tests to see if the passed EnumValue has the same name and value
-func (value *EnumValue) Equal(v *EnumValue) bool {
-	if value == v {
-		return true
-	}
-
-	return value.Identifier == v.Identifier && value.Value == v.Value
-}

--- a/hack/generator/pkg/astmodel/equal.go
+++ b/hack/generator/pkg/astmodel/equal.go
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) Microsoft Corporation.
+ * Licensed under the MIT license.
+ */
+
+package astmodel
+
+import "github.com/google/go-cmp/cmp"
+
+var allowUnexported = cmp.AllowUnexported(
+	PackageReference{},
+	StructType{},
+	PrimitiveType{},
+	ArrayType{},
+	TypeName{},
+	MapType{},
+	OptionalType{},
+	EnumType{},
+)
+
+// NodesEqual compares two astmodel objects and returns whether they're
+// equivalent. It uses github.com/google/go-cmp/cmp.Equal with a list
+// of local types for which to allow comparing unexported fields.
+func NodesEqual(a, b interface{}) bool {
+	return cmp.Equal(a, b, allowUnexported)
+}

--- a/hack/generator/pkg/astmodel/field_definition.go
+++ b/hack/generator/pkg/astmodel/field_definition.go
@@ -9,6 +9,8 @@ import (
 	"fmt"
 	"go/ast"
 	"go/token"
+
+	"github.com/google/go-cmp/cmp"
 )
 
 // FieldName is a semantic type
@@ -135,5 +137,5 @@ func (field *FieldDefinition) AsField(codeGenerationContext *CodeGenerationConte
 
 // Equals tests to see if the specified FieldDefinition specifies the same field
 func (field *FieldDefinition) Equal(f *FieldDefinition) bool {
-	return field == f || (field.fieldName == f.fieldName && field.fieldType.Equal(f.fieldType))
+	return field == f || (field.fieldName == f.fieldName && cmp.Equal(field.fieldType, f.fieldType))
 }

--- a/hack/generator/pkg/astmodel/field_definition.go
+++ b/hack/generator/pkg/astmodel/field_definition.go
@@ -134,6 +134,6 @@ func (field *FieldDefinition) AsField(codeGenerationContext *CodeGenerationConte
 }
 
 // Equals tests to see if the specified FieldDefinition specifies the same field
-func (field *FieldDefinition) Equals(f *FieldDefinition) bool {
-	return field == f || (field.fieldName == f.fieldName && field.fieldType.Equals(f.fieldType))
+func (field *FieldDefinition) Equal(f *FieldDefinition) bool {
+	return field == f || (field.fieldName == f.fieldName && field.fieldType.Equal(f.fieldType))
 }

--- a/hack/generator/pkg/astmodel/field_definition.go
+++ b/hack/generator/pkg/astmodel/field_definition.go
@@ -9,8 +9,6 @@ import (
 	"fmt"
 	"go/ast"
 	"go/token"
-
-	"github.com/google/go-cmp/cmp"
 )
 
 // FieldName is a semantic type
@@ -135,7 +133,7 @@ func (field *FieldDefinition) AsField(codeGenerationContext *CodeGenerationConte
 	return result
 }
 
-// Equals tests to see if the specified FieldDefinition specifies the same field
+// Equal tests to see if the specified FieldDefinition specifies the same field
 func (field *FieldDefinition) Equal(f *FieldDefinition) bool {
-	return field == f || (field.fieldName == f.fieldName && cmp.Equal(field.fieldType, f.fieldType))
+	return field == f || (field.fieldName == f.fieldName && NodesEqual(field.fieldType, f.fieldType))
 }

--- a/hack/generator/pkg/astmodel/field_definition_test.go
+++ b/hack/generator/pkg/astmodel/field_definition_test.go
@@ -89,7 +89,7 @@ func TestFieldDefinition_Equals_WhenGivenFieldDefinition_ReturnsExpectedResult(t
 			t.Parallel()
 			g := NewGomegaWithT(t)
 
-			areEqual := c.thisField.Equals(c.otherField)
+			areEqual := c.thisField.Equal(c.otherField)
 
 			g.Expect(areEqual).To(Equal(c.expected))
 		})

--- a/hack/generator/pkg/astmodel/field_definition_test.go
+++ b/hack/generator/pkg/astmodel/field_definition_test.go
@@ -8,7 +8,6 @@ package astmodel
 import (
 	"testing"
 
-	"github.com/google/go-cmp/cmp"
 	. "github.com/onsi/gomega"
 )
 
@@ -90,7 +89,7 @@ func TestFieldDefinition_Equals_WhenGivenFieldDefinition_ReturnsExpectedResult(t
 			t.Parallel()
 			g := NewGomegaWithT(t)
 
-			areEqual := cmp.Equal(c.thisField, c.otherField)
+			areEqual := NodesEqual(c.thisField, c.otherField)
 
 			g.Expect(areEqual).To(Equal(c.expected))
 		})

--- a/hack/generator/pkg/astmodel/field_definition_test.go
+++ b/hack/generator/pkg/astmodel/field_definition_test.go
@@ -8,6 +8,7 @@ package astmodel
 import (
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
 	. "github.com/onsi/gomega"
 )
 
@@ -89,7 +90,7 @@ func TestFieldDefinition_Equals_WhenGivenFieldDefinition_ReturnsExpectedResult(t
 			t.Parallel()
 			g := NewGomegaWithT(t)
 
-			areEqual := c.thisField.Equal(c.otherField)
+			areEqual := cmp.Equal(c.thisField, c.otherField)
 
 			g.Expect(areEqual).To(Equal(c.expected))
 		})

--- a/hack/generator/pkg/astmodel/file_definition.go
+++ b/hack/generator/pkg/astmodel/file_definition.go
@@ -15,7 +15,6 @@ import (
 	"os"
 	"sort"
 
-	"github.com/google/go-cmp/cmp"
 	"k8s.io/klog/v2"
 )
 
@@ -51,7 +50,7 @@ func (file *FileDefinition) generateImports() map[PackageImport]struct{} {
 	for _, s := range file.definitions {
 		for _, requiredImport := range s.Type().RequiredImports() {
 			// no need to import the current package
-			if !cmp.Equal(requiredImport, file.packageReference) {
+			if !NodesEqual(requiredImport, file.packageReference) {
 				newImport := NewPackageImport(*requiredImport)
 				requiredImports[*newImport] = struct{}{}
 			}
@@ -64,7 +63,7 @@ func (file *FileDefinition) generateImports() map[PackageImport]struct{} {
 	// but a different package path
 	for imp := range requiredImports {
 		for otherImp := range requiredImports {
-			if !cmp.Equal(imp, &otherImp) && imp.PackageName() == otherImp.PackageName() {
+			if !NodesEqual(imp, &otherImp) && imp.PackageName() == otherImp.PackageName() {
 				klog.Warningf(
 					"File %v: import %v (named %v) and import %v (named %v) conflict",
 					file.packageReference.PackagePath(),

--- a/hack/generator/pkg/astmodel/file_definition.go
+++ b/hack/generator/pkg/astmodel/file_definition.go
@@ -50,7 +50,7 @@ func (file *FileDefinition) generateImports() map[PackageImport]struct{} {
 	for _, s := range file.definitions {
 		for _, requiredImport := range s.Type().RequiredImports() {
 			// no need to import the current package
-			if !requiredImport.Equals(file.packageReference) {
+			if !requiredImport.Equal(file.packageReference) {
 				newImport := NewPackageImport(*requiredImport)
 				requiredImports[*newImport] = struct{}{}
 			}
@@ -63,7 +63,7 @@ func (file *FileDefinition) generateImports() map[PackageImport]struct{} {
 	// but a different package path
 	for imp := range requiredImports {
 		for otherImp := range requiredImports {
-			if !imp.Equals(&otherImp) && imp.PackageName() == otherImp.PackageName() {
+			if !imp.Equal(&otherImp) && imp.PackageName() == otherImp.PackageName() {
 				klog.Warningf(
 					"File %v: import %v (named %v) and import %v (named %v) conflict",
 					file.packageReference.PackagePath(),

--- a/hack/generator/pkg/astmodel/file_definition.go
+++ b/hack/generator/pkg/astmodel/file_definition.go
@@ -15,6 +15,7 @@ import (
 	"os"
 	"sort"
 
+	"github.com/google/go-cmp/cmp"
 	"k8s.io/klog/v2"
 )
 
@@ -50,7 +51,7 @@ func (file *FileDefinition) generateImports() map[PackageImport]struct{} {
 	for _, s := range file.definitions {
 		for _, requiredImport := range s.Type().RequiredImports() {
 			// no need to import the current package
-			if !requiredImport.Equal(file.packageReference) {
+			if !cmp.Equal(requiredImport, file.packageReference) {
 				newImport := NewPackageImport(*requiredImport)
 				requiredImports[*newImport] = struct{}{}
 			}
@@ -63,7 +64,7 @@ func (file *FileDefinition) generateImports() map[PackageImport]struct{} {
 	// but a different package path
 	for imp := range requiredImports {
 		for otherImp := range requiredImports {
-			if !imp.Equal(&otherImp) && imp.PackageName() == otherImp.PackageName() {
+			if !cmp.Equal(imp, &otherImp) && imp.PackageName() == otherImp.PackageName() {
 				klog.Warningf(
 					"File %v: import %v (named %v) and import %v (named %v) conflict",
 					file.packageReference.PackagePath(),

--- a/hack/generator/pkg/astmodel/function.go
+++ b/hack/generator/pkg/astmodel/function.go
@@ -19,5 +19,5 @@ type Function interface {
 	AsFunc(codeGenerationContext *CodeGenerationContext, receiver *TypeName, methodName string) *ast.FuncDecl
 
 	// Equals determines if this Function is equal to another one
-	Equals(f Function) bool
+	Equal(f Function) bool
 }

--- a/hack/generator/pkg/astmodel/function.go
+++ b/hack/generator/pkg/astmodel/function.go
@@ -17,7 +17,4 @@ type Function interface {
 
 	// AsFunc renders the current instance as a Go abstract syntax tree
 	AsFunc(codeGenerationContext *CodeGenerationContext, receiver *TypeName, methodName string) *ast.FuncDecl
-
-	// Equals determines if this Function is equal to another one
-	Equal(f Function) bool
 }

--- a/hack/generator/pkg/astmodel/map_type.go
+++ b/hack/generator/pkg/astmodel/map_type.go
@@ -50,13 +50,13 @@ func (m *MapType) References(d *TypeName) bool {
 }
 
 // Equals returns true if the passed type is a map type with the same kinds of keys and elements, false otherwise
-func (m *MapType) Equals(t Type) bool {
+func (m *MapType) Equal(t Type) bool {
 	if m == t {
 		return true
 	}
 
 	if mt, ok := t.(*MapType); ok {
-		return (m.key.Equals(mt.key) && m.value.Equals(mt.value))
+		return (m.key.Equal(mt.key) && m.value.Equal(mt.value))
 	}
 
 	return false

--- a/hack/generator/pkg/astmodel/map_type.go
+++ b/hack/generator/pkg/astmodel/map_type.go
@@ -7,6 +7,8 @@ package astmodel
 
 import (
 	"go/ast"
+
+	"github.com/google/go-cmp/cmp"
 )
 
 // MapType is used to define fields that contain additional property values
@@ -56,7 +58,7 @@ func (m *MapType) Equal(t Type) bool {
 	}
 
 	if mt, ok := t.(*MapType); ok {
-		return (m.key.Equal(mt.key) && m.value.Equal(mt.value))
+		return cmp.Equal(m.key, mt.key) && cmp.Equal(m.value, mt.value)
 	}
 
 	return false

--- a/hack/generator/pkg/astmodel/map_type.go
+++ b/hack/generator/pkg/astmodel/map_type.go
@@ -7,8 +7,6 @@ package astmodel
 
 import (
 	"go/ast"
-
-	"github.com/google/go-cmp/cmp"
 )
 
 // MapType is used to define fields that contain additional property values
@@ -49,19 +47,6 @@ func (m *MapType) RequiredImports() []*PackageReference {
 // References this type has to the given type
 func (m *MapType) References(d *TypeName) bool {
 	return m.key.References(d) || m.value.References(d)
-}
-
-// Equals returns true if the passed type is a map type with the same kinds of keys and elements, false otherwise
-func (m *MapType) Equal(t Type) bool {
-	if m == t {
-		return true
-	}
-
-	if mt, ok := t.(*MapType); ok {
-		return cmp.Equal(m.key, mt.key) && cmp.Equal(m.value, mt.value)
-	}
-
-	return false
 }
 
 // CreateInternalDefinitions invokes CreateInCreateInternalDefinitions on both key and map types

--- a/hack/generator/pkg/astmodel/map_type_test.go
+++ b/hack/generator/pkg/astmodel/map_type_test.go
@@ -8,6 +8,7 @@ package astmodel
 import (
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
 	. "github.com/onsi/gomega"
 )
 
@@ -48,7 +49,7 @@ func TestMapType_Equals_WhenGivenType_ReturnsExpectedResult(t *testing.T) {
 			t.Parallel()
 			g := NewGomegaWithT(t)
 
-			areEqual := c.thisType.Equal(c.otherType)
+			areEqual := cmp.Equal(c.thisType, c.otherType)
 
 			g.Expect(areEqual).To(Equal(c.expected))
 		})

--- a/hack/generator/pkg/astmodel/map_type_test.go
+++ b/hack/generator/pkg/astmodel/map_type_test.go
@@ -48,7 +48,7 @@ func TestMapType_Equals_WhenGivenType_ReturnsExpectedResult(t *testing.T) {
 			t.Parallel()
 			g := NewGomegaWithT(t)
 
-			areEqual := c.thisType.Equals(c.otherType)
+			areEqual := c.thisType.Equal(c.otherType)
 
 			g.Expect(areEqual).To(Equal(c.expected))
 		})

--- a/hack/generator/pkg/astmodel/map_type_test.go
+++ b/hack/generator/pkg/astmodel/map_type_test.go
@@ -8,7 +8,6 @@ package astmodel
 import (
 	"testing"
 
-	"github.com/google/go-cmp/cmp"
 	. "github.com/onsi/gomega"
 )
 
@@ -49,7 +48,7 @@ func TestMapType_Equals_WhenGivenType_ReturnsExpectedResult(t *testing.T) {
 			t.Parallel()
 			g := NewGomegaWithT(t)
 
-			areEqual := cmp.Equal(c.thisType, c.otherType)
+			areEqual := NodesEqual(c.thisType, c.otherType)
 
 			g.Expect(areEqual).To(Equal(c.expected))
 		})

--- a/hack/generator/pkg/astmodel/one_of_json_marshal_function.go
+++ b/hack/generator/pkg/astmodel/one_of_json_marshal_function.go
@@ -27,9 +27,9 @@ func NewOneOfJSONMarshalFunction(oneOfStruct *StructType, idFactory IdentifierFa
 var _ Function = (*OneOfJSONMarshalFunction)(nil)
 
 // Equals determines if this function is equal to the passed in function
-func (f *OneOfJSONMarshalFunction) Equals(other Function) bool {
+func (f *OneOfJSONMarshalFunction) Equal(other Function) bool {
 	if o, ok := other.(*OneOfJSONMarshalFunction); ok {
-		return f.oneOfStruct.Equals(o.oneOfStruct)
+		return f.oneOfStruct.Equal(o.oneOfStruct)
 	}
 
 	return false

--- a/hack/generator/pkg/astmodel/one_of_json_marshal_function.go
+++ b/hack/generator/pkg/astmodel/one_of_json_marshal_function.go
@@ -9,6 +9,8 @@ import (
 	"fmt"
 	"go/ast"
 	"go/token"
+
+	"github.com/google/go-cmp/cmp"
 )
 
 // OneOfJSONMarshalFunction is a function for marshalling discriminated unions
@@ -29,7 +31,7 @@ var _ Function = (*OneOfJSONMarshalFunction)(nil)
 // Equals determines if this function is equal to the passed in function
 func (f *OneOfJSONMarshalFunction) Equal(other Function) bool {
 	if o, ok := other.(*OneOfJSONMarshalFunction); ok {
-		return f.oneOfStruct.Equal(o.oneOfStruct)
+		return cmp.Equal(f.oneOfStruct, o.oneOfStruct)
 	}
 
 	return false

--- a/hack/generator/pkg/astmodel/one_of_json_marshal_function.go
+++ b/hack/generator/pkg/astmodel/one_of_json_marshal_function.go
@@ -9,8 +9,6 @@ import (
 	"fmt"
 	"go/ast"
 	"go/token"
-
-	"github.com/google/go-cmp/cmp"
 )
 
 // OneOfJSONMarshalFunction is a function for marshalling discriminated unions
@@ -28,10 +26,10 @@ func NewOneOfJSONMarshalFunction(oneOfStruct *StructType, idFactory IdentifierFa
 // Ensure OneOfJSONMarshalFunction implements Function interface correctly
 var _ Function = (*OneOfJSONMarshalFunction)(nil)
 
-// Equals determines if this function is equal to the passed in function
+// Equal determines if this function is equal to the passed in function
 func (f *OneOfJSONMarshalFunction) Equal(other Function) bool {
 	if o, ok := other.(*OneOfJSONMarshalFunction); ok {
-		return cmp.Equal(f.oneOfStruct, o.oneOfStruct)
+		return NodesEqual(f.oneOfStruct, o.oneOfStruct)
 	}
 
 	return false

--- a/hack/generator/pkg/astmodel/optional_type.go
+++ b/hack/generator/pkg/astmodel/optional_type.go
@@ -7,6 +7,8 @@ package astmodel
 
 import (
 	"go/ast"
+
+	"github.com/google/go-cmp/cmp"
 )
 
 // OptionalType is used for items that may or may not be present
@@ -51,7 +53,7 @@ func (optional *OptionalType) Equal(t Type) bool {
 	}
 
 	if otherOptional, ok := t.(*OptionalType); ok {
-		return optional.element.Equal(otherOptional.element)
+		return cmp.Equal(optional.element, otherOptional.element)
 	}
 
 	return false

--- a/hack/generator/pkg/astmodel/optional_type.go
+++ b/hack/generator/pkg/astmodel/optional_type.go
@@ -45,13 +45,13 @@ func (optional *OptionalType) References(d *TypeName) bool {
 }
 
 // Equals returns true if this type is equal to the other type
-func (optional *OptionalType) Equals(t Type) bool {
+func (optional *OptionalType) Equal(t Type) bool {
 	if optional == t {
 		return true // reference equality short-cut
 	}
 
 	if otherOptional, ok := t.(*OptionalType); ok {
-		return optional.element.Equals(otherOptional.element)
+		return optional.element.Equal(otherOptional.element)
 	}
 
 	return false

--- a/hack/generator/pkg/astmodel/optional_type.go
+++ b/hack/generator/pkg/astmodel/optional_type.go
@@ -7,8 +7,6 @@ package astmodel
 
 import (
 	"go/ast"
-
-	"github.com/google/go-cmp/cmp"
 )
 
 // OptionalType is used for items that may or may not be present
@@ -44,19 +42,6 @@ func (optional *OptionalType) RequiredImports() []*PackageReference {
 // References is true if it is this type or the 'element' type references it
 func (optional *OptionalType) References(d *TypeName) bool {
 	return optional.element.References(d)
-}
-
-// Equals returns true if this type is equal to the other type
-func (optional *OptionalType) Equal(t Type) bool {
-	if optional == t {
-		return true // reference equality short-cut
-	}
-
-	if otherOptional, ok := t.(*OptionalType); ok {
-		return cmp.Equal(optional.element, otherOptional.element)
-	}
-
-	return false
 }
 
 // CreateInternalDefinitions invokes CreateInternalDefinitions on the inner type

--- a/hack/generator/pkg/astmodel/package_import.go
+++ b/hack/generator/pkg/astmodel/package_import.go
@@ -57,6 +57,6 @@ func (pi *PackageImport) PackageName() string {
 }
 
 // Equals returns true if the passed package reference references the same package, false otherwise
-func (pi *PackageImport) Equals(ref *PackageImport) bool {
-	return pi.PackageReference.Equals(&ref.PackageReference) && pi.name == ref.name
+func (pi *PackageImport) Equal(ref *PackageImport) bool {
+	return pi.PackageReference.Equal(&ref.PackageReference) && pi.name == ref.name
 }

--- a/hack/generator/pkg/astmodel/package_import.go
+++ b/hack/generator/pkg/astmodel/package_import.go
@@ -8,6 +8,8 @@ package astmodel
 import (
 	"go/ast"
 	"go/token"
+
+	"github.com/google/go-cmp/cmp"
 )
 
 // PackageReference indicates which package
@@ -58,5 +60,5 @@ func (pi *PackageImport) PackageName() string {
 
 // Equals returns true if the passed package reference references the same package, false otherwise
 func (pi *PackageImport) Equal(ref *PackageImport) bool {
-	return pi.PackageReference.Equal(&ref.PackageReference) && pi.name == ref.name
+	return cmp.Equal(pi.PackageReference, &ref.PackageReference) && pi.name == ref.name
 }

--- a/hack/generator/pkg/astmodel/package_import.go
+++ b/hack/generator/pkg/astmodel/package_import.go
@@ -8,8 +8,6 @@ package astmodel
 import (
 	"go/ast"
 	"go/token"
-
-	"github.com/google/go-cmp/cmp"
 )
 
 // PackageReference indicates which package
@@ -56,9 +54,4 @@ func (pi *PackageImport) PackageName() string {
 	}
 
 	return pi.PackageReference.PackageName()
-}
-
-// Equals returns true if the passed package reference references the same package, false otherwise
-func (pi *PackageImport) Equal(ref *PackageImport) bool {
-	return cmp.Equal(pi.PackageReference, &ref.PackageReference) && pi.name == ref.name
 }

--- a/hack/generator/pkg/astmodel/package_reference.go
+++ b/hack/generator/pkg/astmodel/package_reference.go
@@ -66,11 +66,6 @@ func (pr *PackageReference) PackageName() string {
 	return l[len(l)-1]
 }
 
-// Equals returns true if the passed package reference references the same package, false otherwise
-func (pr PackageReference) Equal(ref PackageReference) bool {
-	return pr.packagePath == ref.packagePath
-}
-
 // String returns the string representation of the package reference
 func (pr *PackageReference) String() string {
 	return pr.packagePath

--- a/hack/generator/pkg/astmodel/package_reference.go
+++ b/hack/generator/pkg/astmodel/package_reference.go
@@ -67,7 +67,7 @@ func (pr *PackageReference) PackageName() string {
 }
 
 // Equals returns true if the passed package reference references the same package, false otherwise
-func (pr *PackageReference) Equals(ref *PackageReference) bool {
+func (pr *PackageReference) Equal(ref *PackageReference) bool {
 	return pr.packagePath == ref.packagePath
 }
 

--- a/hack/generator/pkg/astmodel/package_reference.go
+++ b/hack/generator/pkg/astmodel/package_reference.go
@@ -67,7 +67,7 @@ func (pr *PackageReference) PackageName() string {
 }
 
 // Equals returns true if the passed package reference references the same package, false otherwise
-func (pr *PackageReference) Equal(ref *PackageReference) bool {
+func (pr PackageReference) Equal(ref PackageReference) bool {
 	return pr.packagePath == ref.packagePath
 }
 

--- a/hack/generator/pkg/astmodel/primitive_type.go
+++ b/hack/generator/pkg/astmodel/primitive_type.go
@@ -48,15 +48,6 @@ func (prim *PrimitiveType) References(d *TypeName) bool {
 	return false
 }
 
-// Equals returns true if the passed type is another primitive type the same name, false otherwise
-func (prim *PrimitiveType) Equal(t Type) bool {
-	if p, ok := t.(*PrimitiveType); ok {
-		return prim.name == p.name
-	}
-
-	return false
-}
-
 // CreateInternalDefinitions does nothing as there are no inner types
 func (prim *PrimitiveType) CreateInternalDefinitions(_ *TypeName, _ IdentifierFactory) (Type, []TypeDefiner) {
 	// a primitive type has no internal types that require definition

--- a/hack/generator/pkg/astmodel/primitive_type.go
+++ b/hack/generator/pkg/astmodel/primitive_type.go
@@ -49,7 +49,7 @@ func (prim *PrimitiveType) References(d *TypeName) bool {
 }
 
 // Equals returns true if the passed type is another primitive type the same name, false otherwise
-func (prim *PrimitiveType) Equals(t Type) bool {
+func (prim *PrimitiveType) Equal(t Type) bool {
 	if p, ok := t.(*PrimitiveType); ok {
 		return prim.name == p.name
 	}

--- a/hack/generator/pkg/astmodel/primitive_type_test.go
+++ b/hack/generator/pkg/astmodel/primitive_type_test.go
@@ -37,7 +37,7 @@ func TestPrimitiveType_Equals_WhenGivenType_ReturnsExpectedResult(t *testing.T) 
 			t.Parallel()
 			g := NewGomegaWithT(t)
 
-			areEqual := c.thisType.Equals(c.otherType)
+			areEqual := c.thisType.Equal(c.otherType)
 
 			g.Expect(areEqual).To(Equal(c.expected))
 		})

--- a/hack/generator/pkg/astmodel/primitive_type_test.go
+++ b/hack/generator/pkg/astmodel/primitive_type_test.go
@@ -8,6 +8,7 @@ package astmodel
 import (
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
 	. "github.com/onsi/gomega"
 )
 
@@ -37,7 +38,7 @@ func TestPrimitiveType_Equals_WhenGivenType_ReturnsExpectedResult(t *testing.T) 
 			t.Parallel()
 			g := NewGomegaWithT(t)
 
-			areEqual := c.thisType.Equal(c.otherType)
+			areEqual := cmp.Equal(c.thisType, c.otherType)
 
 			g.Expect(areEqual).To(Equal(c.expected))
 		})

--- a/hack/generator/pkg/astmodel/primitive_type_test.go
+++ b/hack/generator/pkg/astmodel/primitive_type_test.go
@@ -8,7 +8,6 @@ package astmodel
 import (
 	"testing"
 
-	"github.com/google/go-cmp/cmp"
 	. "github.com/onsi/gomega"
 )
 
@@ -38,7 +37,7 @@ func TestPrimitiveType_Equals_WhenGivenType_ReturnsExpectedResult(t *testing.T) 
 			t.Parallel()
 			g := NewGomegaWithT(t)
 
-			areEqual := cmp.Equal(c.thisType, c.otherType)
+			areEqual := NodesEqual(c.thisType, c.otherType)
 
 			g.Expect(areEqual).To(Equal(c.expected))
 		})

--- a/hack/generator/pkg/astmodel/struct_type.go
+++ b/hack/generator/pkg/astmodel/struct_type.go
@@ -8,6 +8,8 @@ package astmodel
 import (
 	"go/ast"
 	"sort"
+
+	"github.com/google/go-cmp/cmp"
 )
 
 // StructType represents an (unnamed) struct type
@@ -113,7 +115,7 @@ func (structType *StructType) Equal(t Type) bool {
 				return false
 			}
 
-			if !ourField.Equal(f) {
+			if !cmp.Equal(ourField, f) {
 				// Different field, even though same name; not-equal
 				return false
 			}
@@ -131,7 +133,7 @@ func (structType *StructType) Equal(t Type) bool {
 				return false
 			}
 
-			if !ourFunction.Equal(function) {
+			if !cmp.Equal(ourFunction, function) {
 				// Different function, even though same name; not-equal
 				return false
 			}

--- a/hack/generator/pkg/astmodel/struct_type.go
+++ b/hack/generator/pkg/astmodel/struct_type.go
@@ -95,7 +95,7 @@ func (structType *StructType) References(d *TypeName) bool {
 
 // Equals returns true if the passed type is a struct type with the same fields, false otherwise
 // The order of the fields is not relevant
-func (structType *StructType) Equals(t Type) bool {
+func (structType *StructType) Equal(t Type) bool {
 	if structType == t {
 		return true
 	}
@@ -113,7 +113,7 @@ func (structType *StructType) Equals(t Type) bool {
 				return false
 			}
 
-			if !ourField.Equals(f) {
+			if !ourField.Equal(f) {
 				// Different field, even though same name; not-equal
 				return false
 			}
@@ -131,7 +131,7 @@ func (structType *StructType) Equals(t Type) bool {
 				return false
 			}
 
-			if !ourFunction.Equals(function) {
+			if !ourFunction.Equal(function) {
 				// Different function, even though same name; not-equal
 				return false
 			}

--- a/hack/generator/pkg/astmodel/struct_type.go
+++ b/hack/generator/pkg/astmodel/struct_type.go
@@ -8,8 +8,6 @@ package astmodel
 import (
 	"go/ast"
 	"sort"
-
-	"github.com/google/go-cmp/cmp"
 )
 
 // StructType represents an (unnamed) struct type
@@ -91,57 +89,6 @@ func (structType *StructType) References(d *TypeName) bool {
 	}
 
 	// For now, not considering functions in references on purpose
-
-	return false
-}
-
-// Equals returns true if the passed type is a struct type with the same fields, false otherwise
-// The order of the fields is not relevant
-func (structType *StructType) Equal(t Type) bool {
-	if structType == t {
-		return true
-	}
-
-	if st, ok := t.(*StructType); ok {
-		if len(structType.fields) != len(st.fields) {
-			// Different number of fields, not equal
-			return false
-		}
-
-		for n, f := range st.fields {
-			ourField, ok := structType.fields[n]
-			if !ok {
-				// Didn't find the field, not equal
-				return false
-			}
-
-			if !cmp.Equal(ourField, f) {
-				// Different field, even though same name; not-equal
-				return false
-			}
-		}
-
-		if len(structType.functions) != len(st.functions) {
-			// Different number of functions, not equal
-			return false
-		}
-
-		for functionName, function := range st.functions {
-			ourFunction, ok := structType.functions[functionName]
-			if !ok {
-				// Didn't find the func, not equal
-				return false
-			}
-
-			if !cmp.Equal(ourFunction, function) {
-				// Different function, even though same name; not-equal
-				return false
-			}
-		}
-
-		// All fields match, equal
-		return true
-	}
 
 	return false
 }

--- a/hack/generator/pkg/astmodel/struct_type_test.go
+++ b/hack/generator/pkg/astmodel/struct_type_test.go
@@ -8,7 +8,6 @@ package astmodel
 import (
 	"testing"
 
-	"github.com/google/go-cmp/cmp"
 	. "github.com/onsi/gomega"
 )
 
@@ -58,7 +57,7 @@ func TestStructType_Equals_WhenGivenType_ReturnsExpectedResult(t *testing.T) {
 			t.Parallel()
 			g := NewGomegaWithT(t)
 
-			areEqual := cmp.Equal(c.thisType, c.otherType)
+			areEqual := NodesEqual(c.thisType, c.otherType)
 
 			g.Expect(areEqual).To(Equal(c.expected))
 		})

--- a/hack/generator/pkg/astmodel/struct_type_test.go
+++ b/hack/generator/pkg/astmodel/struct_type_test.go
@@ -57,7 +57,7 @@ func TestStructType_Equals_WhenGivenType_ReturnsExpectedResult(t *testing.T) {
 			t.Parallel()
 			g := NewGomegaWithT(t)
 
-			areEqual := c.thisType.Equals(c.otherType)
+			areEqual := c.thisType.Equal(c.otherType)
 
 			g.Expect(areEqual).To(Equal(c.expected))
 		})

--- a/hack/generator/pkg/astmodel/struct_type_test.go
+++ b/hack/generator/pkg/astmodel/struct_type_test.go
@@ -8,6 +8,7 @@ package astmodel
 import (
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
 	. "github.com/onsi/gomega"
 )
 
@@ -57,7 +58,7 @@ func TestStructType_Equals_WhenGivenType_ReturnsExpectedResult(t *testing.T) {
 			t.Parallel()
 			g := NewGomegaWithT(t)
 
-			areEqual := c.thisType.Equal(c.otherType)
+			areEqual := cmp.Equal(c.thisType, c.otherType)
 
 			g.Expect(areEqual).To(Equal(c.expected))
 		})

--- a/hack/generator/pkg/astmodel/type.go
+++ b/hack/generator/pkg/astmodel/type.go
@@ -23,7 +23,7 @@ type Type interface {
 	AsType(codeGenerationContext *CodeGenerationContext) ast.Expr
 
 	// Equals returns true if the passed type is the same as this one, false otherwise
-	Equals(t Type) bool
+	Equal(t Type) bool
 
 	// CreateDefinitions gives a name to the type and might generate some asssociated definitions as well (the second result)
 	// that also must be included in the output.

--- a/hack/generator/pkg/astmodel/type.go
+++ b/hack/generator/pkg/astmodel/type.go
@@ -22,9 +22,6 @@ type Type interface {
 	// (yes this says ast.Expr but that is what the Go 'ast' package uses for types)
 	AsType(codeGenerationContext *CodeGenerationContext) ast.Expr
 
-	// Equals returns true if the passed type is the same as this one, false otherwise
-	Equal(t Type) bool
-
 	// CreateDefinitions gives a name to the type and might generate some asssociated definitions as well (the second result)
 	// that also must be included in the output.
 	//

--- a/hack/generator/pkg/astmodel/type_name.go
+++ b/hack/generator/pkg/astmodel/type_name.go
@@ -8,8 +8,6 @@ package astmodel
 import (
 	"fmt"
 	"go/ast"
-
-	"github.com/google/go-cmp/cmp"
 )
 
 // TypeName is a name associated with another Type (it also is usable as a Type)
@@ -43,7 +41,7 @@ func (typeName *TypeName) AsType(codeGenerationContext *CodeGenerationContext) a
 	}
 
 	// Sanity assertion that the type we're generating is in the same package that the context is for
-	if !cmp.Equal(codeGenerationContext.currentPackage, &typeName.PackageReference) {
+	if !NodesEqual(codeGenerationContext.currentPackage, &typeName.PackageReference) {
 		panic(fmt.Sprintf(
 			"no reference for %v included in package %v",
 			typeName.name,
@@ -55,21 +53,12 @@ func (typeName *TypeName) AsType(codeGenerationContext *CodeGenerationContext) a
 
 // References indicates whether this Type includes any direct references to the given Type
 func (typeName *TypeName) References(d *TypeName) bool {
-	return cmp.Equal(typeName, d)
+	return NodesEqual(typeName, d)
 }
 
 // RequiredImports returns all the imports required for this definition
 func (typeName *TypeName) RequiredImports() []*PackageReference {
 	return []*PackageReference{&typeName.PackageReference}
-}
-
-// Equals returns true if the passed type is the same TypeName, false otherwise
-func (typeName *TypeName) Equal(t Type) bool {
-	if d, ok := t.(*TypeName); ok {
-		return typeName.name == d.name && cmp.Equal(typeName.PackageReference, d.PackageReference)
-	}
-
-	return false
 }
 
 // CreateInternalDefinitions does nothing

--- a/hack/generator/pkg/astmodel/type_name.go
+++ b/hack/generator/pkg/astmodel/type_name.go
@@ -8,6 +8,8 @@ package astmodel
 import (
 	"fmt"
 	"go/ast"
+
+	"github.com/google/go-cmp/cmp"
 )
 
 // TypeName is a name associated with another Type (it also is usable as a Type)
@@ -41,7 +43,7 @@ func (typeName *TypeName) AsType(codeGenerationContext *CodeGenerationContext) a
 	}
 
 	// Sanity assertion that the type we're generating is in the same package that the context is for
-	if !codeGenerationContext.currentPackage.Equal(&typeName.PackageReference) {
+	if !cmp.Equal(codeGenerationContext.currentPackage, &typeName.PackageReference) {
 		panic(fmt.Sprintf(
 			"no reference for %v included in package %v",
 			typeName.name,
@@ -53,7 +55,7 @@ func (typeName *TypeName) AsType(codeGenerationContext *CodeGenerationContext) a
 
 // References indicates whether this Type includes any direct references to the given Type
 func (typeName *TypeName) References(d *TypeName) bool {
-	return typeName.Equal(d)
+	return cmp.Equal(typeName, d)
 }
 
 // RequiredImports returns all the imports required for this definition
@@ -64,7 +66,7 @@ func (typeName *TypeName) RequiredImports() []*PackageReference {
 // Equals returns true if the passed type is the same TypeName, false otherwise
 func (typeName *TypeName) Equal(t Type) bool {
 	if d, ok := t.(*TypeName); ok {
-		return typeName.name == d.name && typeName.PackageReference.Equal(&d.PackageReference)
+		return typeName.name == d.name && cmp.Equal(typeName.PackageReference, d.PackageReference)
 	}
 
 	return false

--- a/hack/generator/pkg/astmodel/type_name.go
+++ b/hack/generator/pkg/astmodel/type_name.go
@@ -41,7 +41,7 @@ func (typeName *TypeName) AsType(codeGenerationContext *CodeGenerationContext) a
 	}
 
 	// Sanity assertion that the type we're generating is in the same package that the context is for
-	if !codeGenerationContext.currentPackage.Equals(&typeName.PackageReference) {
+	if !codeGenerationContext.currentPackage.Equal(&typeName.PackageReference) {
 		panic(fmt.Sprintf(
 			"no reference for %v included in package %v",
 			typeName.name,
@@ -53,7 +53,7 @@ func (typeName *TypeName) AsType(codeGenerationContext *CodeGenerationContext) a
 
 // References indicates whether this Type includes any direct references to the given Type
 func (typeName *TypeName) References(d *TypeName) bool {
-	return typeName.Equals(d)
+	return typeName.Equal(d)
 }
 
 // RequiredImports returns all the imports required for this definition
@@ -62,9 +62,9 @@ func (typeName *TypeName) RequiredImports() []*PackageReference {
 }
 
 // Equals returns true if the passed type is the same TypeName, false otherwise
-func (typeName *TypeName) Equals(t Type) bool {
+func (typeName *TypeName) Equal(t Type) bool {
 	if d, ok := t.(*TypeName); ok {
-		return typeName.name == d.name && typeName.PackageReference.Equals(&d.PackageReference)
+		return typeName.name == d.name && typeName.PackageReference.Equal(&d.PackageReference)
 	}
 
 	return false

--- a/hack/generator/pkg/jsonast/jsonast.go
+++ b/hack/generator/pkg/jsonast/jsonast.go
@@ -793,7 +793,7 @@ func versionOf(url *url.URL) (string, error) {
 func appendIfUniqueType(slice []astmodel.Type, item astmodel.Type) []astmodel.Type {
 	found := false
 	for _, r := range slice {
-		if r.Equals(item) {
+		if r.Equal(item) {
 			found = true
 			break
 		}

--- a/hack/generator/pkg/jsonast/jsonast.go
+++ b/hack/generator/pkg/jsonast/jsonast.go
@@ -17,6 +17,7 @@ import (
 	"github.com/Azure/k8s-infra/hack/generator/pkg/astmodel"
 	"github.com/Azure/k8s-infra/hack/generator/pkg/config"
 	"github.com/devigned/tab"
+	"github.com/google/go-cmp/cmp"
 	"github.com/xeipuuv/gojsonschema"
 )
 
@@ -793,7 +794,7 @@ func versionOf(url *url.URL) (string, error) {
 func appendIfUniqueType(slice []astmodel.Type, item astmodel.Type) []astmodel.Type {
 	found := false
 	for _, r := range slice {
-		if r.Equal(item) {
+		if cmp.Equal(r, item) {
 			found = true
 			break
 		}

--- a/hack/generator/pkg/jsonast/jsonast.go
+++ b/hack/generator/pkg/jsonast/jsonast.go
@@ -17,7 +17,6 @@ import (
 	"github.com/Azure/k8s-infra/hack/generator/pkg/astmodel"
 	"github.com/Azure/k8s-infra/hack/generator/pkg/config"
 	"github.com/devigned/tab"
-	"github.com/google/go-cmp/cmp"
 	"github.com/xeipuuv/gojsonschema"
 )
 
@@ -794,7 +793,7 @@ func versionOf(url *url.URL) (string, error) {
 func appendIfUniqueType(slice []astmodel.Type, item astmodel.Type) []astmodel.Type {
 	found := false
 	for _, r := range slice {
-		if cmp.Equal(r, item) {
+		if astmodel.NodesEqual(r, item) {
 			found = true
 			break
 		}


### PR DESCRIPTION
This removes most of the Equals methods from `astmodel` types - only the ones that need some non-default behaviour are kept.

This was done to explore #123 but we might not want to actually land it, for reasons that are called out in the [go-cmp docs](https://pkg.go.dev/github.com/google/go-cmp/cmp).
1. cmp.Equal panics when it encounters a problem comparing things - in our codebase it panics on structs with unexported fields. I've handled this by adding all the types encountered to an allow list, but we might see this for new types that are added.
2. It's noticeably slower - on my machine `time bin/k8sinfra-gen gen azure-arm.yaml` went from about 15s to about 45s.

Neither of these are deal-breakers for the code generation but the savings in terms of removed Equals methods isn't huge either. What do people think?
