### PR TITLE
Use github.com/pkg/errors to get stack traces from generation errors

### DIFF
--- a/hack/generator/Makefile
+++ b/hack/generator/Makefile
@@ -21,6 +21,8 @@ manifests: $(CONTROLLER_GEN)
 .PHONY: gen-arm
 gen-arm: rm-apis build ; $(info $(M) running k8sinfra-gen gen…) @ ## Running gen
 	$(Q) ./bin/$(APP) gen azure-arm.yaml
+	# Run with verbosity 4 to see a stack trace for errors.
+	# $(Q) ./bin/$(APP) gen azure-arm.yaml -v 4
 
 	$(Q) $(CONTROLLER_GEN) object:headerFile=../boilerplate.go.txt paths="./..."
 

--- a/hack/generator/cmd/gen/gen.go
+++ b/hack/generator/cmd/gen/gen.go
@@ -40,7 +40,7 @@ func NewGenCommand() (*cobra.Command, error) {
 				klog.Errorf("Error during code generation:\n%v\n", err)
 				stackTrace := findDeepestTrace(err)
 				if stackTrace != nil {
-					klog.Errorf("%+v", stackTrace)
+					klog.V(4).Infof("%+v", stackTrace)
 				}
 				return err
 			}

--- a/hack/generator/cmd/gen/gen.go
+++ b/hack/generator/cmd/gen/gen.go
@@ -8,11 +8,13 @@ package gen
 import (
 	"context"
 
-	"github.com/Azure/k8s-infra/hack/generator/pkg/codegen"
-	"github.com/Azure/k8s-infra/hack/generator/pkg/xcobra"
+	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 	"k8s.io/klog/v2"
+
+	"github.com/Azure/k8s-infra/hack/generator/pkg/codegen"
+	"github.com/Azure/k8s-infra/hack/generator/pkg/xcobra"
 )
 
 // NewGenCommand creates a new cobra Command when invoked from the command line
@@ -36,6 +38,10 @@ func NewGenCommand() (*cobra.Command, error) {
 			err = cg.Generate(ctx)
 			if err != nil {
 				klog.Errorf("Error during code generation:\n%v\n", err)
+				stackTrace := findDeepestTrace(err)
+				if stackTrace != nil {
+					klog.Errorf("%+v", stackTrace)
+				}
 				return err
 			}
 
@@ -49,4 +55,27 @@ func NewGenCommand() (*cobra.Command, error) {
 	}
 
 	return cmd, nil
+}
+
+type stackTracer interface {
+	StackTrace() errors.StackTrace
+}
+
+// findDeepestTrace returns the stack trace from the furthest error
+// down the chain that has one. We can't just use errors.Cause(err)
+// here because the innermost error may not have been created by
+// pkg/errors (gasp).
+func findDeepestTrace(err error) errors.StackTrace {
+	if err == nil {
+		return nil
+	}
+	deeperTrace := findDeepestTrace(errors.Unwrap(err))
+	if deeperTrace != nil {
+		return deeperTrace
+	}
+	tracer, ok := err.(stackTracer)
+	if !ok {
+		return nil
+	}
+	return tracer.StackTrace()
 }

--- a/hack/generator/go.mod
+++ b/hack/generator/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/devigned/tab v0.1.1
 	github.com/onsi/gomega v1.8.1
 	github.com/pelletier/go-toml v1.6.0 // indirect
+	github.com/pkg/errors v0.9.1
 	github.com/sebdah/goldie/v2 v2.3.0
 	github.com/spf13/afero v1.2.2 // indirect
 	github.com/spf13/cast v1.3.1 // indirect

--- a/hack/generator/go.sum
+++ b/hack/generator/go.sum
@@ -128,6 +128,8 @@ github.com/pelletier/go-toml v1.6.0 h1:aetoXYr0Tv7xRU/V4B4IZJ2QcbtMUFoNb3ORp7TzI
 github.com/pelletier/go-toml v1.6.0/go.mod h1:5N711Q9dKgbdkxHL+MEfF31hpT7l0S0s/t2kKREewys=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
+github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
+github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/prometheus/client_golang v0.9.1/go.mod h1:7SWBe2y4D6OKWSNQJUaRYU/AaXPKyh/dDVn+NZz0KFw=

--- a/hack/generator/pkg/astmodel/code_generation_context.go
+++ b/hack/generator/pkg/astmodel/code_generation_context.go
@@ -5,7 +5,7 @@
 
 package astmodel
 
-import "fmt"
+import "github.com/pkg/errors"
 
 // CodeGenerationContext stores context about the location code-generation is occurring.
 // This is required because some things (such as specific field types) are impacted by the context
@@ -41,7 +41,7 @@ func (codeGenContext *CodeGenerationContext) PackageImports() map[PackageReferen
 func (codeGenContext *CodeGenerationContext) GetImportedPackageName(reference *PackageReference) (string, error) {
 	packageImport, ok := codeGenContext.packageImports[*reference]
 	if !ok {
-		return "", fmt.Errorf("package %s not imported", reference)
+		return "", errors.Errorf("package %s not imported", reference)
 	}
 
 	return packageImport.PackageName(), nil

--- a/hack/generator/pkg/astmodel/package_definition.go
+++ b/hack/generator/pkg/astmodel/package_definition.go
@@ -73,7 +73,7 @@ func emitFiles(filesToGenerate map[string][]TypeDefiner, outputDir string) error
 		genFile := NewFileDefinition(&defs[0].Name().PackageReference, defs...)
 		outputFile := filepath.Join(outputDir, fullFileName)
 
-		klog.V(5).Infof("Writing '%s'\n", outputFile)
+		klog.V(5).Infof("Writing %q\n", outputFile)
 
 		err := genFile.SaveToFile(outputFile)
 		if err != nil {

--- a/hack/generator/pkg/astmodel/package_definition.go
+++ b/hack/generator/pkg/astmodel/package_definition.go
@@ -7,11 +7,11 @@ package astmodel
 
 import (
 	"bytes"
-	"fmt"
 	"io/ioutil"
 	"path/filepath"
 	"text/template"
 
+	"github.com/pkg/errors"
 	"k8s.io/klog/v2"
 )
 
@@ -77,7 +77,7 @@ func emitFiles(filesToGenerate map[string][]TypeDefiner, outputDir string) error
 
 		err := genFile.SaveToFile(outputFile)
 		if err != nil {
-			return fmt.Errorf("error saving definitions to file '%v'(%w)", outputFile, err)
+			return errors.Wrapf(err, "error saving definitions to file %q", outputFile)
 		}
 	}
 
@@ -250,7 +250,7 @@ func emitGroupVersionFile(pkgDef *PackageDefinition, outputDir string) error {
 
 	err = ioutil.WriteFile(gvFile, buf.Bytes(), 0700)
 	if err != nil {
-		return fmt.Errorf("error writing group version file '%v'(%w)", gvFile, err)
+		return errors.Wrapf(err, "error writing group version file %q", gvFile)
 	}
 
 	return nil

--- a/hack/generator/pkg/astmodel/package_reference.go
+++ b/hack/generator/pkg/astmodel/package_reference.go
@@ -8,6 +8,8 @@ package astmodel
 import (
 	"fmt"
 	"strings"
+
+	"github.com/pkg/errors"
 )
 
 const (
@@ -39,7 +41,7 @@ func (pr *PackageReference) IsLocalPackage() bool {
 
 func (pr *PackageReference) stripLocalPackagePrefix() (string, error) {
 	if !pr.IsLocalPackage() {
-		return "", fmt.Errorf("cannot strip local package prefix from non-local package %v", pr.packagePath)
+		return "", errors.Errorf("cannot strip local package prefix from non-local package %v", pr.packagePath)
 	}
 
 	return strings.Replace(pr.packagePath, localPathPrefix, "", -1), nil

--- a/hack/generator/pkg/astmodel/resource.go
+++ b/hack/generator/pkg/astmodel/resource.go
@@ -9,6 +9,8 @@ import (
 	"fmt"
 	"go/ast"
 	"go/token"
+
+	"github.com/pkg/errors"
 )
 
 // CreateResourceDefinitions creates definitions for a resource
@@ -92,7 +94,7 @@ func (definition *ResourceDefinition) AsDeclarations(codeGenerationContext *Code
 
 	packageName, err := codeGenerationContext.GetImportedPackageName(MetaV1PackageReference)
 	if err != nil {
-		panic(fmt.Errorf("resource definition for %s failed to import package: %w", definition.typeName, err))
+		panic(errors.Wrapf(err, "resource definition for %s failed to import package", definition.typeName))
 	}
 	typeMetaField := defineField("", fmt.Sprintf("%s.TypeMeta", packageName), "`json:\",inline\"`")
 	objectMetaField := defineField("", fmt.Sprintf("%s.ObjectMeta", packageName), "`json:\"metadata,omitempty\"`")

--- a/hack/generator/pkg/codegen/code_generator.go
+++ b/hack/generator/pkg/codegen/code_generator.go
@@ -8,7 +8,6 @@ package codegen
 import (
 	"bufio"
 	"context"
-	"fmt"
 	"io"
 	"io/ioutil"
 	"net/http"
@@ -18,16 +17,17 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/Azure/k8s-infra/hack/generator/pkg/astmodel"
-	"github.com/Azure/k8s-infra/hack/generator/pkg/config"
-	"github.com/Azure/k8s-infra/hack/generator/pkg/jsonast"
 	"github.com/bmatcuk/doublestar"
+	"github.com/pkg/errors"
 	"github.com/xeipuuv/gojsonreference"
 	"github.com/xeipuuv/gojsonschema"
 	"gopkg.in/yaml.v3"
-
 	kerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/klog/v2"
+
+	"github.com/Azure/k8s-infra/hack/generator/pkg/astmodel"
+	"github.com/Azure/k8s-infra/hack/generator/pkg/config"
+	"github.com/Azure/k8s-infra/hack/generator/pkg/jsonast"
 )
 
 // CodeGenerator is a generator of code
@@ -39,12 +39,12 @@ type CodeGenerator struct {
 func NewCodeGenerator(configurationFile string) (*CodeGenerator, error) {
 	config, err := loadConfiguration(configurationFile)
 	if err != nil {
-		return nil, fmt.Errorf("failed to load configuration file '%v' (%w)", configurationFile, err)
+		return nil, errors.Wrapf(err, "failed to load configuration file '%v'", configurationFile)
 	}
 
 	err = config.Initialize()
 	if err != nil {
-		return nil, fmt.Errorf("configuration loaded from '%v' is invalid (%w)", configurationFile, err)
+		return nil, errors.Wrapf(err, "configuration loaded from '%v' is invalid", configurationFile)
 	}
 
 	result := &CodeGenerator{configuration: config}
@@ -58,13 +58,13 @@ func (generator *CodeGenerator) Generate(ctx context.Context) error {
 	klog.V(0).Infof("Loading JSON schema %v", generator.configuration.SchemaURL)
 	schema, err := loadSchema(ctx, generator.configuration.SchemaURL)
 	if err != nil {
-		return fmt.Errorf("error loading schema from '%v' (%w)", generator.configuration.SchemaURL, err)
+		return errors.Wrapf(err, "error loading schema from '%v'", generator.configuration.SchemaURL)
 	}
 
 	klog.V(0).Infof("Cleaning output folder '%v'", generator.configuration.OutputPath)
 	err = deleteGeneratedCodeFromFolder(ctx, generator.configuration.OutputPath)
 	if err != nil {
-		return fmt.Errorf("error cleaning output folder '%v' (%w)", generator.configuration.OutputPath, err)
+		return errors.Wrapf(err, "error cleaning output folder '%v'", generator.configuration.OutputPath)
 	}
 
 	scanner := jsonast.NewSchemaScanner(astmodel.NewIdentifierFactory(), generator.configuration)
@@ -73,22 +73,22 @@ func (generator *CodeGenerator) Generate(ctx context.Context) error {
 
 	defs, err := scanner.GenerateDefinitions(ctx, schema.Root())
 	if err != nil {
-		return fmt.Errorf("failed to walk JSON schema (%w)", err)
+		return errors.Wrapf(err, "failed to walk JSON schema")
 	}
 
 	defs, err = generator.FilterDefinitions(defs)
 	if err != nil {
-		return fmt.Errorf("failed to filter generated definitions (%w)", err)
+		return errors.Wrapf(err, "failed to filter generated definitions")
 	}
 
 	packages, err := generator.CreatePackagesForDefinitions(defs)
 	if err != nil {
-		return fmt.Errorf("failed to assign generated definitions to packages (%w)", err)
+		return errors.Wrapf(err, "failed to assign generated definitions to packages")
 	}
 
 	packages, err = generator.MarkLatestResourceVersionsForStorage(packages)
 	if err != nil {
-		return fmt.Errorf("unable to mark latest resource versions for as storage versions (%w)", err)
+		return errors.Wrapf(err, "unable to mark latest resource versions for as storage versions")
 	}
 
 	fileCount := 0
@@ -113,7 +113,7 @@ func (generator *CodeGenerator) Generate(ctx context.Context) error {
 
 		count, err := pkg.EmitDefinitions(outputDir)
 		if err != nil {
-			return fmt.Errorf("error writing definitions into '%v' (%w)", outputDir, err)
+			return errors.Wrapf(err, "error writing definitions into %q", outputDir)
 		}
 
 		fileCount += count
@@ -199,7 +199,7 @@ func groupResourcesByVersion(
 				name, err := getUnversionedName(resourceDef.Name())
 				if err != nil {
 					// this should never happen as resources will all have versioned names
-					return nil, fmt.Errorf("Unable to extract unversioned name in groupResources: %w", err)
+					return nil, errors.Wrapf(err, "Unable to extract unversioned name in groupResources")
 				}
 
 				result[name] = append(result[name], resourceDef)
@@ -357,7 +357,7 @@ func loadSchema(ctx context.Context, source string) (*gojsonschema.Schema, error
 
 	schema, err := sl.Compile(loader)
 	if err != nil {
-		return nil, fmt.Errorf("error loading schema from '%v' (%w)", source, err)
+		return nil, errors.Wrapf(err, "error loading schema from %q", source)
 	}
 
 	return schema, nil
@@ -369,7 +369,7 @@ func deleteGeneratedCodeFromFolder(ctx context.Context, outputFolder string) err
 
 	files, err := doublestar.Glob(globPattern)
 	if err != nil {
-		return fmt.Errorf("error globbing files with pattern '%s' (%w)", globPattern, err)
+		return errors.Wrapf(err, "error globbing files with pattern %q", globPattern)
 	}
 
 	var errs []error
@@ -382,13 +382,13 @@ func deleteGeneratedCodeFromFolder(ctx context.Context, outputFolder string) err
 		isGenerated, err := isFileGenerated(file)
 
 		if err != nil {
-			errs = append(errs, fmt.Errorf("error determining if file was generated (%w)", err))
+			errs = append(errs, errors.Wrapf(err, "error determining if file was generated"))
 		}
 
 		if isGenerated {
 			err := os.Remove(file)
 			if err != nil {
-				errs = append(errs, fmt.Errorf("error removing file '%v' (%w)", file, err))
+				errs = append(errs, errors.Wrapf(err, "error removing file %q", file))
 			}
 		}
 	}
@@ -479,14 +479,14 @@ func deleteEmptyDirectories(ctx context.Context, path string) error {
 
 		files, err := ioutil.ReadDir(dir)
 		if err != nil {
-			errs = append(errs, fmt.Errorf("error reading directory '%v' (%w)", dir, err))
+			errs = append(errs, errors.Wrapf(err, "error reading directory %q", dir))
 		}
 
 		if len(files) == 0 {
 			// Directory is empty now, we can delete it
 			err := os.Remove(dir)
 			if err != nil {
-				errs = append(errs, fmt.Errorf("error removing dir '%v' (%w)", dir, err))
+				errs = append(errs, errors.Wrapf(err, "error removing dir %q", dir))
 			}
 		}
 	}

--- a/hack/generator/pkg/codegen/code_generator.go
+++ b/hack/generator/pkg/codegen/code_generator.go
@@ -39,12 +39,12 @@ type CodeGenerator struct {
 func NewCodeGenerator(configurationFile string) (*CodeGenerator, error) {
 	config, err := loadConfiguration(configurationFile)
 	if err != nil {
-		return nil, errors.Wrapf(err, "failed to load configuration file '%v'", configurationFile)
+		return nil, errors.Wrapf(err, "failed to load configuration file %q", configurationFile)
 	}
 
 	err = config.Initialize()
 	if err != nil {
-		return nil, errors.Wrapf(err, "configuration loaded from '%v' is invalid", configurationFile)
+		return nil, errors.Wrapf(err, "configuration loaded from %q is invalid", configurationFile)
 	}
 
 	result := &CodeGenerator{configuration: config}
@@ -58,13 +58,13 @@ func (generator *CodeGenerator) Generate(ctx context.Context) error {
 	klog.V(0).Infof("Loading JSON schema %v", generator.configuration.SchemaURL)
 	schema, err := loadSchema(ctx, generator.configuration.SchemaURL)
 	if err != nil {
-		return errors.Wrapf(err, "error loading schema from '%v'", generator.configuration.SchemaURL)
+		return errors.Wrapf(err, "error loading schema from %q", generator.configuration.SchemaURL)
 	}
 
-	klog.V(0).Infof("Cleaning output folder '%v'", generator.configuration.OutputPath)
+	klog.V(0).Infof("Cleaning output folder %q", generator.configuration.OutputPath)
 	err = deleteGeneratedCodeFromFolder(ctx, generator.configuration.OutputPath)
 	if err != nil {
-		return errors.Wrapf(err, "error cleaning output folder '%v'", generator.configuration.OutputPath)
+		return errors.Wrapf(err, "error cleaning output folder %q", generator.configuration.OutputPath)
 	}
 
 	scanner := jsonast.NewSchemaScanner(astmodel.NewIdentifierFactory(), generator.configuration)
@@ -104,10 +104,10 @@ func (generator *CodeGenerator) Generate(ctx context.Context) error {
 		// create directory if not already there
 		outputDir := filepath.Join(generator.configuration.OutputPath, pkg.GroupName, pkg.PackageName)
 		if _, err := os.Stat(outputDir); os.IsNotExist(err) {
-			klog.V(5).Infof("Creating directory '%s'\n", outputDir)
+			klog.V(5).Infof("Creating directory %q\n", outputDir)
 			err = os.MkdirAll(outputDir, 0700)
 			if err != nil {
-				klog.Fatalf("Unable to create directory '%s'", outputDir)
+				klog.Fatalf("Unable to create directory %q", outputDir)
 			}
 		}
 

--- a/hack/generator/pkg/config/configuration.go
+++ b/hack/generator/pkg/config/configuration.go
@@ -6,11 +6,10 @@
 package config
 
 import (
-	"errors"
-	"fmt"
+	"github.com/pkg/errors"
+	kerrors "k8s.io/apimachinery/pkg/util/errors"
 
 	"github.com/Azure/k8s-infra/hack/generator/pkg/astmodel"
-	kerrors "k8s.io/apimachinery/pkg/util/errors"
 )
 
 // Configuration is used to control which types get generated
@@ -109,7 +108,7 @@ func (config *Configuration) ShouldExport(typeName *astmodel.TypeName) (result S
 			case ExportFilterInclude:
 				return Export, f.Because
 			default:
-				panic(fmt.Errorf("unknown exportfilter directive: %s", f.Action))
+				panic(errors.Errorf("unknown exportfilter directive: %s", f.Action))
 			}
 		}
 	}
@@ -128,7 +127,7 @@ func (config *Configuration) ShouldPrune(typeName *astmodel.TypeName) (result Sh
 			case TypeFilterInclude:
 				return Include, f.Because
 			default:
-				panic(fmt.Errorf("unknown typefilter directive: %s", f.Action))
+				panic(errors.Errorf("unknown typefilter directive: %s", f.Action))
 			}
 		}
 	}

--- a/hack/generator/pkg/config/type_transformer.go
+++ b/hack/generator/pkg/config/type_transformer.go
@@ -7,6 +7,9 @@ package config
 
 import (
 	"fmt"
+
+	"github.com/pkg/errors"
+
 	"github.com/Azure/k8s-infra/hack/generator/pkg/astmodel"
 )
 
@@ -32,7 +35,7 @@ func (transformer *TypeTransformer) Initialize() error {
 	}
 
 	if transformer.Target.Name == "" {
-		return fmt.Errorf(
+		return errors.Errorf(
 			"type transformer for group: %s, version: %s, name: %s is missing type name to transform to",
 			transformer.Group,
 			transformer.Version,
@@ -61,7 +64,7 @@ func (transformer *TypeTransformer) initializePrimitiveTypeTarget() error {
 	case "string":
 		transformer.targetType = astmodel.StringType
 	default:
-		return fmt.Errorf(
+		return errors.Errorf(
 			"type transformer for group: %s, version: %s, name: %s has unknown"+
 				"primtive type transformation target: %s",
 			transformer.Group,

--- a/hack/generator/pkg/jsonast/jsonast_test.go
+++ b/hack/generator/pkg/jsonast/jsonast_test.go
@@ -8,17 +8,17 @@ package jsonast
 import (
 	"bytes"
 	"context"
-	"fmt"
-	"github.com/Azure/k8s-infra/hack/generator/pkg/config"
 	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 
-	"github.com/Azure/k8s-infra/hack/generator/pkg/astmodel"
 	"github.com/sebdah/goldie/v2"
 	"github.com/xeipuuv/gojsonschema"
+
+	"github.com/Azure/k8s-infra/hack/generator/pkg/astmodel"
+	"github.com/Azure/k8s-infra/hack/generator/pkg/config"
 )
 
 func runGoldenTest(t *testing.T, path string) {
@@ -27,14 +27,14 @@ func runGoldenTest(t *testing.T, path string) {
 	g := goldie.New(t)
 	inputFile, err := ioutil.ReadFile(path)
 	if err != nil {
-		t.Fatal(fmt.Errorf("cannot read golden test input file: %w", err))
+		t.Fatalf("cannot read golden test input file: %v", err)
 	}
 
 	loader := gojsonschema.NewSchemaLoader()
 	schema, err := loader.Compile(gojsonschema.NewBytesLoader(inputFile))
 
 	if err != nil {
-		t.Fatal(fmt.Errorf("could not compile input: %w", err))
+		t.Fatalf("could not compile input: %v", err)
 	}
 
 	config := config.NewConfiguration()
@@ -42,7 +42,7 @@ func runGoldenTest(t *testing.T, path string) {
 	scanner := NewSchemaScanner(astmodel.NewIdentifierFactory(), config)
 	defs, err := scanner.GenerateDefinitions(context.TODO(), schema.Root())
 	if err != nil {
-		t.Fatal(fmt.Errorf("could not produce nodes from scanner: %w", err))
+		t.Fatalf("could not produce nodes from scanner: %v", err)
 	}
 
 	// put all definitions in one file, regardless
@@ -52,7 +52,7 @@ func runGoldenTest(t *testing.T, path string) {
 	buf := &bytes.Buffer{}
 	err = fileDef.SaveToWriter(path, buf)
 	if err != nil {
-		t.Fatal(fmt.Errorf("could not generate file: %w", err))
+		t.Fatalf("could not generate file: %v", err)
 	}
 
 	g.Assert(t, testName, buf.Bytes())
@@ -79,7 +79,7 @@ func TestGolden(t *testing.T) {
 	})
 
 	if err != nil {
-		t.Fatal(fmt.Errorf("Error enumerating files: %w", err))
+		t.Fatalf("Error enumerating files: %v", err)
 	}
 
 	// run all tests


### PR DESCRIPTION
Replaces all uses of `fmt.Errorf` with either `errors.New`/`errors.Errorf`, or `errors.Wrapf` where an existing error was being wrapped with %w. This means that any errors originating or wrapped in our code will be annotated with a stack trace that can be included when the error is logged at the top level, which will make it simpler to track down problems.

I checked for but didn't find any uses of `errors.Is` or `errors.As` to update to use `pkg/errors` instead.

As a driveby I also replaced uses of `'%s'` or `'%v'` with `%q`.