### PR TITLE
Fix TODO in generateDefinitionsFor

### DIFF
--- a/hack/generator/pkg/astmodel/resource.go
+++ b/hack/generator/pkg/astmodel/resource.go
@@ -14,13 +14,13 @@ import (
 )
 
 // CreateResourceDefinitions creates definitions for a resource
-func CreateResourceDefinitions(name *TypeName, specType *StructType, statusType *StructType, idFactory IdentifierFactory) (TypeDefiner, []TypeDefiner) {
+func CreateResourceDefinitions(name *TypeName, specType Type, statusType Type, idFactory IdentifierFactory) (TypeDefiner, []TypeDefiner) {
 
 	var others []TypeDefiner
 
-	defineStruct := func(suffix string, structType *StructType) *TypeName {
+	defineType := func(suffix string, theType Type) *TypeName {
 		definedName := NewTypeName(name.PackageReference, name.Name()+suffix)
-		defined, definedOthers := structType.CreateDefinitions(definedName, idFactory)
+		defined, definedOthers := theType.CreateDefinitions(definedName, idFactory)
 		others = append(append(others, defined), definedOthers...)
 		return definedName
 	}
@@ -29,12 +29,12 @@ func CreateResourceDefinitions(name *TypeName, specType *StructType, statusType 
 	if specType == nil {
 		panic("spec must always be provided")
 	} else {
-		specName = defineStruct("Spec", specType)
+		specName = defineType("Spec", specType)
 	}
 
 	var statusName *TypeName
 	if statusType != nil {
-		statusName = defineStruct("Status", statusType)
+		statusName = defineType("Status", statusType)
 	}
 
 	this := &ResourceDefinition{typeName: name, spec: specName, status: statusName, isStorageVersion: false}

--- a/hack/generator/pkg/jsonast/jsonast.go
+++ b/hack/generator/pkg/jsonast/jsonast.go
@@ -488,14 +488,7 @@ func generateDefinitionsFor(
 
 	// Give the type a name:
 	if isResource {
-		if specType, ok := result.(*astmodel.StructType); ok {
-			definer, otherDefs = astmodel.CreateResourceDefinitions(typeName, specType, nil, scanner.idFactory)
-		} else {
-			klog.Warningf("expected a struct type for resource: %v", typeName)
-			// TODO: handle this better, only Kusto does it
-			// we can lookup the actual struct and then use that
-			definer, otherDefs = result.CreateDefinitions(typeName, scanner.idFactory)
-		}
+		definer, otherDefs = astmodel.CreateResourceDefinitions(typeName, result, nil, scanner.idFactory)
 	} else {
 		definer, otherDefs = result.CreateDefinitions(typeName, scanner.idFactory)
 	}


### PR DESCRIPTION
Widen the argument types for `CreateResourceDefinitions` which allows removal of a TODO.