### PR TITLE
Make TypeName and PackageReference values

### DIFF
--- a/hack/generator/pkg/astmodel/array_type.go
+++ b/hack/generator/pkg/astmodel/array_type.go
@@ -22,7 +22,7 @@ func NewArrayType(element Type) *ArrayType {
 // assert we implemented Type correctly
 var _ Type = (*ArrayType)(nil)
 
-func (array *ArrayType) AsDeclarations(codeGenerationContext *CodeGenerationContext, name *TypeName, description *string) []ast.Decl {
+func (array *ArrayType) AsDeclarations(codeGenerationContext *CodeGenerationContext, name TypeName, description *string) []ast.Decl {
 	return AsSimpleDeclarations(codeGenerationContext, name, description, array)
 }
 
@@ -34,7 +34,7 @@ func (array *ArrayType) AsType(codeGenerationContext *CodeGenerationContext) ast
 }
 
 // RequiredImports returns a list of packages required by this
-func (array *ArrayType) RequiredImports() []*PackageReference {
+func (array *ArrayType) RequiredImports() []PackageReference {
 	return array.element.RequiredImports()
 }
 

--- a/hack/generator/pkg/astmodel/code_generation_context.go
+++ b/hack/generator/pkg/astmodel/code_generation_context.go
@@ -13,11 +13,11 @@ import "github.com/pkg/errors"
 // a disambiguation must occur and field types must ensure they correctly refer to the disambiguated types
 type CodeGenerationContext struct {
 	packageImports map[PackageReference]PackageImport
-	currentPackage *PackageReference
+	currentPackage PackageReference
 }
 
 // New CodeGenerationContext creates a new immutable code generation context
-func NewCodeGenerationContext(currentPackage *PackageReference, packageImports map[PackageImport]struct{}) *CodeGenerationContext {
+func NewCodeGenerationContext(currentPackage PackageReference, packageImports map[PackageImport]struct{}) *CodeGenerationContext {
 	packageImportsMap := make(map[PackageReference]PackageImport)
 	for imp := range packageImports {
 		packageImportsMap[imp.PackageReference] = imp
@@ -38,8 +38,8 @@ func (codeGenContext *CodeGenerationContext) PackageImports() map[PackageReferen
 }
 
 // GetImportedPackageName gets the imported packages name or an error if the package was not imported
-func (codeGenContext *CodeGenerationContext) GetImportedPackageName(reference *PackageReference) (string, error) {
-	packageImport, ok := codeGenContext.packageImports[*reference]
+func (codeGenContext *CodeGenerationContext) GetImportedPackageName(reference PackageReference) (string, error) {
+	packageImport, ok := codeGenContext.packageImports[reference]
 	if !ok {
 		return "", errors.Errorf("package %s not imported", reference)
 	}

--- a/hack/generator/pkg/astmodel/enum_type.go
+++ b/hack/generator/pkg/astmodel/enum_type.go
@@ -34,7 +34,7 @@ func NewEnumType(baseType *PrimitiveType, options []EnumValue) *EnumType {
 }
 
 // AsDeclarations converts the EnumType to a series of Go AST Decls
-func (enum *EnumType) AsDeclarations(codeGenerationContext *CodeGenerationContext, name *TypeName, description *string) []ast.Decl {
+func (enum *EnumType) AsDeclarations(codeGenerationContext *CodeGenerationContext, name TypeName, description *string) []ast.Decl {
 	var specs []ast.Spec
 	for _, v := range enum.options {
 		s := enum.createValueDeclaration(name, v)
@@ -54,7 +54,7 @@ func (enum *EnumType) AsDeclarations(codeGenerationContext *CodeGenerationContex
 	return result
 }
 
-func (enum *EnumType) createBaseDeclaration(codeGenerationContext *CodeGenerationContext, name *TypeName, description *string) ast.Decl {
+func (enum *EnumType) createBaseDeclaration(codeGenerationContext *CodeGenerationContext, name TypeName, description *string) ast.Decl {
 	identifier := ast.NewIdent(name.Name())
 
 	typeSpecification := &ast.TypeSpec{
@@ -84,7 +84,7 @@ func (enum *EnumType) createBaseDeclaration(codeGenerationContext *CodeGeneratio
 	return declaration
 }
 
-func (enum *EnumType) createValueDeclaration(name *TypeName, value EnumValue) ast.Spec {
+func (enum *EnumType) createValueDeclaration(name TypeName, value EnumValue) ast.Spec {
 
 	enumIdentifier := ast.NewIdent(name.Name())
 	valueIdentifier := ast.NewIdent(name.Name() + value.Identifier)
@@ -145,7 +145,7 @@ func (enum *EnumType) Equals(t Type) bool {
 }
 
 // RequiredImports indicates that Enums never need additional imports
-func (enum *EnumType) RequiredImports() []*PackageReference {
+func (enum *EnumType) RequiredImports() []PackageReference {
 	return nil
 }
 

--- a/hack/generator/pkg/astmodel/file_definition_test.go
+++ b/hack/generator/pkg/astmodel/file_definition_test.go
@@ -245,7 +245,7 @@ func Test_CalcRanks_GivenDiamondWithReverseBar_AssignRanksInOrder(t *testing.T) 
  */
 
 func NewTestObject(name string, fields ...*PropertyDefinition) TypeDefinition {
-	ref := NewTypeName(NewLocalPackageReference("group", "2020-01-01"), name)
+	ref := MakeTypeName(MakeLocalPackageReference("group", "2020-01-01"), name)
 	return MakeTypeDefinition(ref, NewObjectType().WithProperties(fields...))
 }
 

--- a/hack/generator/pkg/astmodel/file_definition_test.go
+++ b/hack/generator/pkg/astmodel/file_definition_test.go
@@ -24,9 +24,9 @@ func Test_NewFileDefinition_GivenValues_InitializesFields(t *testing.T) {
 		NewStringPropertyDefinition("knownAs"),
 		NewStringPropertyDefinition("familyName"),
 	)
-	file := NewFileDefinition(&person.Name().PackageReference, person)
+	file := NewFileDefinition(person.Name().PackageReference, person)
 
-	g.Expect(*file.packageReference).To(Equal(person.Name().PackageReference))
+	g.Expect(file.packageReference).To(Equal(person.Name().PackageReference))
 	g.Expect(file.definitions).To(HaveLen(1))
 }
 
@@ -50,10 +50,10 @@ func Test_CalcRanks_GivenMultipleRoots_AssignsRankZeroToAll(t *testing.T) {
 
 	ranks := calcRanks([]TypeDefinition{root1, root2, root3, root4})
 
-	g.Expect(ranks[*root1.Name()]).To(Equal(0))
-	g.Expect(ranks[*root2.Name()]).To(Equal(0))
-	g.Expect(ranks[*root3.Name()]).To(Equal(0))
-	g.Expect(ranks[*root4.Name()]).To(Equal(0))
+	g.Expect(ranks[root1.Name()]).To(Equal(0))
+	g.Expect(ranks[root2.Name()]).To(Equal(0))
+	g.Expect(ranks[root3.Name()]).To(Equal(0))
+	g.Expect(ranks[root4.Name()]).To(Equal(0))
 }
 
 func Test_CalcRanks_GivenLinearDependencies_AssignsRanksInOrder(t *testing.T) {
@@ -102,10 +102,10 @@ func Test_CalcRanks_GivenLinearDependencies_AssignsRanksInOrder(t *testing.T) {
 
 	ranks := calcRanks([]TypeDefinition{rank0, rank1, rank2, rank3})
 
-	g.Expect(ranks[*rank0.Name()]).To(Equal(0))
-	g.Expect(ranks[*rank1.Name()]).To(Equal(1))
-	g.Expect(ranks[*rank2.Name()]).To(Equal(2))
-	g.Expect(ranks[*rank3.Name()]).To(Equal(3))
+	g.Expect(ranks[rank0.Name()]).To(Equal(0))
+	g.Expect(ranks[rank1.Name()]).To(Equal(1))
+	g.Expect(ranks[rank2.Name()]).To(Equal(2))
+	g.Expect(ranks[rank3.Name()]).To(Equal(3))
 }
 
 func Test_CalcRanks_GivenDiamondDependencies_AssignRanksInOrder(t *testing.T) {
@@ -146,10 +146,10 @@ func Test_CalcRanks_GivenDiamondDependencies_AssignRanksInOrder(t *testing.T) {
 
 	ranks := calcRanks([]TypeDefinition{top, left, right, bottom})
 
-	g.Expect(ranks[*top.Name()]).To(Equal(0))
-	g.Expect(ranks[*right.Name()]).To(Equal(1))
-	g.Expect(ranks[*left.Name()]).To(Equal(1))
-	g.Expect(ranks[*bottom.Name()]).To(Equal(2))
+	g.Expect(ranks[top.Name()]).To(Equal(0))
+	g.Expect(ranks[right.Name()]).To(Equal(1))
+	g.Expect(ranks[left.Name()]).To(Equal(1))
+	g.Expect(ranks[bottom.Name()]).To(Equal(2))
 }
 
 func Test_CalcRanks_GivenDiamondWithBar_AssignRanksInOrder(t *testing.T) {
@@ -190,10 +190,10 @@ func Test_CalcRanks_GivenDiamondWithBar_AssignRanksInOrder(t *testing.T) {
 
 	ranks := calcRanks([]TypeDefinition{top, left, right, bottom})
 
-	g.Expect(ranks[*top.Name()]).To(Equal(0))
-	g.Expect(ranks[*right.Name()]).To(Equal(1))
-	g.Expect(ranks[*left.Name()]).To(Equal(1))
-	g.Expect(ranks[*bottom.Name()]).To(Equal(2))
+	g.Expect(ranks[top.Name()]).To(Equal(0))
+	g.Expect(ranks[right.Name()]).To(Equal(1))
+	g.Expect(ranks[left.Name()]).To(Equal(1))
+	g.Expect(ranks[bottom.Name()]).To(Equal(2))
 }
 
 func Test_CalcRanks_GivenDiamondWithReverseBar_AssignRanksInOrder(t *testing.T) {
@@ -234,10 +234,10 @@ func Test_CalcRanks_GivenDiamondWithReverseBar_AssignRanksInOrder(t *testing.T) 
 
 	ranks := calcRanks([]TypeDefinition{top, left, right, bottom})
 
-	g.Expect(ranks[*top.Name()]).To(Equal(0))
-	g.Expect(ranks[*right.Name()]).To(Equal(1))
-	g.Expect(ranks[*left.Name()]).To(Equal(1))
-	g.Expect(ranks[*bottom.Name()]).To(Equal(2))
+	g.Expect(ranks[top.Name()]).To(Equal(0))
+	g.Expect(ranks[right.Name()]).To(Equal(1))
+	g.Expect(ranks[left.Name()]).To(Equal(1))
+	g.Expect(ranks[bottom.Name()]).To(Equal(2))
 }
 
 /*
@@ -245,7 +245,7 @@ func Test_CalcRanks_GivenDiamondWithReverseBar_AssignRanksInOrder(t *testing.T) 
  */
 
 func NewTestObject(name string, fields ...*PropertyDefinition) TypeDefinition {
-	ref := NewTypeName(*NewLocalPackageReference("group", "2020-01-01"), name)
+	ref := NewTypeName(NewLocalPackageReference("group", "2020-01-01"), name)
 	return MakeTypeDefinition(ref, NewObjectType().WithProperties(fields...))
 }
 

--- a/hack/generator/pkg/astmodel/function.go
+++ b/hack/generator/pkg/astmodel/function.go
@@ -11,14 +11,14 @@ import (
 
 // Function represents something that is an (unnamed) Go function
 type Function interface {
-	RequiredImports() []*PackageReference
+	RequiredImports() []PackageReference
 
 	// References returns the set of types to which this function refers.
 	// Should *not* include the receiver of this function
 	References() TypeNameSet
 
 	// AsFunc renders the current instance as a Go abstract syntax tree
-	AsFunc(codeGenerationContext *CodeGenerationContext, receiver *TypeName, methodName string) *ast.FuncDecl
+	AsFunc(codeGenerationContext *CodeGenerationContext, receiver TypeName, methodName string) *ast.FuncDecl
 
 	// Equals determines if this Function is equal to another one
 	Equals(f Function) bool

--- a/hack/generator/pkg/astmodel/function_test.go
+++ b/hack/generator/pkg/astmodel/function_test.go
@@ -12,10 +12,10 @@ type FakeFunction struct {
 	Referenced TypeNameSet
 }
 
-func (fake *FakeFunction) RequiredImports() []*PackageReference {
-	var result []*PackageReference
+func (fake *FakeFunction) RequiredImports() []PackageReference {
+	var result []PackageReference
 	for k := range fake.Imported {
-		result = append(result, &k)
+		result = append(result, k)
 	}
 
 	return result
@@ -25,7 +25,7 @@ func (fake *FakeFunction) References() TypeNameSet {
 	return fake.Referenced
 }
 
-func (fake *FakeFunction) AsFunc(codeGenerationContext *CodeGenerationContext, receiver *TypeName, methodName string) *ast.FuncDecl {
+func (fake *FakeFunction) AsFunc(codeGenerationContext *CodeGenerationContext, receiver TypeName, methodName string) *ast.FuncDecl {
 	panic("implement me")
 }
 

--- a/hack/generator/pkg/astmodel/map_type.go
+++ b/hack/generator/pkg/astmodel/map_type.go
@@ -38,7 +38,7 @@ func NewStringMapType(value Type) *MapType {
 // assert that we implemented Type correctly
 var _ Type = (*MapType)(nil)
 
-func (m *MapType) AsDeclarations(codeGenerationContext *CodeGenerationContext, name *TypeName, description *string) []ast.Decl {
+func (m *MapType) AsDeclarations(codeGenerationContext *CodeGenerationContext, name TypeName, description *string) []ast.Decl {
 	return AsSimpleDeclarations(codeGenerationContext, name, description, m)
 }
 
@@ -51,8 +51,8 @@ func (m *MapType) AsType(codeGenerationContext *CodeGenerationContext) ast.Expr 
 }
 
 // RequiredImports returns a list of packages required by this
-func (m *MapType) RequiredImports() []*PackageReference {
-	var result []*PackageReference
+func (m *MapType) RequiredImports() []PackageReference {
+	var result []PackageReference
 	result = append(result, m.key.RequiredImports()...)
 	result = append(result, m.value.RequiredImports()...)
 	return result

--- a/hack/generator/pkg/astmodel/object_definition_test.go
+++ b/hack/generator/pkg/astmodel/object_definition_test.go
@@ -22,7 +22,7 @@ func Test_NewObjectDefinition_GivenValues_InitializesProperties(t *testing.T) {
 	const group = "group"
 	const version = "2020-01-01"
 
-	ref := NewTypeName(NewLocalPackageReference(group, version), name)
+	ref := MakeTypeName(MakeLocalPackageReference(group, version), name)
 	objectType := NewObjectType().WithProperties(fullName, familyName, knownAs)
 	objectDefinition := MakeTypeDefinition(ref, objectType)
 
@@ -50,7 +50,7 @@ func Test_ObjectDefinitionWithDescription_GivenDescription_ReturnsExpected(t *te
 
 	description := "This is my test description"
 
-	ref := NewTypeName(NewLocalPackageReference(group, version), name)
+	ref := MakeTypeName(MakeLocalPackageReference(group, version), name)
 	objectType := NewObjectType().WithProperties(fullName, familyName, knownAs)
 	objectDefinition := MakeTypeDefinition(ref, objectType).WithDescription(&description)
 
@@ -64,7 +64,7 @@ func Test_ObjectDefinitionWithDescription_GivenDescription_ReturnsExpected(t *te
 func Test_ObjectDefinitionAsAst_GivenValidStruct_ReturnsNonNilResult(t *testing.T) {
 	g := NewGomegaWithT(t)
 
-	ref := NewTypeName(NewLocalPackageReference("group", "2020-01-01"), "name")
+	ref := MakeTypeName(MakeLocalPackageReference("group", "2020-01-01"), "name")
 	definition := MakeTypeDefinition(ref, NewObjectType())
 	node := definition.AsDeclarations(nil)
 

--- a/hack/generator/pkg/astmodel/object_definition_test.go
+++ b/hack/generator/pkg/astmodel/object_definition_test.go
@@ -22,7 +22,7 @@ func Test_NewObjectDefinition_GivenValues_InitializesProperties(t *testing.T) {
 	const group = "group"
 	const version = "2020-01-01"
 
-	ref := NewTypeName(*NewLocalPackageReference(group, version), name)
+	ref := NewTypeName(NewLocalPackageReference(group, version), name)
 	objectType := NewObjectType().WithProperties(fullName, familyName, knownAs)
 	objectDefinition := MakeTypeDefinition(ref, objectType)
 
@@ -50,7 +50,7 @@ func Test_ObjectDefinitionWithDescription_GivenDescription_ReturnsExpected(t *te
 
 	description := "This is my test description"
 
-	ref := NewTypeName(*NewLocalPackageReference(group, version), name)
+	ref := NewTypeName(NewLocalPackageReference(group, version), name)
 	objectType := NewObjectType().WithProperties(fullName, familyName, knownAs)
 	objectDefinition := MakeTypeDefinition(ref, objectType).WithDescription(&description)
 
@@ -64,7 +64,7 @@ func Test_ObjectDefinitionWithDescription_GivenDescription_ReturnsExpected(t *te
 func Test_ObjectDefinitionAsAst_GivenValidStruct_ReturnsNonNilResult(t *testing.T) {
 	g := NewGomegaWithT(t)
 
-	ref := NewTypeName(*NewLocalPackageReference("group", "2020-01-01"), "name")
+	ref := NewTypeName(NewLocalPackageReference("group", "2020-01-01"), "name")
 	definition := MakeTypeDefinition(ref, NewObjectType())
 	node := definition.AsDeclarations(nil)
 

--- a/hack/generator/pkg/astmodel/object_type.go
+++ b/hack/generator/pkg/astmodel/object_type.go
@@ -31,7 +31,7 @@ func NewObjectType() *ObjectType {
 	}
 }
 
-func (objectType *ObjectType) AsDeclarations(codeGenerationContext *CodeGenerationContext, name *TypeName, description *string) []ast.Decl {
+func (objectType *ObjectType) AsDeclarations(codeGenerationContext *CodeGenerationContext, name TypeName, description *string) []ast.Decl {
 	identifier := ast.NewIdent(name.Name())
 	declaration := &ast.GenDecl{
 		Tok: token.TYPE,
@@ -53,7 +53,7 @@ func (objectType *ObjectType) AsDeclarations(codeGenerationContext *CodeGenerati
 	return result
 }
 
-func (objectType *ObjectType) generateMethodDecls(codeGenerationContext *CodeGenerationContext, typeName *TypeName) []ast.Decl {
+func (objectType *ObjectType) generateMethodDecls(codeGenerationContext *CodeGenerationContext, typeName TypeName) []ast.Decl {
 	var result []ast.Decl
 	for methodName, function := range objectType.functions {
 		funcDef := function.AsFunc(codeGenerationContext, typeName, methodName)
@@ -114,8 +114,8 @@ func (objectType *ObjectType) AsType(codeGenerationContext *CodeGenerationContex
 }
 
 // RequiredImports returns a list of packages required by this
-func (objectType *ObjectType) RequiredImports() []*PackageReference {
-	var result []*PackageReference
+func (objectType *ObjectType) RequiredImports() []PackageReference {
+	var result []PackageReference
 	for _, property := range objectType.properties {
 		result = append(result, property.PropertyType().RequiredImports()...)
 	}

--- a/hack/generator/pkg/astmodel/one_of_json_marshal_function.go
+++ b/hack/generator/pkg/astmodel/one_of_json_marshal_function.go
@@ -44,7 +44,7 @@ func (f *OneOfJSONMarshalFunction) References() TypeNameSet {
 // AsFunc returns the function as a go ast
 func (f *OneOfJSONMarshalFunction) AsFunc(
 	codeGenerationContext *CodeGenerationContext,
-	receiver *TypeName,
+	receiver TypeName,
 	methodName string) *ast.FuncDecl {
 
 	receiverName := f.idFactory.CreateIdentifier(receiver.name, NotExported)
@@ -135,8 +135,8 @@ func (f *OneOfJSONMarshalFunction) AsFunc(
 }
 
 // RequiredImports returns a list of packages required by this
-func (f *OneOfJSONMarshalFunction) RequiredImports() []*PackageReference {
-	return []*PackageReference{
+func (f *OneOfJSONMarshalFunction) RequiredImports() []PackageReference {
+	return []PackageReference{
 		NewPackageReference("encoding/json"),
 	}
 }

--- a/hack/generator/pkg/astmodel/one_of_json_marshal_function.go
+++ b/hack/generator/pkg/astmodel/one_of_json_marshal_function.go
@@ -137,6 +137,6 @@ func (f *OneOfJSONMarshalFunction) AsFunc(
 // RequiredImports returns a list of packages required by this
 func (f *OneOfJSONMarshalFunction) RequiredImports() []PackageReference {
 	return []PackageReference{
-		NewPackageReference("encoding/json"),
+		MakePackageReference("encoding/json"),
 	}
 }

--- a/hack/generator/pkg/astmodel/optional_type.go
+++ b/hack/generator/pkg/astmodel/optional_type.go
@@ -22,7 +22,7 @@ func NewOptionalType(element Type) *OptionalType {
 // assert we implemented Type correctly
 var _ Type = (*OptionalType)(nil)
 
-func (optional *OptionalType) AsDeclarations(codeGenerationContext *CodeGenerationContext, name *TypeName, description *string) []ast.Decl {
+func (optional *OptionalType) AsDeclarations(codeGenerationContext *CodeGenerationContext, name TypeName, description *string) []ast.Decl {
 	return AsSimpleDeclarations(codeGenerationContext, name, description, optional)
 }
 
@@ -39,7 +39,7 @@ func (optional *OptionalType) AsType(codeGenerationContext *CodeGenerationContex
 }
 
 // RequiredImports returns the imports required by the 'element' type
-func (optional *OptionalType) RequiredImports() []*PackageReference {
+func (optional *OptionalType) RequiredImports() []PackageReference {
 	return optional.element.RequiredImports()
 }
 

--- a/hack/generator/pkg/astmodel/package_definition.go
+++ b/hack/generator/pkg/astmodel/package_definition.go
@@ -70,7 +70,7 @@ func (pkgDef *PackageDefinition) DefinitionCount() int {
 func emitFiles(filesToGenerate map[string][]TypeDefinition, outputDir string) error {
 	for fileName, defs := range filesToGenerate {
 		fullFileName := fileName + "_types" + CodeGeneratedFileSuffix
-		genFile := NewFileDefinition(&defs[0].Name().PackageReference, defs...)
+		genFile := NewFileDefinition(defs[0].Name().PackageReference, defs...)
 		outputFile := filepath.Join(outputDir, fullFileName)
 
 		klog.V(5).Infof("Writing %q\n", outputFile)
@@ -84,9 +84,9 @@ func emitFiles(filesToGenerate map[string][]TypeDefinition, outputDir string) er
 	return nil
 }
 
-func anyReferences(defs []TypeDefinition, defName *TypeName) bool {
+func anyReferences(defs []TypeDefinition, defName TypeName) bool {
 	for _, def := range defs {
-		if def.References().Contains(*defName) {
+		if def.References().Contains(defName) {
 			return true
 		}
 	}

--- a/hack/generator/pkg/astmodel/package_import.go
+++ b/hack/generator/pkg/astmodel/package_import.go
@@ -12,7 +12,7 @@ import (
 
 // PackageImport represents an import of a name from a package
 type PackageImport struct {
-	PackageReference PackageReference // This is used as the key in a map so can't be pointer
+	PackageReference PackageReference
 	name             *string
 }
 

--- a/hack/generator/pkg/astmodel/package_import.go
+++ b/hack/generator/pkg/astmodel/package_import.go
@@ -57,5 +57,5 @@ func (pi *PackageImport) PackageName() string {
 
 // Equals returns true if the passed package reference references the same package, false otherwise
 func (pi *PackageImport) Equals(ref *PackageImport) bool {
-	return pi.PackageReference.Equals(&ref.PackageReference) && pi.name == ref.name
+	return pi.PackageReference.Equals(ref.PackageReference) && pi.name == ref.name
 }

--- a/hack/generator/pkg/astmodel/package_import_test.go
+++ b/hack/generator/pkg/astmodel/package_import_test.go
@@ -12,8 +12,8 @@ import (
 )
 
 func TestPackageImport_Equals(t *testing.T) {
-	localPkgRef := NewLocalPackageReference("group", "ver")
-	localPkgImport := NewPackageImport(*localPkgRef)
+	localPkgRef := MakeLocalPackageReference("group", "ver")
+	localPkgImport := NewPackageImport(localPkgRef)
 
 	cases := []struct {
 		name     string
@@ -22,7 +22,7 @@ func TestPackageImport_Equals(t *testing.T) {
 		expected bool
 	}{
 		{"package import is equal to itself", localPkgImport, localPkgImport, true},
-		{"package import is equal to same import different reference", NewPackageImport(*localPkgRef), NewPackageImport(*localPkgRef), true},
+		{"package import is equal to same import different reference", NewPackageImport(localPkgRef), NewPackageImport(localPkgRef), true},
 		{"package import is not equal to import with name", localPkgImport, localPkgImport.WithName("ref"), false},
 		{"package import differs by name is not equal", localPkgImport.WithName("ref1"), localPkgImport.WithName("ref2"), false},
 		{"package imports with same name are equal", localPkgImport.WithName("ref"), localPkgImport.WithName("ref"), true},

--- a/hack/generator/pkg/astmodel/package_reference.go
+++ b/hack/generator/pkg/astmodel/package_reference.go
@@ -24,21 +24,21 @@ type PackageReference struct {
 }
 
 // NewLocalPackageReference Creates a new local package reference from a group and package name
-func NewLocalPackageReference(groupName string, packageName string) *PackageReference {
+func NewLocalPackageReference(groupName string, packageName string) PackageReference {
 	url := localPathPrefix + groupName + "/" + packageName
-	return &PackageReference{packagePath: url}
+	return PackageReference{packagePath: url}
 }
 
 // NewPackageReference creates a new package reference from a path
-func NewPackageReference(packagePath string) *PackageReference {
-	return &PackageReference{packagePath: packagePath}
+func NewPackageReference(packagePath string) PackageReference {
+	return PackageReference{packagePath: packagePath}
 }
 
-func (pr *PackageReference) IsLocalPackage() bool {
+func (pr PackageReference) IsLocalPackage() bool {
 	return strings.HasPrefix(pr.packagePath, localPathPrefix)
 }
 
-func (pr *PackageReference) stripLocalPackagePrefix() (string, error) {
+func (pr PackageReference) stripLocalPackagePrefix() (string, error) {
 	if !pr.IsLocalPackage() {
 		return "", errors.Errorf("cannot strip local package prefix from non-local package %v", pr.packagePath)
 	}
@@ -48,7 +48,7 @@ func (pr *PackageReference) stripLocalPackagePrefix() (string, error) {
 
 // GroupAndPackage gets the group and package for this package reference if applicable,
 // or an error if not
-func (pr *PackageReference) GroupAndPackage() (string, string, error) {
+func (pr PackageReference) GroupAndPackage() (string, string, error) {
 	groupAndVersion, err := pr.stripLocalPackagePrefix()
 	if err != nil {
 		return "", "", err
@@ -59,25 +59,25 @@ func (pr *PackageReference) GroupAndPackage() (string, string, error) {
 }
 
 // PackagePath returns the fully qualified package path
-func (pr *PackageReference) PackagePath() string {
+func (pr PackageReference) PackagePath() string {
 	return pr.packagePath
 }
 
 // PackageName is the package name of the package reference
-func (pr *PackageReference) PackageName() string {
+func (pr PackageReference) PackageName() string {
 	l := strings.Split(pr.packagePath, "/")
 	return l[len(l)-1]
 }
 
 // Equals returns true if the passed package reference references the same package, false otherwise
-func (pr *PackageReference) Equals(ref *PackageReference) bool {
+func (pr PackageReference) Equals(ref PackageReference) bool {
 	return pr.packagePath == ref.packagePath
 }
 
 // String returns the string representation of the package reference
-func (pr *PackageReference) String() string {
+func (pr PackageReference) String() string {
 	return pr.packagePath
 }
 
 // Ensure we implement Stringer
-var _ fmt.Stringer = &PackageReference{}
+var _ fmt.Stringer = PackageReference{}

--- a/hack/generator/pkg/astmodel/package_reference.go
+++ b/hack/generator/pkg/astmodel/package_reference.go
@@ -16,21 +16,21 @@ const (
 	localPathPrefix = "github.com/Azure/k8s-infra/hack/generator/apis/"
 )
 
-var MetaV1PackageReference = NewPackageReference("k8s.io/apimachinery/pkg/apis/meta/v1")
+var MetaV1PackageReference = MakePackageReference("k8s.io/apimachinery/pkg/apis/meta/v1")
 
 // PackageReference indicates which package a type belongs to
 type PackageReference struct {
 	packagePath string
 }
 
-// NewLocalPackageReference Creates a new local package reference from a group and package name
-func NewLocalPackageReference(groupName string, packageName string) PackageReference {
+// MakeLocalPackageReference Creates a new local package reference from a group and package name
+func MakeLocalPackageReference(groupName string, packageName string) PackageReference {
 	url := localPathPrefix + groupName + "/" + packageName
 	return PackageReference{packagePath: url}
 }
 
-// NewPackageReference creates a new package reference from a path
-func NewPackageReference(packagePath string) PackageReference {
+// MakePackageReference creates a new package reference from a path
+func MakePackageReference(packagePath string) PackageReference {
 	return PackageReference{packagePath: packagePath}
 }
 

--- a/hack/generator/pkg/astmodel/primitive_type.go
+++ b/hack/generator/pkg/astmodel/primitive_type.go
@@ -37,12 +37,12 @@ func (prim *PrimitiveType) AsType(codeGenerationContext *CodeGenerationContext) 
 	return ast.NewIdent(prim.name)
 }
 
-func (prim *PrimitiveType) AsDeclarations(CodeGenerationContext *CodeGenerationContext, name *TypeName, description *string) []ast.Decl {
+func (prim *PrimitiveType) AsDeclarations(CodeGenerationContext *CodeGenerationContext, name TypeName, description *string) []ast.Decl {
 	return AsSimpleDeclarations(CodeGenerationContext, name, description, prim)
 }
 
 // RequiredImports returns a list of package required by this
-func (prim *PrimitiveType) RequiredImports() []*PackageReference {
+func (prim *PrimitiveType) RequiredImports() []PackageReference {
 	return nil
 }
 

--- a/hack/generator/pkg/astmodel/resource.go
+++ b/hack/generator/pkg/astmodel/resource.go
@@ -79,7 +79,7 @@ func (definition *ResourceType) MarkAsStorageVersion() *ResourceType {
 }
 
 // RequiredImports returns a list of packages required by this
-func (definition *ResourceType) RequiredImports() []*PackageReference {
+func (definition *ResourceType) RequiredImports() []PackageReference {
 	typeImports := definition.spec.RequiredImports()
 
 	if definition.status != nil {
@@ -92,7 +92,7 @@ func (definition *ResourceType) RequiredImports() []*PackageReference {
 }
 
 // AsDeclarations converts the resource type to a set of go declarations
-func (definition *ResourceType) AsDeclarations(codeGenerationContext *CodeGenerationContext, typeName *TypeName, description *string) []ast.Decl {
+func (definition *ResourceType) AsDeclarations(codeGenerationContext *CodeGenerationContext, typeName TypeName, description *string) []ast.Decl {
 
 	packageName, err := codeGenerationContext.GetImportedPackageName(MetaV1PackageReference)
 	if err != nil {

--- a/hack/generator/pkg/astmodel/type.go
+++ b/hack/generator/pkg/astmodel/type.go
@@ -13,7 +13,7 @@ import (
 // Type represents something that is a Go type
 type Type interface {
 	// RequiredImports returns a list of packages required by this type
-	RequiredImports() []*PackageReference
+	RequiredImports() []PackageReference
 
 	// References returns the names of all types that this type
 	// references. For example, an Array of Persons references a
@@ -25,7 +25,7 @@ type Type interface {
 	AsType(codeGenerationContext *CodeGenerationContext) ast.Expr
 
 	// AsDeclarations renders as a Go abstract syntax tree for a declaration
-	AsDeclarations(codeGenerationContext *CodeGenerationContext, name *TypeName, description *string) []ast.Decl
+	AsDeclarations(codeGenerationContext *CodeGenerationContext, name TypeName, description *string) []ast.Decl
 
 	// Equals returns true if the passed type is the same as this one, false otherwise
 	Equals(t Type) bool
@@ -43,7 +43,7 @@ func TypeEquals(left, right Type) bool {
 // TypeVisitor represents a visitor for a tree of types.
 // The `ctx` argument can be used to “smuggle” additional data down the call-chain.
 type TypeVisitor struct {
-	VisitTypeName     func(this *TypeVisitor, it *TypeName, ctx interface{}) Type
+	VisitTypeName     func(this *TypeVisitor, it TypeName, ctx interface{}) Type
 	VisitArrayType    func(this *TypeVisitor, it *ArrayType, ctx interface{}) Type
 	VisitPrimitive    func(this *TypeVisitor, it *PrimitiveType, ctx interface{}) Type
 	VisitObjectType   func(this *TypeVisitor, it *ObjectType, ctx interface{}) Type
@@ -60,7 +60,7 @@ func (tv *TypeVisitor) Visit(t Type, ctx interface{}) Type {
 	}
 
 	switch it := t.(type) {
-	case *TypeName:
+	case TypeName:
 		return tv.VisitTypeName(tv, it, ctx)
 	case *ArrayType:
 		return tv.VisitArrayType(tv, it, ctx)
@@ -89,7 +89,7 @@ func MakeTypeVisitor() TypeVisitor {
 	// recursive invocations of Visit to avoid having to rebuild the tree if the
 	// leafs do not actually change.
 	return TypeVisitor{
-		VisitTypeName: func(_ *TypeVisitor, it *TypeName, _ interface{}) Type {
+		VisitTypeName: func(_ *TypeVisitor, it TypeName, _ interface{}) Type {
 			return it
 		},
 		VisitArrayType: func(this *TypeVisitor, it *ArrayType, ctx interface{}) Type {

--- a/hack/generator/pkg/astmodel/type_definition.go
+++ b/hack/generator/pkg/astmodel/type_definition.go
@@ -12,17 +12,17 @@ import (
 
 // TypeDefinition is a name paired with a type
 type TypeDefinition struct {
-	name        *TypeName
+	name        TypeName
 	description *string
 	theType     Type
 }
 
-func MakeTypeDefinition(name *TypeName, theType Type) TypeDefinition {
+func MakeTypeDefinition(name TypeName, theType Type) TypeDefinition {
 	return TypeDefinition{name: name, theType: theType}
 }
 
 // Name returns the name being associated with the type
-func (std *TypeDefinition) Name() *TypeName {
+func (std *TypeDefinition) Name() TypeName {
 	return std.name
 }
 
@@ -53,7 +53,7 @@ func (std *TypeDefinition) WithType(t Type) TypeDefinition {
 }
 
 // WithName returns an updated TypeDefinition with the specified name
-func (std *TypeDefinition) WithName(typeName *TypeName) TypeDefinition {
+func (std *TypeDefinition) WithName(typeName TypeName) TypeDefinition {
 	result := *std
 	result.name = typeName
 	return result
@@ -64,7 +64,7 @@ func (std *TypeDefinition) AsDeclarations(codeGenerationContext *CodeGenerationC
 }
 
 // AsSimpleDeclarations is a helper for types that only require a simple name/alias to be defined
-func AsSimpleDeclarations(codeGenerationContext *CodeGenerationContext, name *TypeName, description *string, theType Type) []ast.Decl {
+func AsSimpleDeclarations(codeGenerationContext *CodeGenerationContext, name TypeName, description *string, theType Type) []ast.Decl {
 	var docComments *ast.CommentGroup
 	if description != nil {
 		docComments = &ast.CommentGroup{}
@@ -86,7 +86,7 @@ func AsSimpleDeclarations(codeGenerationContext *CodeGenerationContext, name *Ty
 }
 
 // RequiredImports returns a list of packages required by this type
-func (std *TypeDefinition) RequiredImports() []*PackageReference {
+func (std *TypeDefinition) RequiredImports() []PackageReference {
 	return std.theType.RequiredImports()
 }
 

--- a/hack/generator/pkg/astmodel/type_name.go
+++ b/hack/generator/pkg/astmodel/type_name.go
@@ -19,27 +19,27 @@ type TypeName struct {
 }
 
 // NewTypeName is a factory method for creating a TypeName
-func NewTypeName(pr PackageReference, name string) *TypeName {
-	return &TypeName{pr, name}
+func NewTypeName(pr PackageReference, name string) TypeName {
+	return TypeName{pr, name}
 }
 
 // Name returns the package-local name of the type
-func (typeName *TypeName) Name() string {
+func (typeName TypeName) Name() string {
 	return typeName.name
 }
 
 // A TypeName can be used as a Type,
 // it is simply a reference to the name.
-var _ Type = (*TypeName)(nil)
+var _ Type = TypeName{}
 
-func (typeName *TypeName) AsDeclarations(codeGenerationContext *CodeGenerationContext, name *TypeName, description *string) []ast.Decl {
+func (typeName TypeName) AsDeclarations(codeGenerationContext *CodeGenerationContext, name TypeName, description *string) []ast.Decl {
 	return AsSimpleDeclarations(codeGenerationContext, name, description, typeName)
 }
 
 // AsType implements Type for TypeName
-func (typeName *TypeName) AsType(codeGenerationContext *CodeGenerationContext) ast.Expr {
+func (typeName TypeName) AsType(codeGenerationContext *CodeGenerationContext) ast.Expr {
 	// If our package is being referenced, we need to ensure we include a selector for that reference
-	packageName, err := codeGenerationContext.GetImportedPackageName(&typeName.PackageReference)
+	packageName, err := codeGenerationContext.GetImportedPackageName(typeName.PackageReference)
 	if err == nil {
 		return &ast.SelectorExpr{
 			X:   ast.NewIdent(packageName),
@@ -48,7 +48,7 @@ func (typeName *TypeName) AsType(codeGenerationContext *CodeGenerationContext) a
 	}
 
 	// Sanity assertion that the type we're generating is in the same package that the context is for
-	if !codeGenerationContext.currentPackage.Equals(&typeName.PackageReference) {
+	if !codeGenerationContext.currentPackage.Equals(typeName.PackageReference) {
 		panic(fmt.Sprintf(
 			"no reference for %v included in package %v",
 			typeName.name,
@@ -59,33 +59,30 @@ func (typeName *TypeName) AsType(codeGenerationContext *CodeGenerationContext) a
 }
 
 // References returns a set containing this type name.
-func (typeName *TypeName) References() TypeNameSet {
-	if typeName == nil {
-		return nil
-	}
-	return NewTypeNameSet(*typeName)
+func (typeName TypeName) References() TypeNameSet {
+	return NewTypeNameSet(typeName)
 }
 
 // RequiredImports returns all the imports required for this definition
-func (typeName *TypeName) RequiredImports() []*PackageReference {
-	return []*PackageReference{&typeName.PackageReference}
+func (typeName TypeName) RequiredImports() []PackageReference {
+	return []PackageReference{typeName.PackageReference}
 }
 
 // Equals returns true if the passed type is the same TypeName, false otherwise
-func (typeName *TypeName) Equals(t Type) bool {
-	if d, ok := t.(*TypeName); ok {
-		return typeName.name == d.name && typeName.PackageReference.Equals(&d.PackageReference)
+func (typeName TypeName) Equals(t Type) bool {
+	if d, ok := t.(TypeName); ok {
+		return typeName.name == d.name && typeName.PackageReference.Equals(d.PackageReference)
 	}
 
 	return false
 }
 
 // String returns the string representation of the type name
-func (typeName *TypeName) String() string {
+func (typeName TypeName) String() string {
 	return fmt.Sprintf("%s/%s", typeName.PackageReference, typeName.name)
 }
 
-func (typeName *TypeName) Singular() *TypeName {
+func (typeName TypeName) Singular() TypeName {
 	return NewTypeName(typeName.PackageReference, flect.Singularize(typeName.name))
 }
 

--- a/hack/generator/pkg/astmodel/type_name.go
+++ b/hack/generator/pkg/astmodel/type_name.go
@@ -18,8 +18,8 @@ type TypeName struct {
 	name             string
 }
 
-// NewTypeName is a factory method for creating a TypeName
-func NewTypeName(pr PackageReference, name string) TypeName {
+// MakeTypeName is a factory method for creating a TypeName
+func MakeTypeName(pr PackageReference, name string) TypeName {
 	return TypeName{pr, name}
 }
 
@@ -83,7 +83,7 @@ func (typeName TypeName) String() string {
 }
 
 func (typeName TypeName) Singular() TypeName {
-	return NewTypeName(typeName.PackageReference, flect.Singularize(typeName.name))
+	return MakeTypeName(typeName.PackageReference, flect.Singularize(typeName.name))
 }
 
 // Ensure we implement Stringer

--- a/hack/generator/pkg/codegen/codegen_test.go
+++ b/hack/generator/pkg/codegen/codegen_test.go
@@ -8,12 +8,13 @@ package codegen
 import (
 	"bytes"
 	"context"
-	"github.com/pkg/errors"
 	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/pkg/errors"
 
 	"github.com/sebdah/goldie/v2"
 	"github.com/xeipuuv/gojsonschema"
@@ -47,8 +48,8 @@ func runGoldenTest(t *testing.T, path string) {
 		Action: func(ctx context.Context, defs Types) (Types, error) {
 			// The golden files always generate a top-level Test type - mark
 			// that as the root.
-			roots := astmodel.NewTypeNameSet(*astmodel.NewTypeName(
-				*astmodel.NewPackageReference(
+			roots := astmodel.NewTypeNameSet(astmodel.NewTypeName(
+				astmodel.NewPackageReference(
 					"github.com/Azure/k8s-infra/hack/generator/apis/test/v20200101"),
 				"Test",
 			))
@@ -64,13 +65,11 @@ func runGoldenTest(t *testing.T, path string) {
 	exportPackagesTestPipelineStage := PipelineStage{
 		Name: "Export packages for test",
 		Action: func(ctx context.Context, defs Types) (Types, error) {
-			var pr *astmodel.PackageReference
+			var pr astmodel.PackageReference
 			var ds []astmodel.TypeDefinition
 			for _, def := range defs {
 				ds = append(ds, def)
-				if pr == nil {
-					pr = &def.Name().PackageReference
-				}
+				pr = def.Name().PackageReference
 			}
 
 			// put all definitions in one file, regardless.

--- a/hack/generator/pkg/codegen/codegen_test.go
+++ b/hack/generator/pkg/codegen/codegen_test.go
@@ -48,8 +48,8 @@ func runGoldenTest(t *testing.T, path string) {
 		Action: func(ctx context.Context, defs Types) (Types, error) {
 			// The golden files always generate a top-level Test type - mark
 			// that as the root.
-			roots := astmodel.NewTypeNameSet(astmodel.NewTypeName(
-				astmodel.NewPackageReference(
+			roots := astmodel.NewTypeNameSet(astmodel.MakeTypeName(
+				astmodel.MakePackageReference(
 					"github.com/Azure/k8s-infra/hack/generator/apis/test/v20200101"),
 				"Test",
 			))

--- a/hack/generator/pkg/codegen/pipeline_apply_export_filters.go
+++ b/hack/generator/pkg/codegen/pipeline_apply_export_filters.go
@@ -44,7 +44,7 @@ func filterTypes(
 				klog.V(2).Infof("Exporting %s because %s", defName, reason)
 			}
 
-			newDefinitions[*def.Name()] = def
+			newDefinitions[def.Name()] = def
 		}
 	}
 

--- a/hack/generator/pkg/codegen/pipeline_export_generated_code.go
+++ b/hack/generator/pkg/codegen/pipeline_export_generated_code.go
@@ -191,7 +191,7 @@ func groupResourcesByVersion(packages []*astmodel.PackageDefinition) (map[unvers
 	return result, nil
 }
 
-func getUnversionedName(name *astmodel.TypeName) (unversionedName, error) {
+func getUnversionedName(name astmodel.TypeName) (unversionedName, error) {
 	group, _, err := name.PackageReference.GroupAndPackage()
 	if err != nil {
 		return unversionedName{}, err

--- a/hack/generator/pkg/codegen/pipeline_improve_resource_pluralization.go
+++ b/hack/generator/pkg/codegen/pipeline_improve_resource_pluralization.go
@@ -23,7 +23,7 @@ func improveResourcePluralization() PipelineStage {
 				if _, ok := typeDef.Type().(*astmodel.ResourceType); ok {
 					newTypeName := typeName.Singular()
 					typeDef = typeDef.WithName(newTypeName)
-					result[*newTypeName] = typeDef
+					result[newTypeName] = typeDef
 				} else {
 					result[typeName] = typeDef
 				}

--- a/hack/generator/pkg/codegen/pipeline_name_types_for_crd.go
+++ b/hack/generator/pkg/codegen/pipeline_name_types_for_crd.go
@@ -60,7 +60,7 @@ func nameInnerTypes(
 	visitor.VisitEnumType = func(this *astmodel.TypeVisitor, it *astmodel.EnumType, ctx interface{}) astmodel.Type {
 		nameHint := ctx.(string)
 
-		enumName := astmodel.NewTypeName(def.Name().PackageReference, idFactory.CreateEnumIdentifier(nameHint))
+		enumName := astmodel.MakeTypeName(def.Name().PackageReference, idFactory.CreateEnumIdentifier(nameHint))
 
 		namedEnum := astmodel.MakeTypeDefinition(enumName, it)
 		namedEnum = namedEnum.WithDescription(getDescription(enumName))
@@ -80,7 +80,7 @@ func nameInnerTypes(
 			props = append(props, prop.WithType(newPropType))
 		}
 
-		objectName := astmodel.NewTypeName(def.Name().PackageReference, nameHint)
+		objectName := astmodel.MakeTypeName(def.Name().PackageReference, nameHint)
 
 		namedObjectType := astmodel.MakeTypeDefinition(objectName, it.WithProperties(props...))
 		namedObjectType = namedObjectType.WithDescription(getDescription(objectName))
@@ -100,7 +100,7 @@ func nameInnerTypes(
 			status = this.Visit(it.StatusType(), nameHint+"Status")
 		}
 
-		resourceName := astmodel.NewTypeName(def.Name().PackageReference, nameHint)
+		resourceName := astmodel.MakeTypeName(def.Name().PackageReference, nameHint)
 
 		resource := astmodel.MakeTypeDefinition(resourceName, astmodel.NewResourceType(spec, status))
 		resource = resource.WithDescription(getDescription(resourceName))

--- a/hack/generator/pkg/codegen/pipeline_name_types_for_crd.go
+++ b/hack/generator/pkg/codegen/pipeline_name_types_for_crd.go
@@ -21,8 +21,8 @@ func nameTypesForCRD(idFactory astmodel.IdentifierFactory) PipelineStage {
 			result := make(Types)
 
 			// this is a little bit of a hack, better way to do it?
-			getDescription := func(typeName *astmodel.TypeName) *string {
-				if typeDef, ok := types[*typeName]; ok {
+			getDescription := func(typeName astmodel.TypeName) *string {
+				if typeDef, ok := types[typeName]; ok {
 					return typeDef.Description()
 				}
 
@@ -32,7 +32,7 @@ func nameTypesForCRD(idFactory astmodel.IdentifierFactory) PipelineStage {
 			for typeName, typeDef := range types {
 				newDefs := nameInnerTypes(typeDef, idFactory, getDescription)
 				for _, newDef := range newDefs {
-					result[*newDef.Name()] = newDef
+					result[newDef.Name()] = newDef
 				}
 
 				if _, ok := result[typeName]; !ok {
@@ -50,7 +50,7 @@ func nameTypesForCRD(idFactory astmodel.IdentifierFactory) PipelineStage {
 func nameInnerTypes(
 	def astmodel.TypeDefinition,
 	idFactory astmodel.IdentifierFactory,
-	getDescription func(*astmodel.TypeName) *string) []astmodel.TypeDefinition {
+	getDescription func(astmodel.TypeName) *string) []astmodel.TypeDefinition {
 
 	var resultTypes []astmodel.TypeDefinition
 

--- a/hack/generator/pkg/codegen/pipeline_name_types_for_crd.go
+++ b/hack/generator/pkg/codegen/pipeline_name_types_for_crd.go
@@ -95,7 +95,7 @@ func nameInnerTypes(
 
 		spec := this.Visit(it.SpecType(), nameHint+"Spec")
 
-		var status astmodel.Type // the type is very important here, it must be a nil(Type) if status isn’t set, not a nil(*TypeName)
+		var status astmodel.Type
 		if it.StatusType() != nil {
 			status = this.Visit(it.StatusType(), nameHint+"Status")
 		}

--- a/hack/generator/pkg/codegen/pipeline_strip_unused_types.go
+++ b/hack/generator/pkg/codegen/pipeline_strip_unused_types.go
@@ -32,15 +32,15 @@ func StripUnusedDefinitions(
 	references := make(map[astmodel.TypeName]astmodel.TypeNameSet)
 
 	for _, def := range definitions {
-		references[*def.Name()] = def.References()
+		references[def.Name()] = def.References()
 	}
 
 	graph := newReferenceGraph(roots, references)
 	connectedTypes := graph.connected()
 	usedDefinitions := make(Types)
 	for _, def := range definitions {
-		if connectedTypes.Contains(*def.Name()) {
-			usedDefinitions[*def.Name()] = def
+		if connectedTypes.Contains(def.Name()) {
+			usedDefinitions[def.Name()] = def
 		}
 	}
 
@@ -53,7 +53,7 @@ func collectResourceDefinitions(definitions Types) astmodel.TypeNameSet {
 	resources := make(astmodel.TypeNameSet)
 	for _, def := range definitions {
 		if _, ok := def.Type().(*astmodel.ResourceType); ok {
-			resources.Add(*def.Name())
+			resources.Add(def.Name())
 		}
 	}
 	return resources

--- a/hack/generator/pkg/codegen/pipeline_strip_unused_types_test.go
+++ b/hack/generator/pkg/codegen/pipeline_strip_unused_types_test.go
@@ -18,7 +18,7 @@ const packagePath = "test.package/v1"
 func TestConnectionChecker_Avoids_Cycles(t *testing.T) {
 	g := NewGomegaWithT(t)
 	makeName := func(name string) astmodel.TypeName {
-		return astmodel.NewTypeName(astmodel.NewPackageReference(packagePath), name)
+		return astmodel.MakeTypeName(astmodel.MakePackageReference(packagePath), name)
 	}
 
 	makeSet := func(names ...string) astmodel.TypeNameSet {

--- a/hack/generator/pkg/codegen/pipeline_strip_unused_types_test.go
+++ b/hack/generator/pkg/codegen/pipeline_strip_unused_types_test.go
@@ -18,7 +18,7 @@ const packagePath = "test.package/v1"
 func TestConnectionChecker_Avoids_Cycles(t *testing.T) {
 	g := NewGomegaWithT(t)
 	makeName := func(name string) astmodel.TypeName {
-		return *astmodel.NewTypeName(*astmodel.NewPackageReference(packagePath), name)
+		return astmodel.NewTypeName(astmodel.NewPackageReference(packagePath), name)
 	}
 
 	makeSet := func(names ...string) astmodel.TypeNameSet {

--- a/hack/generator/pkg/config/configuration.go
+++ b/hack/generator/pkg/config/configuration.go
@@ -99,7 +99,7 @@ func (config *Configuration) Initialize() error {
 
 // ShouldExport tests for whether a given type should be exported as Go code
 // Returns a result indicating whether export should occur as well as a reason for logging
-func (config *Configuration) ShouldExport(typeName *astmodel.TypeName) (result ShouldExportResult, because string) {
+func (config *Configuration) ShouldExport(typeName astmodel.TypeName) (result ShouldExportResult, because string) {
 	for _, f := range config.ExportFilters {
 		if f.AppliesToType(typeName) {
 			switch f.Action {
@@ -118,7 +118,7 @@ func (config *Configuration) ShouldExport(typeName *astmodel.TypeName) (result S
 }
 
 // ShouldPrune tests for whether a given type should be extracted from the JSON schema or pruned
-func (config *Configuration) ShouldPrune(typeName *astmodel.TypeName) (result ShouldPruneResult, because string) {
+func (config *Configuration) ShouldPrune(typeName astmodel.TypeName) (result ShouldPruneResult, because string) {
 	for _, f := range config.TypeFilters {
 		if f.AppliesToType(typeName) {
 			switch f.Action {
@@ -138,7 +138,7 @@ func (config *Configuration) ShouldPrune(typeName *astmodel.TypeName) (result Sh
 
 // TransformType uses the configured type transformers to transform a type name (reference) to a different type.
 // If no transformation is performed, nil is returned
-func (config *Configuration) TransformType(name *astmodel.TypeName) (astmodel.Type, string) {
+func (config *Configuration) TransformType(name astmodel.TypeName) (astmodel.Type, string) {
 	for _, transformer := range config.TypeTransformers {
 		result := transformer.TransformTypeName(name)
 		if result != nil {

--- a/hack/generator/pkg/config/configuration_test.go
+++ b/hack/generator/pkg/config/configuration_test.go
@@ -14,12 +14,12 @@ import (
 )
 
 // Shared test values:
-var package2019 = *astmodel.NewLocalPackageReference("group", "2019-01-01")
+var package2019 = astmodel.NewLocalPackageReference("group", "2019-01-01")
 var person2019 = astmodel.NewTypeName(package2019, "person")
 var post2019 = astmodel.NewTypeName(package2019, "post")
 var student2019 = astmodel.NewTypeName(package2019, "student")
 
-var package2020 = *astmodel.NewLocalPackageReference("group", "2020-01-01")
+var package2020 = astmodel.NewLocalPackageReference("group", "2020-01-01")
 var address2020 = astmodel.NewTypeName(package2020, "address")
 var person2020 = astmodel.NewTypeName(package2020, "person")
 var professor2020 = astmodel.NewTypeName(package2020, "professor")

--- a/hack/generator/pkg/config/configuration_test.go
+++ b/hack/generator/pkg/config/configuration_test.go
@@ -14,17 +14,17 @@ import (
 )
 
 // Shared test values:
-var package2019 = astmodel.NewLocalPackageReference("group", "2019-01-01")
-var person2019 = astmodel.NewTypeName(package2019, "person")
-var post2019 = astmodel.NewTypeName(package2019, "post")
-var student2019 = astmodel.NewTypeName(package2019, "student")
+var package2019 = astmodel.MakeLocalPackageReference("group", "2019-01-01")
+var person2019 = astmodel.MakeTypeName(package2019, "person")
+var post2019 = astmodel.MakeTypeName(package2019, "post")
+var student2019 = astmodel.MakeTypeName(package2019, "student")
 
-var package2020 = astmodel.NewLocalPackageReference("group", "2020-01-01")
-var address2020 = astmodel.NewTypeName(package2020, "address")
-var person2020 = astmodel.NewTypeName(package2020, "person")
-var professor2020 = astmodel.NewTypeName(package2020, "professor")
-var student2020 = astmodel.NewTypeName(package2020, "student")
-var tutor2020 = astmodel.NewTypeName(package2020, "tutor")
+var package2020 = astmodel.MakeLocalPackageReference("group", "2020-01-01")
+var address2020 = astmodel.MakeTypeName(package2020, "address")
+var person2020 = astmodel.MakeTypeName(package2020, "person")
+var professor2020 = astmodel.MakeTypeName(package2020, "professor")
+var student2020 = astmodel.MakeTypeName(package2020, "student")
+var tutor2020 = astmodel.MakeTypeName(package2020, "tutor")
 
 func Test_WithSingleFilter_FiltersExpectedTypes(t *testing.T) {
 	g := NewGomegaWithT(t)

--- a/hack/generator/pkg/config/type_matcher.go
+++ b/hack/generator/pkg/config/type_matcher.go
@@ -7,9 +7,10 @@ package config
 
 import (
 	"fmt"
-	"github.com/Azure/k8s-infra/hack/generator/pkg/astmodel"
 	"regexp"
 	"strings"
+
+	"github.com/Azure/k8s-infra/hack/generator/pkg/astmodel"
 )
 
 // TypeMatcher contains basic functionality for a filter
@@ -60,7 +61,7 @@ func (typeMatcher *TypeMatcher) matches(glob string, regex **regexp.Regexp, name
 }
 
 // AppliesToType indicates whether this filter should be applied to the supplied type definition
-func (typeMatcher *TypeMatcher) AppliesToType(typeName *astmodel.TypeName) bool {
+func (typeMatcher *TypeMatcher) AppliesToType(typeName astmodel.TypeName) bool {
 	groupName, packageName, err := typeName.PackageReference.GroupAndPackage()
 	if err != nil {
 		// TODO: Should this func return an error rather than panic?

--- a/hack/generator/pkg/config/type_matcher_test.go
+++ b/hack/generator/pkg/config/type_matcher_test.go
@@ -6,18 +6,19 @@
 package config_test
 
 import (
-	"github.com/Azure/k8s-infra/hack/generator/pkg/config"
 	"testing"
+
+	"github.com/Azure/k8s-infra/hack/generator/pkg/config"
 
 	"github.com/Azure/k8s-infra/hack/generator/pkg/astmodel"
 	. "github.com/onsi/gomega"
 )
 
 // Shared test values -- note that these are used by type_transformer_test.go too
-var person2020 = astmodel.NewTypeName(*astmodel.NewLocalPackageReference("party", "2020-01-01"), "person")
-var post2019 = astmodel.NewTypeName(*astmodel.NewLocalPackageReference("thing", "2019-01-01"), "post")
-var student2019 = astmodel.NewTypeName(*astmodel.NewLocalPackageReference("role", "2019-01-01"), "student")
-var tutor2019 = astmodel.NewTypeName(*astmodel.NewLocalPackageReference("role", "2019-01-01"), "tutor")
+var person2020 = astmodel.NewTypeName(astmodel.NewLocalPackageReference("party", "2020-01-01"), "person")
+var post2019 = astmodel.NewTypeName(astmodel.NewLocalPackageReference("thing", "2019-01-01"), "post")
+var student2019 = astmodel.NewTypeName(astmodel.NewLocalPackageReference("role", "2019-01-01"), "student")
+var tutor2019 = astmodel.NewTypeName(astmodel.NewLocalPackageReference("role", "2019-01-01"), "tutor")
 
 func Test_FilterByGroup_CorrectlySelectsStructs(t *testing.T) {
 	g := NewGomegaWithT(t)

--- a/hack/generator/pkg/config/type_matcher_test.go
+++ b/hack/generator/pkg/config/type_matcher_test.go
@@ -15,10 +15,10 @@ import (
 )
 
 // Shared test values -- note that these are used by type_transformer_test.go too
-var person2020 = astmodel.NewTypeName(astmodel.NewLocalPackageReference("party", "2020-01-01"), "person")
-var post2019 = astmodel.NewTypeName(astmodel.NewLocalPackageReference("thing", "2019-01-01"), "post")
-var student2019 = astmodel.NewTypeName(astmodel.NewLocalPackageReference("role", "2019-01-01"), "student")
-var tutor2019 = astmodel.NewTypeName(astmodel.NewLocalPackageReference("role", "2019-01-01"), "tutor")
+var person2020 = astmodel.MakeTypeName(astmodel.MakeLocalPackageReference("party", "2020-01-01"), "person")
+var post2019 = astmodel.MakeTypeName(astmodel.MakeLocalPackageReference("thing", "2019-01-01"), "post")
+var student2019 = astmodel.MakeTypeName(astmodel.MakeLocalPackageReference("role", "2019-01-01"), "student")
+var tutor2019 = astmodel.MakeTypeName(astmodel.MakeLocalPackageReference("role", "2019-01-01"), "tutor")
 
 func Test_FilterByGroup_CorrectlySelectsStructs(t *testing.T) {
 	g := NewGomegaWithT(t)

--- a/hack/generator/pkg/config/type_transformer.go
+++ b/hack/generator/pkg/config/type_transformer.go
@@ -47,8 +47,8 @@ func (transformer *TypeTransformer) Initialize() error {
 		return transformer.initializePrimitiveTypeTarget()
 	}
 
-	transformer.targetType = astmodel.NewTypeName(
-		astmodel.NewPackageReference(transformer.Target.PackagePath),
+	transformer.targetType = astmodel.MakeTypeName(
+		astmodel.MakePackageReference(transformer.Target.PackagePath),
 		transformer.Target.Name)
 	return nil
 }

--- a/hack/generator/pkg/config/type_transformer.go
+++ b/hack/generator/pkg/config/type_transformer.go
@@ -48,7 +48,7 @@ func (transformer *TypeTransformer) Initialize() error {
 	}
 
 	transformer.targetType = astmodel.NewTypeName(
-		*astmodel.NewPackageReference(transformer.Target.PackagePath),
+		astmodel.NewPackageReference(transformer.Target.PackagePath),
 		transformer.Target.Name)
 	return nil
 }
@@ -77,7 +77,7 @@ func (transformer *TypeTransformer) initializePrimitiveTypeTarget() error {
 	return nil
 }
 
-func (transformer *TypeTransformer) TransformTypeName(typeName *astmodel.TypeName) astmodel.Type {
+func (transformer *TypeTransformer) TransformTypeName(typeName astmodel.TypeName) astmodel.Type {
 	name := typeName.Name()
 
 	if typeName.PackageReference.IsLocalPackage() {

--- a/hack/generator/pkg/jsonast/jsonast.go
+++ b/hack/generator/pkg/jsonast/jsonast.go
@@ -188,11 +188,11 @@ func (scanner *SchemaScanner) GenerateDefinitions(
 		return nil, errors.Wrapf(err, "Unable to extract version for schema")
 	}
 
-	rootPackage := astmodel.NewLocalPackageReference(
+	rootPackage := astmodel.MakeLocalPackageReference(
 		scanner.idFactory.CreateGroupName(rootGroup),
 		scanner.idFactory.CreatePackageNameFromVersion(rootVersion))
 
-	rootTypeName := astmodel.NewTypeName(rootPackage, rootName)
+	rootTypeName := astmodel.MakeTypeName(rootPackage, rootName)
 
 	_, err = generateDefinitionsFor(ctx, scanner, rootTypeName, false, url, schema)
 	if err != nil {
@@ -443,8 +443,8 @@ func refHandler(ctx context.Context, scanner *SchemaScanner, schema *gojsonschem
 	isResource := isResource(url)
 
 	// produce a usable name:
-	typeName := astmodel.NewTypeName(
-		astmodel.NewLocalPackageReference(
+	typeName := astmodel.MakeTypeName(
+		astmodel.MakeLocalPackageReference(
 			scanner.idFactory.CreateGroupName(group),
 			scanner.idFactory.CreatePackageNameFromVersion(version)),
 		scanner.idFactory.CreateIdentifier(name, astmodel.Exported))

--- a/hack/generator/pkg/jsonast/jsonast.go
+++ b/hack/generator/pkg/jsonast/jsonast.go
@@ -49,28 +49,28 @@ type (
 )
 
 // findTypeDefinition looks to see if we have seen the specified definition before, returning its definition if we have.
-func (scanner *SchemaScanner) findTypeDefinition(name *astmodel.TypeName) (*astmodel.TypeDefinition, bool) {
-	result, ok := scanner.definitions[*name]
+func (scanner *SchemaScanner) findTypeDefinition(name astmodel.TypeName) (*astmodel.TypeDefinition, bool) {
+	result, ok := scanner.definitions[name]
 	return result, ok
 }
 
 // addTypeDefinition adds a type definition to emit later
 func (scanner *SchemaScanner) addTypeDefinition(def astmodel.TypeDefinition) {
-	if existing, ok := scanner.definitions[*def.Name()]; ok && existing != nil {
+	if existing, ok := scanner.definitions[def.Name()]; ok && existing != nil {
 		panic(fmt.Sprintf("overwriting existing definition for %v", def.Name()))
 	}
 
-	scanner.definitions[*def.Name()] = &def
+	scanner.definitions[def.Name()] = &def
 }
 
 // addEmptyTypeDefinition adds a placeholder definition; it should always be replaced later
-func (scanner *SchemaScanner) addEmptyTypeDefinition(name *astmodel.TypeName) {
-	scanner.definitions[*name] = nil
+func (scanner *SchemaScanner) addEmptyTypeDefinition(name astmodel.TypeName) {
+	scanner.definitions[name] = nil
 }
 
 // removeTypeDefinition removes a type definition
-func (scanner *SchemaScanner) removeTypeDefinition(name *astmodel.TypeName) {
-	delete(scanner.definitions, *name)
+func (scanner *SchemaScanner) removeTypeDefinition(name astmodel.TypeName) {
+	delete(scanner.definitions, name)
 }
 
 // Definitions for different kinds of JSON schema
@@ -192,7 +192,7 @@ func (scanner *SchemaScanner) GenerateDefinitions(
 		scanner.idFactory.CreateGroupName(rootGroup),
 		scanner.idFactory.CreatePackageNameFromVersion(rootVersion))
 
-	rootTypeName := astmodel.NewTypeName(*rootPackage, rootName)
+	rootTypeName := astmodel.NewTypeName(rootPackage, rootName)
 
 	_, err = generateDefinitionsFor(ctx, scanner, rootTypeName, false, url, schema)
 	if err != nil {
@@ -207,7 +207,7 @@ func (scanner *SchemaScanner) GenerateDefinitions(
 			panic(fmt.Sprintf("%v was nil", defName))
 		}
 
-		defs[*def.Name()] = *def
+		defs[def.Name()] = *def
 	}
 
 	return defs, nil
@@ -444,7 +444,7 @@ func refHandler(ctx context.Context, scanner *SchemaScanner, schema *gojsonschem
 
 	// produce a usable name:
 	typeName := astmodel.NewTypeName(
-		*astmodel.NewLocalPackageReference(
+		astmodel.NewLocalPackageReference(
 			scanner.idFactory.CreateGroupName(group),
 			scanner.idFactory.CreatePackageNameFromVersion(version)),
 		scanner.idFactory.CreateIdentifier(name, astmodel.Exported))
@@ -469,7 +469,7 @@ func refHandler(ctx context.Context, scanner *SchemaScanner, schema *gojsonschem
 func generateDefinitionsFor(
 	ctx context.Context,
 	scanner *SchemaScanner,
-	typeName *astmodel.TypeName,
+	typeName astmodel.TypeName,
 	isResource bool,
 	url *url.URL,
 	schema *gojsonschema.SubSchema) (astmodel.Type, error) {
@@ -556,7 +556,7 @@ func allOfHandler(ctx context.Context, scanner *SchemaScanner, schema *gojsonsch
 			// at the moment we will just take the spec type:
 			return handleType(properties, concreteType.SpecType())
 
-		case *astmodel.TypeName:
+		case astmodel.TypeName:
 			if def, ok := scanner.findTypeDefinition(concreteType); ok {
 				return handleType(properties, def.Type())
 			}
@@ -632,7 +632,7 @@ func generateOneOfUnionType(ctx context.Context, subschemas []*gojsonschema.SubS
 
 	for i, t := range results {
 		switch concreteType := t.(type) {
-		case *astmodel.TypeName:
+		case astmodel.TypeName:
 			// Just a sanity check that we've already scanned this definition
 			// TODO: Could remove this?
 			if _, ok := scanner.findTypeDefinition(concreteType); !ok {


### PR DESCRIPTION
... never pointers. This fixes a few annoyances and some gotchas with for-loops over the `Types` type.