### PR TITLE
Modify MakeOptional() and MakeRequired() to be true inverses of each other

### DIFF
--- a/hack/generator/pkg/astmodel/optional_type.go
+++ b/hack/generator/pkg/astmodel/optional_type.go
@@ -60,3 +60,8 @@ func (optional *OptionalType) Equals(t Type) bool {
 
 	return false
 }
+
+// BaseType returns the underlying type
+func (optional *OptionalType) BaseType() Type {
+	return optional.element
+}

--- a/hack/generator/pkg/astmodel/property_definition.go
+++ b/hack/generator/pkg/astmodel/property_definition.go
@@ -82,18 +82,72 @@ func (property *PropertyDefinition) WithValidation(validation Validation) *Prope
 
 // MakeRequired returns a new PropertyDefinition that is marked as required
 func (property *PropertyDefinition) MakeRequired() *PropertyDefinition {
-	return property.WithValidation(ValidateRequired())
-}
-
-	if _, ok := property.propertyType.(*OptionalType); ok {
-// MakeOptional returns a new PropertyDefinition that has an optional value
-func (property *PropertyDefinition) MakeOptional() *PropertyDefinition {
+	if !property.HasOptionalType() && property.HasRequiredValidation() {
 		return property
 	}
 
 	result := *property
-	result.propertyType = NewOptionalType(result.propertyType)
+
+	if property.HasOptionalType() {
+		// Need to remove the optionality
+		ot := property.propertyType.(*OptionalType)
+		result.propertyType = ot.BaseType()
+	}
+
+	if !property.HasRequiredValidation() {
+		result = *result.WithValidation(ValidateRequired())
+	}
+
 	return &result
+}
+
+// MakeOptional returns a new PropertyDefinition that has an optional value
+func (property *PropertyDefinition) MakeOptional() *PropertyDefinition {
+	if property.HasOptionalType() && !property.HasRequiredValidation() {
+		// No change required
+		return property
+	}
+
+	result := *property
+
+	if !property.HasOptionalType() {
+		// Need to make the type optional
+		result.propertyType = NewOptionalType(result.propertyType)
+	}
+
+	if property.HasRequiredValidation() {
+		// Need to remove the Required validation
+		var validations []Validation
+		for _, v := range result.validations {
+			if !v.HasName(RequiredValidationName) {
+				validations = append(validations, v)
+			}
+		}
+
+		result.validations = validations
+	}
+
+	return &result
+}
+
+// HasRequiredValidation returns true if the property has validation specifying that it is required;
+// returns false otherwise.
+func (property *PropertyDefinition) HasRequiredValidation() bool {
+	required := ValidateRequired()
+	for _, v := range property.validations {
+		if v == required {
+			return true
+		}
+	}
+
+	return false
+}
+
+// HasOptionalType returns true if the type of this property is an optioan reference to a value
+// (and might therefore be nil).
+func (property *PropertyDefinition) HasOptionalType() bool {
+	_, ok := property.propertyType.(*OptionalType)
+	return ok
 }
 
 // AsField generates a Go AST field node representing this property definition

--- a/hack/generator/pkg/astmodel/property_definition.go
+++ b/hack/generator/pkg/astmodel/property_definition.go
@@ -85,9 +85,9 @@ func (property *PropertyDefinition) MakeRequired() *PropertyDefinition {
 	return property.WithValidation(ValidateRequired())
 }
 
-// MakeTypeOptional returns a new PropertyDefinition that has an optional value
-func (property *PropertyDefinition) MakeTypeOptional() *PropertyDefinition {
 	if _, ok := property.propertyType.(*OptionalType); ok {
+// MakeOptional returns a new PropertyDefinition that has an optional value
+func (property *PropertyDefinition) MakeOptional() *PropertyDefinition {
 		return property
 	}
 

--- a/hack/generator/pkg/astmodel/property_definition_test.go
+++ b/hack/generator/pkg/astmodel/property_definition_test.go
@@ -163,7 +163,7 @@ func Test_PropertyDefinition_MakeRequired_ReturnsDifferentReference(t *testing.T
 }
 
 /*
- * MakeTypeOptional() Tests
+ * MakeOptional() Tests
  */
 
 func Test_PropertyDefinitionWithRequiredType_MakeTypeOptional_ReturnsDifferentReference(t *testing.T) {

--- a/hack/generator/pkg/astmodel/property_definition_test.go
+++ b/hack/generator/pkg/astmodel/property_definition_test.go
@@ -153,10 +153,39 @@ func Test_PropertyDefinitionWithType_GivenSameType_ReturnsExistingReference(t *t
  * MakeRequired() Tests
  */
 
-func Test_PropertyDefinition_MakeRequired_ReturnsDifferentReference(t *testing.T) {
+func Test_PropertyDefinitionMakeRequired_WhenOptional_ReturnsDifferentReference(t *testing.T) {
 	g := NewGomegaWithT(t)
 
-	original := NewPropertyDefinition(fieldName, fieldJsonName, fieldType)
+	original := NewPropertyDefinition(fieldName, fieldJsonName, fieldType).MakeOptional()
+	field := original.MakeRequired()
+
+	g.Expect(field).NotTo(BeIdenticalTo(original))
+}
+
+func TestPropertyDefinitionMakeRequired_WhenOptional_ReturnsTypeWithMandatoryValidation(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	original := NewPropertyDefinition(fieldName, fieldJsonName, fieldType).MakeOptional()
+	field := original.MakeRequired()
+
+	g.Expect(field.validations).To(ContainElement(ValidateRequired()))
+}
+
+func Test_PropertyDefinitionMakeRequired_WhenRequired_ReturnsExistingReference(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	original := NewPropertyDefinition(fieldName, fieldJsonName, fieldType).MakeRequired()
+	field := original.MakeRequired()
+
+	g.Expect(field).To(BeIdenticalTo(original))
+}
+
+func Test_PropertyDefinitionMakeRequired_WhenTypeOptionalAndValidationPresent_ReturnsNewReference(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	original := NewPropertyDefinition(fieldName, fieldJsonName, fieldType).
+		MakeOptional().
+		WithValidation(ValidateRequired())
 	field := original.MakeRequired()
 
 	g.Expect(field).NotTo(BeIdenticalTo(original))
@@ -166,22 +195,40 @@ func Test_PropertyDefinition_MakeRequired_ReturnsDifferentReference(t *testing.T
  * MakeOptional() Tests
  */
 
-func Test_PropertyDefinitionWithRequiredType_MakeTypeOptional_ReturnsDifferentReference(t *testing.T) {
+func TestPropertyDefinitionMakeOptional_WhenRequired_ReturnsDifferentReference(t *testing.T) {
 	g := NewGomegaWithT(t)
 
-	original := NewPropertyDefinition(fieldName, fieldJsonName, fieldType)
-	field := original.MakeTypeOptional()
+	original := NewPropertyDefinition(fieldName, fieldJsonName, fieldType).MakeRequired()
+	field := original.MakeOptional()
 
 	g.Expect(field).NotTo(BeIdenticalTo(original))
 }
 
-func Test_PropertyDefinitionWithOptionalType_MakeTypeOptional_ReturnsExistingReference(t *testing.T) {
+func TestPropertyDefinitionMakeOptional_WhenRequired_ReturnsTypeWithoutMandatoryValidation(t *testing.T) {
 	g := NewGomegaWithT(t)
 
-	original := NewPropertyDefinition(fieldName, fieldJsonName, fieldType).MakeTypeOptional()
-	field := original.MakeTypeOptional()
+	original := NewPropertyDefinition(fieldName, fieldJsonName, fieldType).MakeRequired()
+	field := original.MakeOptional()
+
+	g.Expect(field.validations).NotTo(ContainElement(ValidateRequired()))
+}
+
+func Test_PropertyDefinitionMakeOptional_WhenOptional_ReturnsExistingReference(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	original := NewPropertyDefinition(fieldName, fieldJsonName, fieldType).MakeOptional()
+	field := original.MakeOptional()
 
 	g.Expect(field).To(BeIdenticalTo(original))
+}
+
+func Test_PropertyDefinitionMakeOptional_WhenTypeMandatoryAndMissingValidation_ReturnsNewReference(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	original := NewPropertyDefinition(fieldName, fieldJsonName, fieldType)
+	field := original.MakeOptional()
+
+	g.Expect(field).NotTo(BeIdenticalTo(original))
 }
 
 /*

--- a/hack/generator/pkg/astmodel/validations.go
+++ b/hack/generator/pkg/astmodel/validations.go
@@ -45,13 +45,31 @@ func GenerateKubebuilderComment(validation Validation) string {
 	return fmt.Sprintf("%s%s", prefix, validation.name)
 }
 
+func (v Validation) HasName(name string) bool {
+	return v.name == name
+}
+
+/*
+ * Constants for names of validation
+ */
+
+const (
+	EnumValidationName string = "Enum"
+	RequiredValidationName string = "Required"
+)
+
+/*
+ * Factory methods for Validation instances
+ */
+
 // ValidateEnum returns a Validation that requires the value be one of the
 // passed 'permittedValues'
 func ValidateEnum(permittedValues []interface{}) Validation {
-	return Validation{"Enum", permittedValues}
+	return Validation{EnumValidationName, permittedValues}
 }
 
 // ValidateRequired returns a Validation that requires a value be present
 func ValidateRequired() Validation {
-	return Validation{"Required", nil}
+	return Validation{RequiredValidationName, nil}
 }
+

--- a/hack/generator/pkg/jsonast/jsonast.go
+++ b/hack/generator/pkg/jsonast/jsonast.go
@@ -370,7 +370,7 @@ func getProperties(ctx context.Context, scanner *SchemaScanner, schema *gojsonsc
 		if isRequired {
 			property = property.MakeRequired()
 		} else {
-			property = property.MakeTypeOptional()
+			property = property.MakeOptional()
 		}
 
 		properties = append(properties, property)
@@ -646,7 +646,7 @@ func generateOneOfUnionType(ctx context.Context, subschemas []*gojsonschema.SubS
 			// but we still need it for controller-gen
 			jsonName := scanner.idFactory.CreateIdentifier(concreteType.Name(), astmodel.NotExported)
 			property := astmodel.NewPropertyDefinition(
-				propertyName, jsonName, concreteType).MakeTypeOptional().WithDescription(&propertyDescription)
+				propertyName, jsonName, concreteType).MakeOptional().WithDescription(&propertyDescription)
 			properties = append(properties, property)
 		case *astmodel.EnumType:
 			// TODO: This name sucks but what alternative do we have?
@@ -657,7 +657,7 @@ func generateOneOfUnionType(ctx context.Context, subschemas []*gojsonschema.SubS
 			// but we still need it for controller-gen
 			jsonName := scanner.idFactory.CreateIdentifier(name, astmodel.NotExported)
 			property := astmodel.NewPropertyDefinition(
-				propertyName, jsonName, concreteType).MakeTypeOptional().WithDescription(&propertyDescription)
+				propertyName, jsonName, concreteType).MakeOptional().WithDescription(&propertyDescription)
 			properties = append(properties, property)
 		case *astmodel.ObjectType:
 			// TODO: This name sucks but what alternative do we have?
@@ -668,7 +668,7 @@ func generateOneOfUnionType(ctx context.Context, subschemas []*gojsonschema.SubS
 			// but we still need it for controller-gen
 			jsonName := scanner.idFactory.CreateIdentifier(name, astmodel.NotExported)
 			property := astmodel.NewPropertyDefinition(
-				propertyName, jsonName, concreteType).MakeTypeOptional().WithDescription(&propertyDescription)
+				propertyName, jsonName, concreteType).MakeOptional().WithDescription(&propertyDescription)
 			properties = append(properties, property)
 		case *astmodel.PrimitiveType:
 			var primitiveTypeName string
@@ -686,7 +686,7 @@ func generateOneOfUnionType(ctx context.Context, subschemas []*gojsonschema.SubS
 			// but we still need it for controller-gen
 			jsonName := scanner.idFactory.CreateIdentifier(name, astmodel.NotExported)
 			property := astmodel.NewPropertyDefinition(
-				propertyName, jsonName, concreteType).MakeTypeOptional().WithDescription(&propertyDescription)
+				propertyName, jsonName, concreteType).MakeOptional().WithDescription(&propertyDescription)
 			properties = append(properties, property)
 		default:
 			return nil, errors.Errorf("unexpected oneOf member, type: %T", t)


### PR DESCRIPTION
The two methods `MakeOptionalType()` and `MakeRequired()` on `PropertyDefinition` weren't true inverses of each other, meaning they could only be used on a brand new property definition. This PR changes them to be true inverses, so that we can call `MakeOptional()` on a required property and it will properly reverse/restore the configuration.
