### PR TITLE
Update identifier_factory to handle reserved words

### DIFF
--- a/hack/generator/pkg/astmodel/identifier_factory.go
+++ b/hack/generator/pkg/astmodel/identifier_factory.go
@@ -33,7 +33,8 @@ type IdentifierFactory interface {
 
 // identifierFactory is an implementation of the IdentifierFactory interface
 type identifierFactory struct {
-	renames map[string]string
+	renames       map[string]string
+	reservedWords map[string]string
 }
 
 // assert the implementation exists
@@ -42,7 +43,8 @@ var _ IdentifierFactory = (*identifierFactory)(nil)
 // NewIdentifierFactory creates an IdentifierFactory ready for use
 func NewIdentifierFactory() IdentifierFactory {
 	return &identifierFactory{
-		renames: createRenames(),
+		renames:       createRenames(),
+		reservedWords: createReservedWords(),
 	}
 }
 
@@ -73,6 +75,12 @@ func (factory *identifierFactory) CreateIdentifier(name string, visibility Visib
 	}
 
 	result := strings.Join(caseCorrectedWords, "")
+
+	if alternateWord, ok := factory.reservedWords[result]; ok {
+		// This is a reserved word, we need to use an alternate word
+		return alternateWord
+	}
+
 	return result
 }
 
@@ -85,6 +93,37 @@ func createRenames() map[string]string {
 	return map[string]string{
 		"$schema": "Schema",
 		"*":       "Star", // This happens mostly in enums
+	}
+}
+
+// These are words reserved by go
+func createReservedWords() map[string]string {
+	return map[string]string{
+		"break":       "brk",
+		"case":        "c",
+		"chan":        "chn",
+		"const":       "cnst",
+		"continue":    "cont",
+		"default":     "def",
+		"defer":       "deferVar",
+		"else":        "els",
+		"fallthrough": "fallthrgh",
+		"for":         "f",
+		"func":        "funcVar",
+		"go":          "g",
+		"goto":        "gotoVar",
+		"if":          "ifVar",
+		"import":      "imp",
+		"interface":   "iface",
+		"map":         "m",
+		"package":     "pkg",
+		"range":       "rng",
+		"return":      "ret",
+		"select":      "sel",
+		"struct":      "strct",
+		"switch":      "sw",
+		"type":        "typeVar",
+		"var":         "v",
 	}
 }
 

--- a/hack/generator/pkg/astmodel/identifier_factory.go
+++ b/hack/generator/pkg/astmodel/identifier_factory.go
@@ -96,7 +96,7 @@ func createRenames() map[string]string {
 	}
 }
 
-// These are words reserved by go
+// These are words reserved by go, along with our chosen substitutes
 func createReservedWords() map[string]string {
 	return map[string]string{
 		"break":       "brk",

--- a/hack/generator/pkg/astmodel/identifier_factory_test.go
+++ b/hack/generator/pkg/astmodel/identifier_factory_test.go
@@ -25,6 +25,7 @@ func Test_CreateIdentifier_GivenName_ReturnsExpectedIdentifier(t *testing.T) {
 		{"XMLDocument", Exported, "XMLDocument"},
 		{"this id has spaces", Exported, "ThisIdHasSpaces"},
 		{"this, id, has, spaces", Exported, "ThisIdHasSpaces"},
+		{"package", Exported, "Package"},
 		{"name", NotExported, "name"},
 		{"Name", NotExported, "name"},
 		{"$schema", NotExported, "schema"},
@@ -33,6 +34,7 @@ func Test_CreateIdentifier_GivenName_ReturnsExpectedIdentifier(t *testing.T) {
 		{"XMLDocument", NotExported, "xmlDocument"},
 		{"this id has spaces", NotExported, "thisIdHasSpaces"},
 		{"this, id, has, spaces", NotExported, "thisIdHasSpaces"},
+		{"package", NotExported, "pkg"},
 	}
 
 	idfactory := NewIdentifierFactory()

--- a/hack/generator/pkg/astmodel/validations.go
+++ b/hack/generator/pkg/astmodel/validations.go
@@ -54,7 +54,7 @@ func (v Validation) HasName(name string) bool {
  */
 
 const (
-	EnumValidationName string = "Enum"
+	EnumValidationName     string = "Enum"
 	RequiredValidationName string = "Required"
 )
 
@@ -72,4 +72,3 @@ func ValidateEnum(permittedValues []interface{}) Validation {
 func ValidateRequired() Validation {
 	return Validation{RequiredValidationName, nil}
 }
-


### PR DESCRIPTION
This solves an issue that we will end up having with certain words when we use them as either private variables (or function variables).

Uppercase identifiers with those same words don't have issues