### PR TITLE
Split out ResourceDefinition from StructDefinition

### DIFF
--- a/hack/generator/pkg/astmodel/array_type.go
+++ b/hack/generator/pkg/astmodel/array_type.go
@@ -59,6 +59,6 @@ func (array *ArrayType) CreateInternalDefinitions(name *TypeName, idFactory Iden
 }
 
 // CreateDefinitions defines a named type for this array type
-func (array *ArrayType) CreateDefinitions(name *TypeName, _ IdentifierFactory, _ bool) (TypeDefiner, []TypeDefiner) {
+func (array *ArrayType) CreateDefinitions(name *TypeName, _ IdentifierFactory) (TypeDefiner, []TypeDefiner) {
 	return NewSimpleTypeDefiner(name, array), nil
 }

--- a/hack/generator/pkg/astmodel/enum_type.go
+++ b/hack/generator/pkg/astmodel/enum_type.go
@@ -78,12 +78,12 @@ func (enum *EnumType) RequiredImports() []*PackageReference {
 // of this "raw" enum type
 func (enum *EnumType) CreateInternalDefinitions(nameHint *TypeName, idFactory IdentifierFactory) (Type, []TypeDefiner) {
 	// an internal enum must always be named:
-	definedEnum, otherTypes := enum.CreateDefinitions(nameHint, idFactory, false)
+	definedEnum, otherTypes := enum.CreateDefinitions(nameHint, idFactory)
 	return definedEnum.Name(), append(otherTypes, definedEnum)
 }
 
 // CreateDefinitions defines a named type for this "raw" enum type
-func (enum *EnumType) CreateDefinitions(name *TypeName, idFactory IdentifierFactory, _ bool) (TypeDefiner, []TypeDefiner) {
+func (enum *EnumType) CreateDefinitions(name *TypeName, idFactory IdentifierFactory) (TypeDefiner, []TypeDefiner) {
 	identifier := idFactory.CreateEnumIdentifier(name.name)
 	canonicalName := NewTypeName(name.PackageReference, identifier)
 	return NewEnumDefinition(canonicalName, enum), nil

--- a/hack/generator/pkg/astmodel/file_definition.go
+++ b/hack/generator/pkg/astmodel/file_definition.go
@@ -111,7 +111,7 @@ func (file *FileDefinition) AsAst() ast.Node {
 	// Emit struct registration for each resource:
 	var exprs []ast.Expr
 	for _, defn := range file.definitions {
-		if structDefn, ok := defn.(*StructDefinition); ok && structDefn.IsResource() {
+		if structDefn, ok := defn.(*ResourceDefinition); ok {
 			exprs = append(exprs, &ast.UnaryExpr{
 				Op: token.AND,
 				X:  &ast.CompositeLit{Type: structDefn.Name().AsType(codeGenContext)},

--- a/hack/generator/pkg/astmodel/file_definition_test.go
+++ b/hack/generator/pkg/astmodel/file_definition_test.go
@@ -28,7 +28,7 @@ func NewTestStruct(name string, fields ...string) StructDefinition {
 	}
 
 	ref := NewTypeName(*NewLocalPackageReference("group", "2020-01-01"), name)
-	definition := NewStructDefinition(ref, NewStructType().WithFields(fs...), false)
+	definition := NewStructDefinition(ref, NewStructType().WithFields(fs...))
 
 	return *definition
 }

--- a/hack/generator/pkg/astmodel/map_type.go
+++ b/hack/generator/pkg/astmodel/map_type.go
@@ -70,6 +70,6 @@ func (m *MapType) CreateInternalDefinitions(name *TypeName, idFactory Identifier
 }
 
 // CreateDefinitions defines a named type for this MapType
-func (m *MapType) CreateDefinitions(name *TypeName, _ IdentifierFactory, _ bool) (TypeDefiner, []TypeDefiner) {
+func (m *MapType) CreateDefinitions(name *TypeName, _ IdentifierFactory) (TypeDefiner, []TypeDefiner) {
 	return NewSimpleTypeDefiner(name, m), nil
 }

--- a/hack/generator/pkg/astmodel/optional_type.go
+++ b/hack/generator/pkg/astmodel/optional_type.go
@@ -64,6 +64,6 @@ func (optional *OptionalType) CreateInternalDefinitions(name *TypeName, idFactor
 }
 
 // CreateDefinitions defines a named type for this OptionalType
-func (optional *OptionalType) CreateDefinitions(name *TypeName, _ IdentifierFactory, _ bool) (TypeDefiner, []TypeDefiner) {
+func (optional *OptionalType) CreateDefinitions(name *TypeName, _ IdentifierFactory) (TypeDefiner, []TypeDefiner) {
 	return NewSimpleTypeDefiner(name, optional), nil
 }

--- a/hack/generator/pkg/astmodel/package_definition.go
+++ b/hack/generator/pkg/astmodel/package_definition.go
@@ -94,14 +94,14 @@ func anyReferences(defs []TypeDefiner, defName *TypeName) bool {
 	return false
 }
 
-func partitionDefinitions(definitions []TypeDefiner) (resourceStructs []*StructDefinition, otherDefinitions []TypeDefiner) {
+func partitionDefinitions(definitions []TypeDefiner) (resourceStructs []*ResourceDefinition, otherDefinitions []TypeDefiner) {
 
-	var resources []*StructDefinition
+	var resources []*ResourceDefinition
 	var notResources []TypeDefiner
 
 	for _, def := range definitions {
-		if structDef, ok := def.(*StructDefinition); ok && structDef.IsResource() {
-			resources = append(resources, structDef)
+		if resourceDef, ok := def.(*ResourceDefinition); ok {
+			resources = append(resources, resourceDef)
 		} else {
 			notResources = append(notResources, def)
 		}

--- a/hack/generator/pkg/astmodel/primitive_type.go
+++ b/hack/generator/pkg/astmodel/primitive_type.go
@@ -64,7 +64,7 @@ func (prim *PrimitiveType) CreateInternalDefinitions(_ *TypeName, _ IdentifierFa
 }
 
 // CreateDefinitions defines a named type for this primitive
-func (prim *PrimitiveType) CreateDefinitions(name *TypeName, _ IdentifierFactory, _ bool) (TypeDefiner, []TypeDefiner) {
+func (prim *PrimitiveType) CreateDefinitions(name *TypeName, _ IdentifierFactory) (TypeDefiner, []TypeDefiner) {
 	return NewSimpleTypeDefiner(name, prim), nil
 }
 

--- a/hack/generator/pkg/astmodel/resource.go
+++ b/hack/generator/pkg/astmodel/resource.go
@@ -56,7 +56,9 @@ func (definition *ResourceDefinition) Name() *TypeName {
 }
 
 func (definition *ResourceDefinition) Type() Type {
-	return definition.spec // TODO?????
+	return definition.spec // TODO BUG: the status is not considered here
+	// TO FIX: consider lifting up the two methods used on the result of this method
+	// (which are References/RequiredImports) into the TypeDefiner interface
 }
 
 func (definition *ResourceDefinition) MarkAsStorageVersion() *ResourceDefinition {

--- a/hack/generator/pkg/astmodel/resource.go
+++ b/hack/generator/pkg/astmodel/resource.go
@@ -1,0 +1,131 @@
+/*
+ * Copyright (c) Microsoft Corporation.
+ * Licensed under the MIT license.
+ */
+
+package astmodel
+
+import (
+	"go/ast"
+	"go/token"
+)
+
+// CreateResourceDefinitions creates definitions for a resource
+func CreateResourceDefinitions(name *TypeName, specType *StructType, statusType *StructType, idFactory IdentifierFactory) (TypeDefiner, []TypeDefiner) {
+
+	var others []TypeDefiner
+
+	var specName *TypeName
+	if specType != nil {
+		specName = NewTypeName(name.PackageReference, name.Name()+"Spec")
+		specDef, specOthers := specType.CreateDefinitions(specName, idFactory)
+
+		others = append(append(others, specDef), specOthers...)
+	} else {
+		panic("spec must always be provided")
+	}
+
+	var statusName *TypeName
+	if statusType != nil {
+		statusName = NewTypeName(name.PackageReference, name.Name()+"Status")
+		statusDef, statusOthers := statusType.CreateDefinitions(statusName, idFactory)
+
+		others = append(append(others, statusDef), statusOthers...)
+	}
+
+	this := &ResourceDefinition{typeName: name, spec: specName, status: statusName, isStorageVersion: false}
+
+	return this, others
+}
+
+// ResourceDefinition represents an ARM resource
+type ResourceDefinition struct {
+	typeName         *TypeName
+	spec             *TypeName
+	status           *TypeName
+	isStorageVersion bool
+	description      *string
+}
+
+// assert that ResourceDefinition implements TypeDefiner
+var _ TypeDefiner = &ResourceDefinition{}
+
+func (definition *ResourceDefinition) Name() *TypeName {
+	return definition.typeName
+}
+
+func (definition *ResourceDefinition) Type() Type {
+	return definition.spec // TODO?????
+}
+
+func (definition *ResourceDefinition) WithIsStorageVersion(isStorageVersion bool) *ResourceDefinition {
+	result := *definition
+	result.isStorageVersion = isStorageVersion
+	return &result
+}
+
+func (definition *ResourceDefinition) WithDescription(description *string) TypeDefiner {
+	result := *definition
+	result.description = description
+	return &result
+}
+
+// TODO: metav1 import should be added via RequiredImports?
+var typeMetaField = defineField("", "metav1.TypeMeta", "`json:\",inline\"`")
+var objectMetaField = defineField("", "metav1.ObjectMeta", "`json:\"metadata,omitempty\"`")
+
+// AsDeclarations converts the ResourceDefinition to a go declaration
+func (definition *ResourceDefinition) AsDeclarations(codeGenerationContext *CodeGenerationContext) []ast.Decl {
+
+	/*
+		start off with:
+			metav1.TypeMeta   `json:",inline"`
+			metav1.ObjectMeta `json:"metadata,omitempty"`
+
+		then the Spec/Status fields
+	*/
+	fields := []*ast.Field{
+		typeMetaField,
+		objectMetaField,
+		defineField("Spec", definition.spec.name, "`json:\"spec,omitempty\"`"),
+	}
+
+	if definition.status != nil {
+		fields = append(fields, defineField("Status", definition.status.name, "`json:\"spec,omitempty\"`"))
+	}
+
+	resourceIdentifier := ast.NewIdent(definition.typeName.name)
+	resourceTypeSpec := &ast.TypeSpec{
+		Name: resourceIdentifier,
+		Type: &ast.StructType{
+			Fields: &ast.FieldList{List: fields},
+		},
+	}
+
+	comments :=
+		[]*ast.Comment{
+			{
+				Text: "// +kubebuilder:object:root=true\n",
+			},
+		}
+
+	if definition.isStorageVersion {
+		comments = append(comments, &ast.Comment{
+			Text: "// +kubebuilder:storageversion\n",
+		})
+	}
+
+	if definition.description != nil {
+		comments = append(comments, &ast.Comment{
+			Text: "/*" + *definition.description + "*/",
+		})
+	}
+
+	return []ast.Decl{
+		&ast.GenDecl{
+			Tok:   token.TYPE,
+			Specs: []ast.Spec{resourceTypeSpec},
+			Doc:   &ast.CommentGroup{List: comments},
+		},
+	}
+}

--- a/hack/generator/pkg/astmodel/resource.go
+++ b/hack/generator/pkg/astmodel/resource.go
@@ -51,22 +51,26 @@ type ResourceDefinition struct {
 // assert that ResourceDefinition implements TypeDefiner
 var _ TypeDefiner = &ResourceDefinition{}
 
+// Name returns the name of the type being defined
 func (definition *ResourceDefinition) Name() *TypeName {
 	return definition.typeName
 }
 
+// Type returns the type to be associated with the name
 func (definition *ResourceDefinition) Type() Type {
 	return definition.spec // TODO BUG: the status is not considered here
 	// TO FIX: consider lifting up the two methods used on the result of this method
 	// (which are References/RequiredImports) into the TypeDefiner interface
 }
 
+// MarkAsStorageVersion marks the resource as the Kubebuilder storage version
 func (definition *ResourceDefinition) MarkAsStorageVersion() *ResourceDefinition {
 	result := *definition
 	result.isStorageVersion = true
 	return &result
 }
 
+// WithDescription replaces the description of the resource
 func (definition *ResourceDefinition) WithDescription(description *string) TypeDefiner {
 	result := *definition
 	result.description = description

--- a/hack/generator/pkg/astmodel/resource.go
+++ b/hack/generator/pkg/astmodel/resource.go
@@ -15,22 +15,23 @@ func CreateResourceDefinitions(name *TypeName, specType *StructType, statusType 
 
 	var others []TypeDefiner
 
-	var specName *TypeName
-	if specType != nil {
-		specName = NewTypeName(name.PackageReference, name.Name()+"Spec")
-		specDef, specOthers := specType.CreateDefinitions(specName, idFactory)
+	defineStruct := func(suffix string, structType *StructType) *TypeName {
+		definedName := NewTypeName(name.PackageReference, name.Name()+suffix)
+		defined, definedOthers := structType.CreateDefinitions(definedName, idFactory)
+		others = append(append(others, defined), definedOthers...)
+		return definedName
+	}
 
-		others = append(append(others, specDef), specOthers...)
-	} else {
+	var specName *TypeName
+	if specType == nil {
 		panic("spec must always be provided")
+	} else {
+		specName = defineStruct("Spec", specType)
 	}
 
 	var statusName *TypeName
 	if statusType != nil {
-		statusName = NewTypeName(name.PackageReference, name.Name()+"Status")
-		statusDef, statusOthers := statusType.CreateDefinitions(statusName, idFactory)
-
-		others = append(append(others, statusDef), statusOthers...)
+		statusName = defineStruct("Status", statusType)
 	}
 
 	this := &ResourceDefinition{typeName: name, spec: specName, status: statusName, isStorageVersion: false}

--- a/hack/generator/pkg/astmodel/resource.go
+++ b/hack/generator/pkg/astmodel/resource.go
@@ -58,9 +58,9 @@ func (definition *ResourceDefinition) Type() Type {
 	return definition.spec // TODO?????
 }
 
-func (definition *ResourceDefinition) WithIsStorageVersion(isStorageVersion bool) *ResourceDefinition {
+func (definition *ResourceDefinition) MarkAsStorageVersion() *ResourceDefinition {
 	result := *definition
-	result.isStorageVersion = isStorageVersion
+	result.isStorageVersion = true
 	return &result
 }
 

--- a/hack/generator/pkg/astmodel/struct_definition_test.go
+++ b/hack/generator/pkg/astmodel/struct_definition_test.go
@@ -22,7 +22,7 @@ func Test_NewStructDefinition_GivenValues_InitializesFields(t *testing.T) {
 	knownAsField := createStringField("knownAs", "Commonly known as")
 
 	ref := NewTypeName(*NewLocalPackageReference(group, version), name)
-	definition := NewStructDefinition(ref, NewStructType().WithFields(fullNameField, familyNameField, knownAsField), false)
+	definition := NewStructDefinition(ref, NewStructType().WithFields(fullNameField, familyNameField, knownAsField))
 
 	definitionGroup, definitionPackage, err := definition.Name().PackageReference.GroupAndPackage()
 	g.Expect(err).To(BeNil())
@@ -30,14 +30,14 @@ func Test_NewStructDefinition_GivenValues_InitializesFields(t *testing.T) {
 	g.Expect(definition.Name().name).To(Equal(name))
 	g.Expect(definitionGroup).To(Equal(group))
 	g.Expect(definitionPackage).To(Equal(version))
-	g.Expect(definition.StructType.fields).To(HaveLen(3))
+	g.Expect(definition.structType.fields).To(HaveLen(3))
 }
 
 func Test_StructDefinitionAsAst_GivenValidStruct_ReturnsNonNilResult(t *testing.T) {
 	g := NewGomegaWithT(t)
 
 	ref := NewTypeName(*NewLocalPackageReference("group", "2020-01-01"), "name")
-	field := NewStructDefinition(ref, NewStructType(), false)
+	field := NewStructDefinition(ref, NewStructType())
 	node := field.AsDeclarations(nil)
 
 	g.Expect(node).NotTo(BeNil())

--- a/hack/generator/pkg/astmodel/struct_type.go
+++ b/hack/generator/pkg/astmodel/struct_type.go
@@ -82,6 +82,7 @@ func (structType *StructType) RequiredImports() []*PackageReference {
 
 // References this type has to the given type
 func (structType *StructType) References(d *TypeName) bool {
+
 	for _, field := range structType.fields {
 		if field.FieldType().References(d) {
 			return true
@@ -148,13 +149,13 @@ func (structType *StructType) Equals(t Type) bool {
 // of the anonymous struct type. This is needed for controller-gen to work correctly:
 func (structType *StructType) CreateInternalDefinitions(name *TypeName, idFactory IdentifierFactory) (Type, []TypeDefiner) {
 	// an internal struct must always be named:
-	definedStruct, otherTypes := structType.CreateDefinitions(name, idFactory, false /* internal structs are never resources */)
+	definedStruct, otherTypes := structType.CreateDefinitions(name, idFactory)
 	return definedStruct.Name(), append(otherTypes, definedStruct)
 }
 
 // CreateDefinitions defines a named type for this struct and invokes CreateInternalDefinitions for each field type
 // to instantiate any definitions required by internal types.
-func (structType *StructType) CreateDefinitions(name *TypeName, idFactory IdentifierFactory, isResource bool) (TypeDefiner, []TypeDefiner) {
+func (structType *StructType) CreateDefinitions(name *TypeName, idFactory IdentifierFactory) (TypeDefiner, []TypeDefiner) {
 
 	var otherTypes []TypeDefiner
 	var newFields []*FieldDefinition
@@ -175,7 +176,7 @@ func (structType *StructType) CreateDefinitions(name *TypeName, idFactory Identi
 		newStructType.functions[functionName] = function
 	}
 
-	return NewStructDefinition(name, newStructType, isResource), otherTypes
+	return NewStructDefinition(name, newStructType), otherTypes
 }
 
 // WithField creates a new StructType with another field attached to it

--- a/hack/generator/pkg/astmodel/type.go
+++ b/hack/generator/pkg/astmodel/type.go
@@ -27,8 +27,6 @@ type Type interface {
 
 	// CreateDefinitions gives a name to the type and might generate some asssociated definitions as well (the second result)
 	// that also must be included in the output.
-	//
-	// [isResource is only relevant to struct types and identifies if they are a root resource for Kubebuilder]
 	CreateDefinitions(name *TypeName, idFactory IdentifierFactory) (TypeDefiner, []TypeDefiner)
 
 	// CreateInternalDefinitions creates definitions for nested types where needed (e.g. nested anonymous enums, structs),

--- a/hack/generator/pkg/astmodel/type.go
+++ b/hack/generator/pkg/astmodel/type.go
@@ -29,7 +29,7 @@ type Type interface {
 	// that also must be included in the output.
 	//
 	// [isResource is only relevant to struct types and identifies if they are a root resource for Kubebuilder]
-	CreateDefinitions(name *TypeName, idFactory IdentifierFactory, isResource bool) (TypeDefiner, []TypeDefiner)
+	CreateDefinitions(name *TypeName, idFactory IdentifierFactory) (TypeDefiner, []TypeDefiner)
 
 	// CreateInternalDefinitions creates definitions for nested types where needed (e.g. nested anonymous enums, structs),
 	// and returns the new, updated type to use in this type’s place.

--- a/hack/generator/pkg/astmodel/type_name.go
+++ b/hack/generator/pkg/astmodel/type_name.go
@@ -77,7 +77,7 @@ func (typeName *TypeName) CreateInternalDefinitions(_ *TypeName, _ IdentifierFac
 }
 
 // CreateDefinitions adds another name to this already-named type
-func (typeName *TypeName) CreateDefinitions(name *TypeName, _ IdentifierFactory, _ bool) (TypeDefiner, []TypeDefiner) {
+func (typeName *TypeName) CreateDefinitions(name *TypeName, _ IdentifierFactory) (TypeDefiner, []TypeDefiner) {
 	return NewSimpleTypeDefiner(name, typeName), nil
 }
 

--- a/hack/generator/pkg/codegen/code_generator.go
+++ b/hack/generator/pkg/codegen/code_generator.go
@@ -157,7 +157,9 @@ func (generator *CodeGenerator) MarkLatestResourceVersionsForStorage(
 
 				// mark as storage version if it's the latest version
 				isLatestVersion := thisPackagePath == latestPackagePath
-				resourceDef = resourceDef.WithIsStorageVersion(isLatestVersion)
+				if isLatestVersion {
+					resourceDef = resourceDef.MarkAsStorageVersion()
+				}
 
 				resultPkg.AddDefinition(resourceDef)
 			} else {

--- a/hack/generator/pkg/codegen/code_generator.go
+++ b/hack/generator/pkg/codegen/code_generator.go
@@ -140,10 +140,10 @@ func (generator *CodeGenerator) MarkLatestResourceVersionsForStorage(
 
 		resultPkg := astmodel.NewPackageDefinition(pkg.GroupName, pkg.PackageName, pkg.GeneratorVersion)
 		for _, def := range pkg.Definitions() {
-			// see if it is a resource (only struct definitions can be resources)
-			if structDef, ok := def.(*astmodel.StructDefinition); ok && structDef.IsResource() {
+			// see if it is a resource
+			if resourceDef, ok := def.(*astmodel.ResourceDefinition); ok {
 
-				unversionedName, err := getUnversionedName(structDef.TypeName)
+				unversionedName, err := getUnversionedName(resourceDef.Name())
 				if err != nil {
 					// should never happen as all resources have versioned names
 					return nil, err
@@ -152,14 +152,14 @@ func (generator *CodeGenerator) MarkLatestResourceVersionsForStorage(
 				allVersionsOfResource := resourceLookup[unversionedName]
 				latestVersionOfResource := allVersionsOfResource[len(allVersionsOfResource)-1]
 
-				thisPackagePath := structDef.Name().PackageReference.PackagePath()
+				thisPackagePath := resourceDef.Name().PackageReference.PackagePath()
 				latestPackagePath := latestVersionOfResource.Name().PackageReference.PackagePath()
 
 				// mark as storage version if it's the latest version
 				isLatestVersion := thisPackagePath == latestPackagePath
-				structDef = structDef.WithIsStorageVersion(isLatestVersion)
+				resourceDef = resourceDef.WithIsStorageVersion(isLatestVersion)
 
-				resultPkg.AddDefinition(structDef)
+				resultPkg.AddDefinition(resourceDef)
 			} else {
 				// otherwise simply add it
 				resultPkg.AddDefinition(def)
@@ -187,20 +187,20 @@ type unversionedName struct {
 }
 
 func groupResourcesByVersion(
-	pkgs []*astmodel.PackageDefinition) (map[unversionedName][]*astmodel.StructDefinition, error) {
+	pkgs []*astmodel.PackageDefinition) (map[unversionedName][]*astmodel.ResourceDefinition, error) {
 
-	result := make(map[unversionedName][]*astmodel.StructDefinition)
+	result := make(map[unversionedName][]*astmodel.ResourceDefinition)
 
 	for _, pkg := range pkgs {
 		for _, def := range pkg.Definitions() {
-			if structDef, ok := def.(*astmodel.StructDefinition); ok && structDef.IsResource() {
-				name, err := getUnversionedName(structDef.TypeName)
+			if resourceDef, ok := def.(*astmodel.ResourceDefinition); ok {
+				name, err := getUnversionedName(resourceDef.Name())
 				if err != nil {
 					// this should never happen as resources will all have versioned names
 					return nil, fmt.Errorf("Unable to extract unversioned name in groupResources: %w", err)
 				}
 
-				result[name] = append(result[name], structDef)
+				result[name] = append(result[name], resourceDef)
 			}
 		}
 	}
@@ -208,7 +208,7 @@ func groupResourcesByVersion(
 	// order each set of resources by package name (== by version as these are sortable dates)
 	for _, slice := range result {
 		sort.Slice(slice, func(i, j int) bool {
-			return slice[i].TypeName.PackageReference.PackageName() < slice[j].TypeName.PackageReference.PackageName()
+			return slice[i].Name().PackageReference.PackageName() < slice[j].Name().PackageReference.PackageName()
 		})
 	}
 

--- a/hack/generator/pkg/jsonast/jsonast.go
+++ b/hack/generator/pkg/jsonast/jsonast.go
@@ -468,8 +468,22 @@ func generateDefinitionsFor(
 		return nil, err
 	}
 
+	var definer astmodel.TypeDefiner
+	var otherDefs []astmodel.TypeDefiner
+
 	// Give the type a name:
-	definer, otherDefs := result.CreateDefinitions(typeName, scanner.idFactory, isResource)
+	if isResource {
+		if specType, ok := result.(*astmodel.StructType); ok {
+			definer, otherDefs = astmodel.CreateResourceDefinitions(typeName, specType, nil, scanner.idFactory)
+		} else {
+			klog.Warningf("expected a struct type for resource: %v", typeName)
+			// TODO: handle this better, only Kusto does it
+			// we can lookup the actual struct and then use that
+			definer, otherDefs = result.CreateDefinitions(typeName, scanner.idFactory)
+		}
+	} else {
+		definer, otherDefs = result.CreateDefinitions(typeName, scanner.idFactory)
+	}
 
 	description := "Generated from: " + url.String()
 	definer = definer.WithDescription(&description)


### PR DESCRIPTION
This removes the bad-feeling `isResource` parameter from `CreateDefinitions` and cleans up some checks in the package/file generation. It also encodes that only resources can have `isStorageVersion` set which wasn’t enforced by the types before. (I also like that it gets us further away from Go-AST-specific naming.)