### PR TITLE
Base type-to-file allocation on the ReferenceGraph code

### DIFF
--- a/hack/generator/pkg/astmodel/reference_graph.go
+++ b/hack/generator/pkg/astmodel/reference_graph.go
@@ -68,11 +68,12 @@ func (c ReferenceGraph) collectTypes(depth int, node TypeName, collected Reachab
 	if currentDepth, ok := collected[node]; ok {
 		// We can stop here - we've already visited this node.
 		// But first, see if we are at a lower depth:
-		if depth < currentDepth {
-			collected[node] = depth
+		if depth >= currentDepth {
+			return
 		}
 
-		return
+		// if the depth is lower than what we already had
+		// we must continue to reassign depths
 	}
 
 	collected[node] = depth

--- a/hack/generator/pkg/astmodel/reference_graph.go
+++ b/hack/generator/pkg/astmodel/reference_graph.go
@@ -44,12 +44,19 @@ func NewReferenceGraphWithResourcesAsRoots(types Types) ReferenceGraph {
 	return NewReferenceGraph(roots, references)
 }
 
+type ReachableTypes map[TypeName]int // int = depth
+
+func (reachable ReachableTypes) Contains(tn TypeName) bool {
+	_, ok := reachable[tn]
+	return ok
+}
+
 // Connected returns the set of types that are reachable from the roots.
-func (c ReferenceGraph) Connected() TypeNameSet {
+func (c ReferenceGraph) Connected() ReachableTypes {
 	// Make a non-nil set so we don't need to worry about passing it back down.
-	connectedTypes := make(TypeNameSet)
+	connectedTypes := make(ReachableTypes)
 	for node := range c.roots {
-		c.collectTypes(node, connectedTypes)
+		c.collectTypes(0, node, connectedTypes)
 	}
 
 	return connectedTypes
@@ -57,14 +64,19 @@ func (c ReferenceGraph) Connected() TypeNameSet {
 
 // collectTypes returns the set of types that are reachable from the given
 // 'node' (and places them in 'collected').
-func (c ReferenceGraph) collectTypes(node TypeName, collected TypeNameSet) {
-	if collected.Contains(node) {
+func (c ReferenceGraph) collectTypes(depth int, node TypeName, collected ReachableTypes) {
+	if currentDepth, ok := collected[node]; ok {
 		// We can stop here - we've already visited this node.
+		// But first, see if we are at a lower depth:
+		if depth < currentDepth {
+			collected[node] = depth
+		}
+
 		return
 	}
 
-	collected.Add(node)
+	collected[node] = depth
 	for child := range c.references[node] {
-		c.collectTypes(child, collected)
+		c.collectTypes(depth+1, child, collected)
 	}
 }

--- a/hack/generator/pkg/astmodel/reference_graph_test.go
+++ b/hack/generator/pkg/astmodel/reference_graph_test.go
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) Microsoft Corporation.
+ * Licensed under the MIT license.
+ */
+
+package astmodel
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+)
+
+func Test_ReferenceGraph_Gives_Correct_Depth(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	pr := MakeLocalPackageReference("group", "package")
+
+	name := func(name string) TypeName {
+		return MakeTypeName(pr, name)
+	}
+
+	names := func(ns ...string) TypeNameSet {
+		result := make(TypeNameSet)
+		for _, n := range ns {
+			result.Add(name(n))
+		}
+
+		return result
+	}
+
+	// if there are two paths to reach ‘c’, it should get the lowest depth assigned:
+
+	// r > a (1)
+	//  \ /
+	//   v
+	//   b (1/2)
+	//   |
+	//   v
+	//   c (2/3)
+
+	// the result should not be dependent on iteration order!
+
+	references := map[TypeName]TypeNameSet{
+		name("r"): names("a", "b"),
+		name("a"): names("b"),
+		name("b"): names("c"),
+	}
+
+	roots := names("r")
+
+	graph := NewReferenceGraph(roots, references)
+
+	result := graph.Connected()
+
+	g.Expect(result[name("a")]).To(Equal(1))
+	g.Expect(result[name("b")]).To(Equal(1))
+	g.Expect(result[name("c")]).To(Equal(2)) // not 3!
+}

--- a/hack/generator/pkg/astmodel/type_definition.go
+++ b/hack/generator/pkg/astmodel/type_definition.go
@@ -91,7 +91,7 @@ func (std *TypeDefinition) RequiredImports() []PackageReference {
 }
 
 // FileNameHint returns what a file that contains this name (if any) should be called
-// this is not always used as we might combine multiple definitions into one file
+// this is not always used as we often combine multiple definitions into one file
 func FileNameHint(name TypeName) string {
 	return transformToSnakeCase(name.name)
 }

--- a/hack/generator/pkg/astmodel/type_definition.go
+++ b/hack/generator/pkg/astmodel/type_definition.go
@@ -90,8 +90,8 @@ func (std *TypeDefinition) RequiredImports() []PackageReference {
 	return std.theType.RequiredImports()
 }
 
-// FileNameHint returns what a file that contains this definition (if any) should be called
+// FileNameHint returns what a file that contains this name (if any) should be called
 // this is not always used as we might combine multiple definitions into one file
-func FileNameHint(def TypeDefinition) string {
-	return transformToSnakeCase(def.Name().name)
+func FileNameHint(name TypeName) string {
+	return transformToSnakeCase(name.name)
 }

--- a/hack/generator/pkg/codegen/pipeline_strip_unused_types_test.go
+++ b/hack/generator/pkg/codegen/pipeline_strip_unused_types_test.go
@@ -43,5 +43,10 @@ func TestConnectionChecker_Avoids_Cycles(t *testing.T) {
 	graph := astmodel.NewReferenceGraph(roots, references)
 	connectedSet := graph.Connected()
 
-	g.Expect(connectedSet).To(Equal(makeSet("res1", "res2", "A", "B", "C", "D")))
+	var names astmodel.TypeNameSet
+	for name := range connectedSet {
+		names = names.Add(name)
+	}
+
+	g.Expect(names).To(Equal(makeSet("res1", "res2", "A", "B", "C", "D")))
 }


### PR DESCRIPTION
This simplifies it greatly and it no longer gets “stuck” on my WIP branch.