### PR TITLE
Add a pipeline stage to check for remaining AnyType instances

### DIFF
--- a/hack/generator/azure-arm.yaml
+++ b/hack/generator/azure-arm.yaml
@@ -23,6 +23,117 @@ exportFilters:
     group: definitions
     name: ResourceBase
     because: this type is not used
+
+  # Exclusions for packages that currently produce types including AnyType.
+  # TODO: get rid of these, either by chasing the teams generating
+  # weird json or by handling them differently in the generator.
+  - action: exclude
+    group: microsoft.authorization
+    because: it generates types containing AnyType
+  - action: exclude
+    group: microsoft.automation
+    version: v20151031
+    because: it generates types containing AnyType
+  - action: exclude
+    group: microsoft.cognitiveservices
+    version: v20170418
+    because: it generates types containing AnyType
+  - action: exclude
+    group: microsoft.compute
+    because: it generates types containing AnyType
+  - action: exclude
+    group: microsoft.compute.extensions
+    because: it generates types containing AnyType
+  - action: exclude
+    group: microsoft.compute.galleries
+    because: it generates types containing AnyType
+  - action: exclude
+    group: microsoft.containerinstance
+    because: it generates types containing AnyType
+  - action: exclude
+    group: microsoft.containerregistry
+    version: v20171001
+    because: it generates types containing AnyType
+  - action: exclude
+    group: microsoft.datafactory
+    version: v20180601
+    because: it generates types containing AnyType
+  - action: exclude
+    group: microsoft.eventgrid
+    because: it generates types containing AnyType
+  - action: exclude
+    group: microsoft.importexport
+    version: v20161101
+    because: it generates types containing AnyType
+  - action: exclude
+    group: microsoft.insights
+    version: v20180301
+    because: it generates types containing AnyType
+  - action: exclude
+    group: microsoft.keyvault
+    version: v20150601
+    because: it generates types containing AnyType
+  - action: exclude
+    group: microsoft.kusto
+    because: it generates types containing AnyType
+  - action: exclude
+    group: microsoft.logic
+    because: it generates types containing AnyType
+  - action: exclude
+    group: microsoft.machinelearning
+    version: v20170101
+    because: it generates types containing AnyType
+  - action: exclude
+    group: microsoft.machinelearningservices
+    version: v20200101
+    because: it generates types containing AnyType
+  - action: exclude
+    group: microsoft.migrate
+    version: v20191001
+    because: it generates types containing AnyType
+  - action: exclude
+    group: microsoft.netapp
+    because: it generates types containing AnyType
+  - action: exclude
+    group: microsoft.network
+    because: it generates types containing AnyType
+  - action: exclude
+    group: microsoft.notificationhubs
+    version: v20150401
+    because: it generates types containing AnyType
+  - action: exclude
+    group: microsoft.recoveryservices
+    because: it generates types containing AnyType
+  - action: exclude
+    group: microsoft.relay
+    because: it generates types containing AnyType
+  - action: exclude
+    group: microsoft.resources
+    because: it generates types containing AnyType
+  - action: exclude
+    group: microsoft.servicebus
+    version: v20170401
+    because: it generates types containing AnyType
+  - action: exclude
+    group: microsoft.storage
+    version: v20190601
+    because: it generates types containing AnyType
+  - action: exclude
+    group: microsoft.streamanalytics
+    version: v20160301
+    because: it generates types containing AnyType
+  - action: exclude
+    group: microsoft.visualstudio
+    version: v20140226
+    because: it generates types containing AnyType
+  - action: exclude
+    group: microsoft.vmwarecloudsimple
+    version: v20190401
+    because: it generates types containing AnyType
+  - action: exclude
+    group: microsoft.web
+    because: it generates types containing AnyType
+
 typeTransformers:
   - group: definitions
     name: NumberOrExpression

--- a/hack/generator/pkg/codegen/code_generator.go
+++ b/hack/generator/pkg/codegen/code_generator.go
@@ -60,6 +60,7 @@ func corePipelineStages(idFactory astmodel.IdentifierFactory, configuration *con
 		improveResourcePluralization(),
 		applyExportFilters(configuration),
 		stripUnreferencedTypeDefinitions(),
+		checkForAnyType(),
 	}
 }
 

--- a/hack/generator/pkg/codegen/codegen_test.go
+++ b/hack/generator/pkg/codegen/codegen_test.go
@@ -103,6 +103,8 @@ func runGoldenTest(t *testing.T, path string) {
 			pipeline = append(pipeline, loadSchemaIntoTypes(idFactory, config, testSchemaLoader))
 		} else if strings.HasPrefix(stage.Name, "Delete generated code from") {
 			continue // Skip this
+		} else if strings.HasPrefix(stage.Name, "Check for rogue AnyTypes") {
+			continue // Skip this
 		} else if strings.HasPrefix(stage.Name, "Export packages") {
 			pipeline = append(pipeline, exportPackagesTestPipelineStage)
 		} else if strings.HasPrefix(stage.Name, "Strip unreferenced types") {

--- a/hack/generator/pkg/codegen/pipeline_apply_export_filters.go
+++ b/hack/generator/pkg/codegen/pipeline_apply_export_filters.go
@@ -36,7 +36,7 @@ func filterTypes(
 
 		switch shouldExport {
 		case config.Skip:
-			klog.V(2).Infof("Skipping %s because %s", defName, reason)
+			klog.V(3).Infof("Skipping %s because %s", defName, reason)
 
 		case config.Export:
 			if reason == "" {

--- a/hack/generator/pkg/codegen/pipeline_check_for_anytype.go
+++ b/hack/generator/pkg/codegen/pipeline_check_for_anytype.go
@@ -1,0 +1,83 @@
+/*
+ * Copyright (c) Microsoft Corporation.
+ * Licensed under the MIT license.
+ */
+
+package codegen
+
+import (
+	"context"
+	"sort"
+	"strings"
+
+	"github.com/pkg/errors"
+	"k8s.io/klog/v2"
+
+	"github.com/Azure/k8s-infra/hack/generator/pkg/astmodel"
+)
+
+// checkForAnyType returns a stage that will return an error if there
+// are any uses of AnyType remaining in the passed defs.
+func checkForAnyType() PipelineStage {
+	return PipelineStage{
+		"Check for rogue AnyTypes",
+		func(ctx context.Context, defs astmodel.Types) (astmodel.Types, error) {
+			var badNames []astmodel.TypeName
+			for name, def := range defs {
+				if containsAnyType(def.Type()) {
+					badNames = append(badNames, name)
+				}
+			}
+
+			if len(badNames) == 0 {
+				return defs, nil
+			}
+
+			packages, err := groupNamesIntoPackages(badNames)
+			if err != nil {
+				return nil, errors.Wrap(err, "summarising bad types")
+			}
+			return nil, errors.Errorf("AnyTypes found - add exclusions for: %s", strings.Join(packages, ", "))
+		},
+	}
+}
+
+func containsAnyType(theType astmodel.Type) bool {
+	var found bool
+	visitor := astmodel.MakeTypeVisitor()
+	visitor.VisitPrimitive = func(_ *astmodel.TypeVisitor, it *astmodel.PrimitiveType, _ interface{}) astmodel.Type {
+		if it == astmodel.AnyType {
+			found = true
+		}
+		return it
+	}
+	visitor.Visit(theType, nil)
+	return found
+}
+
+func groupNamesIntoPackages(names []astmodel.TypeName) ([]string, error) {
+	grouped := make(map[string][]string)
+	for _, name := range names {
+		group, version, err := name.PackageReference.GroupAndPackage()
+		if err != nil {
+			return nil, err
+		}
+		groupVersion := group + "/" + version
+		grouped[groupVersion] = append(grouped[groupVersion], name.Name())
+	}
+
+	var groupNames []string
+	for groupName := range grouped {
+		groupNames = append(groupNames, groupName)
+	}
+	sort.Strings(groupNames)
+
+	if klog.V(2).Enabled() {
+		for _, groupName := range groupNames {
+			sort.Strings(grouped[groupName])
+			klog.Infof("%s: %v", groupName, grouped[groupName])
+		}
+	}
+
+	return groupNames, nil
+}

--- a/hack/generator/pkg/codegen/pipeline_check_for_anytype_test.go
+++ b/hack/generator/pkg/codegen/pipeline_check_for_anytype_test.go
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) Microsoft Corporation.
+ * Licensed under the MIT license.
+ */
+
+package codegen
+
+import (
+	"context"
+	"testing"
+
+	"github.com/Azure/k8s-infra/hack/generator/pkg/astmodel"
+
+	. "github.com/onsi/gomega"
+)
+
+func TestFindsAnytypes(t *testing.T) {
+	g := NewGomegaWithT(t)
+	p1 := astmodel.MakeLocalPackageReference("horo.logy", "v20200730")
+	p2 := astmodel.MakeLocalPackageReference("road.train", "v20200730")
+	p3 := astmodel.MakeLocalPackageReference("wah.wah", "v20200730")
+
+	defs := make(astmodel.Types)
+	add := func(p astmodel.PackageReference, n string, t astmodel.Type) {
+		defs.Add(astmodel.MakeTypeDefinition(astmodel.MakeTypeName(p, n), t))
+	}
+	// A couple of types in the same package...
+	add(p1, "A", astmodel.AnyType)
+	add(p1, "B", astmodel.NewObjectType().WithProperties(
+		astmodel.NewPropertyDefinition("Field1", "field1", astmodel.BoolType),
+		astmodel.NewPropertyDefinition("Field2", "field2", astmodel.AnyType),
+	))
+	// One in another...
+	add(p2, "A", astmodel.NewMapType(astmodel.StringType, astmodel.AnyType))
+	// One that's fine.
+	add(p3, "C", astmodel.NewArrayType(astmodel.IntType))
+
+	results, err := checkForAnyType().Action(context.Background(), defs)
+
+	g.Expect(results).To(HaveLen(0))
+	g.Expect(err).To(MatchError("AnyTypes found - add exclusions for: horo.logy/v20200730, road.train/v20200730"))
+}

--- a/hack/generator/pkg/jsonast/jsonast.go
+++ b/hack/generator/pkg/jsonast/jsonast.go
@@ -452,7 +452,7 @@ func refHandler(ctx context.Context, scanner *SchemaScanner, schema *gojsonschem
 	// Prune the graph according to the configuration
 	shouldPrune, because := scanner.configuration.ShouldPrune(typeName)
 	if shouldPrune == config.Prune {
-		klog.V(2).Infof("Skipping %s because %s", typeName, because)
+		klog.V(3).Infof("Skipping %s because %s", typeName, because)
 		return nil, nil // Skip entirely
 	}
 


### PR DESCRIPTION
Raises an error with the containing packages (so they can be added to the filtering) if any are found.

Added exclusions in azure-arm.yaml for all groups/versions that fail at the moment. This gives us a list of the packages that need to be worked through.

If you want to see the specific types containing AnyType run with verbosity level 2 or higher. (Adjusted the type filtering logging
level up to 3 to avoid drowning in skipped types at the same time.)