### PR TITLE
Fix a bug in the type ranking algorithm 

### DIFF
--- a/hack/generator/pkg/astmodel/file_definition.go
+++ b/hack/generator/pkg/astmodel/file_definition.go
@@ -112,7 +112,7 @@ func assignRanks(definers []TypeDefiner, ranks map[TypeName]int) []TypeDefiner {
 	// Assign ranks
 	for _, d := range assignable {
 		rank := ranks[*d.Name()]
-		for ref := range d.Type().References() {
+		for ref := range d.References() {
 			if _, ok := ranks[ref]; !ok {
 				// Never overwrite an existing rank
 				ranks[ref] = rank + 1

--- a/hack/generator/pkg/astmodel/file_definition.go
+++ b/hack/generator/pkg/astmodel/file_definition.go
@@ -78,7 +78,7 @@ func calcRanks(definitions []TypeDefiner) map[TypeName]int {
 	for len(queue) > 0 {
 		queue = assignRanks(queue, ranks)
 		if len(queue) == lastLength {
-			// No progress made - give everything a fallback rank
+			// No progress made - give everything remaining a fallback rank
 			for _, d := range queue {
 				ranks[*d.Name()] = 10000
 			}
@@ -112,8 +112,11 @@ func assignRanks(definers []TypeDefiner, ranks map[TypeName]int) []TypeDefiner {
 	// Assign ranks
 	for _, d := range assignable {
 		rank := ranks[*d.Name()]
-		for ref := range d.References() {
-			ranks[ref] = rank + 1
+		for ref := range d.Type().References() {
+			if _, ok := ranks[ref]; !ok {
+				// Never overwrite an existing rank
+				ranks[ref] = rank + 1
+			}
 		}
 	}
 

--- a/hack/generator/pkg/astmodel/file_definition_test.go
+++ b/hack/generator/pkg/astmodel/file_definition_test.go
@@ -20,11 +20,11 @@ func Test_NewFileDefinition_GivenValues_InitializesFields(t *testing.T) {
 
 	person := NewTestStruct(
 		"Person",
-		NewStringFieldDefinition("fullName"),
-		NewStringFieldDefinition("knownAs"),
-		NewStringFieldDefinition("familyName"),
+		NewStringPropertyDefinition("fullName"),
+		NewStringPropertyDefinition("knownAs"),
+		NewStringPropertyDefinition("familyName"),
 	)
-	file := NewFileDefinition(&person.Name().PackageReference, []TypeDefiner{&person}, nil)
+	file := NewFileDefinition(&person.Name().PackageReference, &person, nil)
 
 	g.Expect(*file.packageReference).To(Equal(person.Name().PackageReference))
 	g.Expect(file.definitions).To(HaveLen(1))
@@ -54,13 +54,13 @@ func Test_CalcRanks_GivenLinearDependencies_AssignsRanksInOrder(t *testing.T) {
 	g := NewGomegaWithT(t)
 
 	rank3 := NewTestStruct("d")
-	referenceToRank3 := NewFieldDefinition("f3", "f3", rank3.Name())
+	referenceToRank3 := NewPropertyDefinition("f3", "f3", rank3.Name())
 
 	rank2 := NewTestStruct("c", referenceToRank3)
-	referenceToRank2 := NewFieldDefinition("f2", "f2", rank2.Name())
+	referenceToRank2 := NewPropertyDefinition("f2", "f2", rank2.Name())
 
 	rank1 := NewTestStruct("b", referenceToRank2)
-	referenceToRank1 := NewFieldDefinition("f1", "f1", rank1.Name())
+	referenceToRank1 := NewPropertyDefinition("f1", "f1", rank1.Name())
 
 	rank0 := NewTestStruct("a", referenceToRank1)
 
@@ -76,13 +76,13 @@ func Test_CalcRanks_GivenDiamondDependencies_AssignRanksInOrder(t *testing.T) {
 	g := NewGomegaWithT(t)
 
 	bottom := NewTestStruct("bottom")
-	referenceToBottom := NewFieldDefinition("b", "b", bottom.Name())
+	referenceToBottom := NewPropertyDefinition("b", "b", bottom.Name())
 
 	left := NewTestStruct("l", referenceToBottom)
-	referenceToLeft := NewFieldDefinition("l", "l", left.Name())
+	referenceToLeft := NewPropertyDefinition("l", "l", left.Name())
 
 	right := NewTestStruct("r", referenceToBottom)
-	referenceToRight := NewFieldDefinition("r", "r", right.Name())
+	referenceToRight := NewPropertyDefinition("r", "r", right.Name())
 
 	top := NewTestStruct("a", referenceToLeft, referenceToRight)
 
@@ -98,13 +98,13 @@ func Test_CalcRanks_GivenDiamondWithBar_AssignRanksInOrder(t *testing.T) {
 	g := NewGomegaWithT(t)
 
 	bottom := NewTestStruct("bottom")
-	referenceToBottom := NewFieldDefinition("b", "b", bottom.Name())
+	referenceToBottom := NewPropertyDefinition("b", "b", bottom.Name())
 
 	right := NewTestStruct("r", referenceToBottom)
-	referenceToRight := NewFieldDefinition("r", "r", right.Name())
+	referenceToRight := NewPropertyDefinition("r", "r", right.Name())
 
 	left := NewTestStruct("l", referenceToBottom, referenceToRight)
-	referenceToLeft := NewFieldDefinition("l", "l", left.Name())
+	referenceToLeft := NewPropertyDefinition("l", "l", left.Name())
 
 	top := NewTestStruct("a", referenceToLeft, referenceToRight)
 
@@ -121,13 +121,13 @@ func Test_CalcRanks_GivenDiamondWithReverseBar_AssignRanksInOrder(t *testing.T) 
 
 	bottom := NewTestStruct("bottom")
 
-	referenceToBottom := NewFieldDefinition("b", "b", bottom.Name())
+	referenceToBottom := NewPropertyDefinition("b", "b", bottom.Name())
 	left := NewTestStruct("l", referenceToBottom)
 
-	referenceToLeft := NewFieldDefinition("l", "l", left.Name())
+	referenceToLeft := NewPropertyDefinition("l", "l", left.Name())
 	right := NewTestStruct("r", referenceToBottom, referenceToLeft)
 
-	referenceToRight := NewFieldDefinition("r", "r", right.Name())
+	referenceToRight := NewPropertyDefinition("r", "r", right.Name())
 	top := NewTestStruct("a", referenceToLeft, referenceToRight)
 
 	ranks := calcRanks([]TypeDefiner{&top, &left, &right, &bottom})
@@ -142,14 +142,13 @@ func Test_CalcRanks_GivenDiamondWithReverseBar_AssignRanksInOrder(t *testing.T) 
  * Supporting methods
  */
 
-func NewTestStruct(name string, fields ...*FieldDefinition) StructDefinition {
+func NewTestStruct(name string, fields ...*PropertyDefinition) StructDefinition {
 	ref := NewTypeName(*NewLocalPackageReference("group", "2020-01-01"), name)
-	definition := NewStructDefinition(ref, NewStructType().WithFields(fields...))
+	definition := NewStructDefinition(ref, NewStructType().WithProperties(fields...))
 
 	return *definition
 }
 
-func NewStringFieldDefinition(name string) *FieldDefinition {
-	return NewFieldDefinition(FieldName(name), name, StringType)
+func NewStringPropertyDefinition(name string) *PropertyDefinition {
+	return NewPropertyDefinition(PropertyName(name), name, StringType)
 }
-

--- a/hack/generator/pkg/astmodel/file_definition_test.go
+++ b/hack/generator/pkg/astmodel/file_definition_test.go
@@ -24,7 +24,7 @@ func Test_NewFileDefinition_GivenValues_InitializesFields(t *testing.T) {
 		NewStringPropertyDefinition("knownAs"),
 		NewStringPropertyDefinition("familyName"),
 	)
-	file := NewFileDefinition(&person.Name().PackageReference, &person, nil)
+	file := NewFileDefinition(&person.Name().PackageReference, &person)
 
 	g.Expect(*file.packageReference).To(Equal(person.Name().PackageReference))
 	g.Expect(file.definitions).To(HaveLen(1))

--- a/hack/generator/pkg/astmodel/file_definition_test.go
+++ b/hack/generator/pkg/astmodel/file_definition_test.go
@@ -37,6 +37,12 @@ func Test_NewFileDefinition_GivenValues_InitializesFields(t *testing.T) {
 func Test_CalcRanks_GivenMultipleRoots_AssignsRankZeroToAll(t *testing.T) {
 	g := NewGomegaWithT(t)
 
+	// +---------+   +---------+   +---------+   +---------+
+	// |         |   |         |   |         |   |         |
+	// |  root1  |   |  root2  |   |  root3  |   |  root4  |
+	// |         |   |         |   |         |   |         |
+	// +---------+   +---------+   +---------+   +---------+
+
 	root1 := NewTestStruct("r1")
 	root2 := NewTestStruct("b")
 	root3 := NewTestStruct("c")
@@ -52,6 +58,36 @@ func Test_CalcRanks_GivenMultipleRoots_AssignsRankZeroToAll(t *testing.T) {
 
 func Test_CalcRanks_GivenLinearDependencies_AssignsRanksInOrder(t *testing.T) {
 	g := NewGomegaWithT(t)
+
+	// +---------+
+	// |         |
+	// |  rank0  |
+	// |         |
+	// +---+-----+
+	//     |
+	//     |
+	//     v
+	// +---+-----+
+	// |         |
+	// |  rank1  |
+	// |         |
+	// +---+-----+
+	//     |
+	//     |
+	//     v
+	// +---+-----+
+	// |         |
+	// |  rank2  |
+	// |         |
+	// +---+-----+
+	//     |
+	//     |
+	//     v
+	// +---+-----+
+	// |         |
+	// |  rank3  |
+	// |         |
+	// +---------+
 
 	rank3 := NewTestStruct("d")
 	referenceToRank3 := NewPropertyDefinition("f3", "f3", rank3.Name())
@@ -75,6 +111,28 @@ func Test_CalcRanks_GivenLinearDependencies_AssignsRanksInOrder(t *testing.T) {
 func Test_CalcRanks_GivenDiamondDependencies_AssignRanksInOrder(t *testing.T) {
 	g := NewGomegaWithT(t)
 
+	//         +---------+
+	//         |         |
+	//         |   top   |
+	//         |         |
+	//         ++-------++
+	//          |       |
+	//          |       |
+	//          v       v
+	// +--------++     ++--------+
+	// |         |     |         |
+	// |  left   |     |  right  |
+	// |         |     |         |
+	// +--------++     ++--------+
+	//          |       |
+	//          |       |
+	//          v       v
+	//         ++-------++
+	//         |         |
+	//         | bottom  |
+	//         |         |
+	//         +---------+
+
 	bottom := NewTestStruct("bottom")
 	referenceToBottom := NewPropertyDefinition("b", "b", bottom.Name())
 
@@ -97,6 +155,28 @@ func Test_CalcRanks_GivenDiamondDependencies_AssignRanksInOrder(t *testing.T) {
 func Test_CalcRanks_GivenDiamondWithBar_AssignRanksInOrder(t *testing.T) {
 	g := NewGomegaWithT(t)
 
+	//         +---------+
+	//         |         |
+	//         |   top   |
+	//         |         |
+	//         ++-------++
+	//          |       |
+	//          |       |
+	//          v       v
+	// +--------++     ++--------+
+	// |         |     |         |
+	// |  left   +---->+  right  |
+	// |         |     |         |
+	// +--------++     ++--------+
+	//          |       |
+	//          |       |
+	//          v       v
+	//         ++-------++
+	//         |         |
+	//         | bottom  |
+	//         |         |
+	//         +---------+
+
 	bottom := NewTestStruct("bottom")
 	referenceToBottom := NewPropertyDefinition("b", "b", bottom.Name())
 
@@ -118,6 +198,28 @@ func Test_CalcRanks_GivenDiamondWithBar_AssignRanksInOrder(t *testing.T) {
 
 func Test_CalcRanks_GivenDiamondWithReverseBar_AssignRanksInOrder(t *testing.T) {
 	g := NewGomegaWithT(t)
+
+	//         +---------+
+	//         |         |
+	//         |   top   |
+	//         |         |
+	//         ++-------++
+	//          |       |
+	//          |       |
+	//          v       v
+	// +--------++     ++--------+
+	// |         |     |         |
+	// |  left   +<----+  right  |
+	// |         |     |         |
+	// +--------++     ++--------+
+	//          |       |
+	//          |       |
+	//          v       v
+	//         ++-------++
+	//         |         |
+	//         | bottom  |
+	//         |         |
+	//         +---------+
 
 	bottom := NewTestStruct("bottom")
 

--- a/hack/generator/pkg/astmodel/file_definition_test.go
+++ b/hack/generator/pkg/astmodel/file_definition_test.go
@@ -11,24 +11,145 @@ import (
 	. "github.com/onsi/gomega"
 )
 
+/*
+ * NewFileDefinition tests
+ */
+
 func Test_NewFileDefinition_GivenValues_InitializesFields(t *testing.T) {
 	g := NewGomegaWithT(t)
 
-	person := NewTestStruct("Person", "fullName", "knownAs", "familyName")
-	file := NewFileDefinition(&person.Name().PackageReference, &person)
+	person := NewTestStruct(
+		"Person",
+		NewStringFieldDefinition("fullName"),
+		NewStringFieldDefinition("knownAs"),
+		NewStringFieldDefinition("familyName"),
+	)
+	file := NewFileDefinition(&person.Name().PackageReference, []TypeDefiner{&person}, nil)
 
 	g.Expect(*file.packageReference).To(Equal(person.Name().PackageReference))
 	g.Expect(file.definitions).To(HaveLen(1))
 }
 
-func NewTestStruct(name string, properties ...string) StructDefinition {
-	var ps []*PropertyDefinition
-	for _, n := range properties {
-		ps = append(ps, NewPropertyDefinition(PropertyName(n), n, StringType))
-	}
+/*
+ * calcRanks() tests
+ */
 
+func Test_CalcRanks_GivenMultipleRoots_AssignsRankZeroToAll(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	root1 := NewTestStruct("r1")
+	root2 := NewTestStruct("b")
+	root3 := NewTestStruct("c")
+	root4 := NewTestStruct("d")
+
+	ranks := calcRanks([]TypeDefiner{&root1, &root2, &root3, &root4})
+
+	g.Expect(ranks[*root1.Name()]).To(Equal(0))
+	g.Expect(ranks[*root2.Name()]).To(Equal(0))
+	g.Expect(ranks[*root3.Name()]).To(Equal(0))
+	g.Expect(ranks[*root4.Name()]).To(Equal(0))
+}
+
+func Test_CalcRanks_GivenLinearDependencies_AssignsRanksInOrder(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	rank3 := NewTestStruct("d")
+	referenceToRank3 := NewFieldDefinition("f3", "f3", rank3.Name())
+
+	rank2 := NewTestStruct("c", referenceToRank3)
+	referenceToRank2 := NewFieldDefinition("f2", "f2", rank2.Name())
+
+	rank1 := NewTestStruct("b", referenceToRank2)
+	referenceToRank1 := NewFieldDefinition("f1", "f1", rank1.Name())
+
+	rank0 := NewTestStruct("a", referenceToRank1)
+
+	ranks := calcRanks([]TypeDefiner{&rank0, &rank1, &rank2, &rank3})
+
+	g.Expect(ranks[*rank0.Name()]).To(Equal(0))
+	g.Expect(ranks[*rank1.Name()]).To(Equal(1))
+	g.Expect(ranks[*rank2.Name()]).To(Equal(2))
+	g.Expect(ranks[*rank3.Name()]).To(Equal(3))
+}
+
+func Test_CalcRanks_GivenDiamondDependencies_AssignRanksInOrder(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	bottom := NewTestStruct("bottom")
+	referenceToBottom := NewFieldDefinition("b", "b", bottom.Name())
+
+	left := NewTestStruct("l", referenceToBottom)
+	referenceToLeft := NewFieldDefinition("l", "l", left.Name())
+
+	right := NewTestStruct("r", referenceToBottom)
+	referenceToRight := NewFieldDefinition("r", "r", right.Name())
+
+	top := NewTestStruct("a", referenceToLeft, referenceToRight)
+
+	ranks := calcRanks([]TypeDefiner{&top, &left, &right, &bottom})
+
+	g.Expect(ranks[*top.Name()]).To(Equal(0))
+	g.Expect(ranks[*right.Name()]).To(Equal(1))
+	g.Expect(ranks[*left.Name()]).To(Equal(1))
+	g.Expect(ranks[*bottom.Name()]).To(Equal(2))
+}
+
+func Test_CalcRanks_GivenDiamondWithBar_AssignRanksInOrder(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	bottom := NewTestStruct("bottom")
+	referenceToBottom := NewFieldDefinition("b", "b", bottom.Name())
+
+	right := NewTestStruct("r", referenceToBottom)
+	referenceToRight := NewFieldDefinition("r", "r", right.Name())
+
+	left := NewTestStruct("l", referenceToBottom, referenceToRight)
+	referenceToLeft := NewFieldDefinition("l", "l", left.Name())
+
+	top := NewTestStruct("a", referenceToLeft, referenceToRight)
+
+	ranks := calcRanks([]TypeDefiner{&top, &left, &right, &bottom})
+
+	g.Expect(ranks[*top.Name()]).To(Equal(0))
+	g.Expect(ranks[*right.Name()]).To(Equal(1))
+	g.Expect(ranks[*left.Name()]).To(Equal(1))
+	g.Expect(ranks[*bottom.Name()]).To(Equal(2))
+}
+
+func Test_CalcRanks_GivenDiamondWithReverseBar_AssignRanksInOrder(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	bottom := NewTestStruct("bottom")
+
+	referenceToBottom := NewFieldDefinition("b", "b", bottom.Name())
+	left := NewTestStruct("l", referenceToBottom)
+
+	referenceToLeft := NewFieldDefinition("l", "l", left.Name())
+	right := NewTestStruct("r", referenceToBottom, referenceToLeft)
+
+	referenceToRight := NewFieldDefinition("r", "r", right.Name())
+	top := NewTestStruct("a", referenceToLeft, referenceToRight)
+
+	ranks := calcRanks([]TypeDefiner{&top, &left, &right, &bottom})
+
+	g.Expect(ranks[*top.Name()]).To(Equal(0))
+	g.Expect(ranks[*right.Name()]).To(Equal(1))
+	g.Expect(ranks[*left.Name()]).To(Equal(1))
+	g.Expect(ranks[*bottom.Name()]).To(Equal(2))
+}
+
+/*
+ * Supporting methods
+ */
+
+func NewTestStruct(name string, fields ...*FieldDefinition) StructDefinition {
 	ref := NewTypeName(*NewLocalPackageReference("group", "2020-01-01"), name)
-	definition := NewStructDefinition(ref, NewStructType().WithProperties(ps...))
+	definition := NewStructDefinition(ref, NewStructType().WithFields(fields...))
 
 	return *definition
 }
+
+func NewStringFieldDefinition(name string) *FieldDefinition {
+	return NewFieldDefinition(FieldName(name), name, StringType)
+}
+


### PR DESCRIPTION
There was a bug in the type ranking algorithm that could result in different ranks depending on the iteration order of the types. Thanks @matthchr for finding this edge case. This PR fixes the bug and adds some test coverage.