### PR TITLE
Use singular names for resources

### DIFF
--- a/hack/generator/pkg/astmodel/type_name.go
+++ b/hack/generator/pkg/astmodel/type_name.go
@@ -7,6 +7,7 @@ package astmodel
 
 import (
 	"fmt"
+	"github.com/jinzhu/inflection"
 	"go/ast"
 )
 
@@ -85,6 +86,10 @@ func (typeName *TypeName) CreateDefinitions(name *TypeName, _ IdentifierFactory)
 // String returns the string representation of the type name
 func (typeName *TypeName) String() string {
 	return fmt.Sprintf("%s/%s", typeName.PackageReference, typeName.name)
+}
+
+func (typeName *TypeName) Singular() *TypeName {
+	return NewTypeName(typeName.PackageReference, inflection.Singular(typeName.name))
 }
 
 // Ensure we implement Stringer

--- a/hack/generator/pkg/astmodel/type_name.go
+++ b/hack/generator/pkg/astmodel/type_name.go
@@ -7,7 +7,7 @@ package astmodel
 
 import (
 	"fmt"
-	"github.com/jinzhu/inflection"
+	"github.com/gobuffalo/flect"
 	"go/ast"
 )
 
@@ -89,7 +89,7 @@ func (typeName *TypeName) String() string {
 }
 
 func (typeName *TypeName) Singular() *TypeName {
-	return NewTypeName(typeName.PackageReference, inflection.Singular(typeName.name))
+	return NewTypeName(typeName.PackageReference, flect.Singularize(typeName.name))
 }
 
 // Ensure we implement Stringer

--- a/hack/generator/pkg/jsonast/jsonast.go
+++ b/hack/generator/pkg/jsonast/jsonast.go
@@ -467,6 +467,10 @@ func generateDefinitionsFor(
 		return nil, err
 	}
 
+	if isResource {
+		typeName = typeName.Singular()
+	}
+
 	// see if we already generated something for this ref
 	if _, ok := scanner.findTypeDefinition(typeName); ok {
 		return typeName, nil
@@ -488,8 +492,7 @@ func generateDefinitionsFor(
 	// Give the type a name:
 	if isResource {
 		if specType, ok := result.(*astmodel.StructType); ok {
-			resourceName := typeName.Singular()
-			definer, otherDefs = astmodel.CreateResourceDefinitions(resourceName, specType, nil, scanner.idFactory)
+			definer, otherDefs = astmodel.CreateResourceDefinitions(typeName, specType, nil, scanner.idFactory)
 		} else {
 			klog.Warningf("expected a struct type for resource: %v", typeName)
 			// TODO: handle this better, only Kusto does it
@@ -504,7 +507,6 @@ func generateDefinitionsFor(
 	definer = definer.WithDescription(&description)
 
 	// register all definitions
-	scanner.removeTypeDefinition(typeName) // In case we used a singular name for the actual type
 	scanner.addTypeDefinition(definer)
 	for _, otherDef := range otherDefs {
 		scanner.addTypeDefinition(otherDef)


### PR DESCRIPTION
Uses the library [*inflection*](https://github.com/jinzhu/inflection) to ensure that the names of resources are given in singular form (as suits types) instead of plural forms (as used by ARM).

| Old Name | New Name |
| -- | -- |
| Accounts | Account |
| BatchAccounts | BatchAccount |
| BatchAccountsCertificates | BatchAccountsCertificate |
| VirtualMachineScaleSets | VirtualMachineScaleSet |
| Vaults | Vault |
