### PR TITLE
Improve the IdentifierFactory to make it easy to deal with plurals

### DIFF
--- a/hack/generator/pkg/astmodel/identifier_factory.go
+++ b/hack/generator/pkg/astmodel/identifier_factory.go
@@ -228,5 +228,7 @@ func createWholeRenames() map[string]string {
 func createPartRenames() map[string]string {
 	return map[string]string{
 		"batchAccounts": "batchAccount",
+		"virtualMachineScaleSets": "virtualMachineScaleSet",
+		"virtualMachines": "virtualMachine",
 	}
 }

--- a/hack/generator/pkg/astmodel/identifier_factory_test.go
+++ b/hack/generator/pkg/astmodel/identifier_factory_test.go
@@ -33,6 +33,15 @@ func Test_CreateIdentifier_GivenName_ReturnsExpectedIdentifier(t *testing.T) {
 		{"XMLDocument", NotExported, "xmlDocument"},
 		{"this id has spaces", NotExported, "thisIdHasSpaces"},
 		{"this, id, has, spaces", NotExported, "thisIdHasSpaces"},
+		{"this 7 part id has 2 numbers", Exported, "This7PartIdHas2Numbers"},
+		// Underscores don't trip it up, not even multiple ones
+		{"foo_bar_baz", Exported, "FooBarBaz"},
+		{"__internal__", Exported, "Internal"},
+		// A single change can trigger in the midst of a longer_separated_identifier
+		{"batchAccounts_properties", Exported, "BatchAccountProperties"},
+		{"batchAccounts_certificates", NotExported, "batchAccountCertificates"},
+		// But only if it's in one piece
+		{"batch_accounts_properties", Exported, "BatchAccountsProperties"},
 	}
 
 	idfactory := NewIdentifierFactory()


### PR DESCRIPTION
Enhances the identifier factory with the ability to modify parts of an identifier when they appear separated by understores (`_`), allowing to rename, for example, `BatchAccounts` to `BatchAccount` throughout.

I tried a handful of other approaches, but they all over-triggered, so I went for a compromise that should allow us to get the naming we want without too many false positives.

Resolves #141

### ToDo
- [ ] Check for false positives

### Beyond Compare Screenshots

Filename changes (`master` on the left, this PR on the right):
![image](https://user-images.githubusercontent.com/1272094/85957865-0b82eb00-b9e5-11ea-9397-12d040b919a7.png)

Sample changes within files:
![image](https://user-images.githubusercontent.com/1272094/85957886-484ee200-b9e5-11ea-801d-f7a4a4b940b8.png)

![image](https://user-images.githubusercontent.com/1272094/85957916-9532b880-b9e5-11ea-9040-75f7b0d92a89.png)
