### PR TITLE
Make resource pluralization fixups its own pipeline stage

### DIFF
--- a/hack/generator/pkg/astmodel/type_definition.go
+++ b/hack/generator/pkg/astmodel/type_definition.go
@@ -45,6 +45,20 @@ func (std TypeDefinition) WithDescription(desc *string) TypeDefinition {
 	return std
 }
 
+// WithType returns an updated TypeDefinition with the specified type
+func (std *TypeDefinition) WithType(t Type) TypeDefinition {
+	result := *std
+	result.theType = t
+	return result
+}
+
+// WithName returns an updated TypeDefinition with the specified name
+func (std *TypeDefinition) WithName(typeName *TypeName) TypeDefinition {
+	result := *std
+	result.name = typeName
+	return result
+}
+
 func (std *TypeDefinition) AsDeclarations(codeGenerationContext *CodeGenerationContext) []ast.Decl {
 	return std.theType.AsDeclarations(codeGenerationContext, std.name, std.description)
 }

--- a/hack/generator/pkg/codegen/code_generator.go
+++ b/hack/generator/pkg/codegen/code_generator.go
@@ -56,6 +56,7 @@ func NewCodeGeneratorFromConfig(configuration *config.Configuration, idFactory a
 func corePipelineStages(idFactory astmodel.IdentifierFactory, configuration *config.Configuration) []PipelineStage {
 	return []PipelineStage{
 		nameTypesForCRD(idFactory),
+		improveResourcePluralization(),
 		applyExportFilters(configuration),
 		stripUnreferencedTypeDefinitions(),
 	}

--- a/hack/generator/pkg/codegen/pipeline_improve_resource_pluralization.go
+++ b/hack/generator/pkg/codegen/pipeline_improve_resource_pluralization.go
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) Microsoft Corporation.
+ * Licensed under the MIT license.
+ */
+
+package codegen
+
+import (
+	"context"
+
+	"github.com/Azure/k8s-infra/hack/generator/pkg/astmodel"
+)
+
+// improveResourcePluralization improves pluralization for resources
+func improveResourcePluralization() PipelineStage {
+
+	return PipelineStage{
+		Name: "Improve resource pluralization",
+		Action: func(ctx context.Context, types Types) (Types, error) {
+
+			result := make(Types)
+			for typeName, typeDef := range types {
+				if _, ok := typeDef.Type().(*astmodel.ResourceType); ok {
+					newTypeName := typeName.Singular()
+					typeDef = typeDef.WithName(newTypeName)
+					result[*newTypeName] = typeDef
+				} else {
+					result[typeName] = typeDef
+				}
+			}
+
+			return result, nil
+		},
+	}
+}

--- a/hack/generator/pkg/jsonast/jsonast.go
+++ b/hack/generator/pkg/jsonast/jsonast.go
@@ -477,10 +477,6 @@ func generateDefinitionsFor(
 		return nil, err
 	}
 
-	if isResource {
-		typeName = typeName.Singular()
-	}
-
 	// see if we already generated something for this ref
 	if _, ok := scanner.findTypeDefinition(typeName); ok {
 		return typeName, nil


### PR DESCRIPTION
  - Changing the names of resources is sensitive because other places
    (such as ownership mapping) may have a reference to the old type
    name. Promoting this step to a pipeline phase forces all the code
    updating resource names to be co-located, which is much easier to
    read than having it spread across a few different functions in
    jsonast.