### PR TITLE
Update CodeGenerationContext to have package references

### DIFF
--- a/hack/generator/pkg/astmodel/code_generation_context.go
+++ b/hack/generator/pkg/astmodel/code_generation_context.go
@@ -5,7 +5,9 @@
 
 package astmodel
 
-import "github.com/pkg/errors"
+import (
+	"github.com/pkg/errors"
+)
 
 // CodeGenerationContext stores context about the location code-generation is occurring.
 // This is required because some things (such as specific field types) are impacted by the context
@@ -14,16 +16,25 @@ import "github.com/pkg/errors"
 type CodeGenerationContext struct {
 	packageImports map[PackageReference]PackageImport
 	currentPackage PackageReference
+
+	generatedPackages map[PackageReference]*PackageDefinition
 }
 
 // New CodeGenerationContext creates a new immutable code generation context
-func NewCodeGenerationContext(currentPackage PackageReference, packageImports map[PackageImport]struct{}) *CodeGenerationContext {
+func NewCodeGenerationContext(
+	currentPackage PackageReference,
+	packageImports map[PackageImport]struct{},
+	generatedPackages map[PackageReference]*PackageDefinition) *CodeGenerationContext {
+
 	packageImportsMap := make(map[PackageReference]PackageImport)
 	for imp := range packageImports {
 		packageImportsMap[imp.PackageReference] = imp
 	}
 
-	return &CodeGenerationContext{currentPackage: currentPackage, packageImports: packageImportsMap}
+	return &CodeGenerationContext{
+		currentPackage:    currentPackage,
+		packageImports:    packageImportsMap,
+		generatedPackages: generatedPackages}
 }
 
 // PackageImports returns the set of package references in the current context
@@ -45,4 +56,31 @@ func (codeGenContext *CodeGenerationContext) GetImportedPackageName(reference Pa
 	}
 
 	return packageImport.PackageName(), nil
+}
+
+// GetGeneratedPackage gets a reference to the PackageDefinition referred to by the provided reference
+func (codeGenContext *CodeGenerationContext) GetGeneratedPackage(reference PackageReference) (*PackageDefinition, error) {
+
+	// Make sure that we're actually importing that package -- don't want to allow references to things we aren't importing
+	_, err := codeGenContext.GetImportedPackageName(reference)
+	if !reference.Equals(codeGenContext.currentPackage) && err != nil {
+		return nil, err
+	}
+
+	packageDef, ok := codeGenContext.generatedPackages[reference]
+	if !ok {
+		return nil, errors.Errorf("%v not imported", reference)
+	}
+	return packageDef, nil
+}
+
+// GetImportedDefinition looks up a particular type definition in a package referenced by this context
+func (codeGenContext *CodeGenerationContext) GetImportedDefinition(typeName TypeName) (TypeDefinition, error) {
+	pkg, err := codeGenContext.GetGeneratedPackage(typeName.PackageReference)
+
+	if err != nil {
+		return TypeDefinition{}, err
+	}
+
+	return pkg.GetDefinition(typeName)
 }

--- a/hack/generator/pkg/astmodel/file_definition.go
+++ b/hack/generator/pkg/astmodel/file_definition.go
@@ -26,10 +26,13 @@ type FileDefinition struct {
 	packageReference PackageReference
 	// definitions to include in this file
 	definitions []TypeDefinition
+
+	// other packages whose references may be needed for code generation
+	generatedPackages map[PackageReference]*PackageDefinition
 }
 
 // NewFileDefinition creates a file definition containing specified definitions
-func NewFileDefinition(packageRef PackageReference, definitions ...TypeDefinition) *FileDefinition {
+func NewFileDefinition(packageRef PackageReference, definitions []TypeDefinition, generatedPackages map[PackageReference]*PackageDefinition) *FileDefinition {
 
 	// Topological sort of the definitions, putting them in order of reference
 	ranks := calcRanks(definitions)
@@ -44,7 +47,7 @@ func NewFileDefinition(packageRef PackageReference, definitions ...TypeDefinitio
 	})
 
 	// TODO: check that all definitions are from same package
-	return &FileDefinition{packageRef, definitions}
+	return &FileDefinition{packageRef, definitions, generatedPackages}
 }
 
 // Calculate the ranks for each type
@@ -182,7 +185,7 @@ func (file *FileDefinition) AsAst() ast.Node {
 	packageReferences := file.generateImports()
 
 	// Create context from imports
-	codeGenContext := NewCodeGenerationContext(file.packageReference, packageReferences)
+	codeGenContext := NewCodeGenerationContext(file.packageReference, packageReferences, file.generatedPackages)
 
 	// Create import header if needed
 	if len(packageReferences) > 0 {

--- a/hack/generator/pkg/astmodel/file_definition_test.go
+++ b/hack/generator/pkg/astmodel/file_definition_test.go
@@ -24,7 +24,7 @@ func Test_NewFileDefinition_GivenValues_InitializesFields(t *testing.T) {
 		NewStringPropertyDefinition("knownAs"),
 		NewStringPropertyDefinition("familyName"),
 	)
-	file := NewFileDefinition(person.Name().PackageReference, person)
+	file := NewFileDefinition(person.Name().PackageReference, []TypeDefinition{person}, nil)
 
 	g.Expect(file.packageReference).To(Equal(person.Name().PackageReference))
 	g.Expect(file.definitions).To(HaveLen(1))

--- a/hack/generator/pkg/astmodel/package_definition_test.go
+++ b/hack/generator/pkg/astmodel/package_definition_test.go
@@ -18,12 +18,14 @@ func TestPackageGroupVersion_IncludesGeneratorVersion(t *testing.T) {
 	g := NewGomegaWithT(t)
 
 	pkg := NewPackageDefinition("longest-johns", "santiana", "latest-version")
+	pkgs := make(map[PackageReference]*PackageDefinition)
+	pkgs[MakeLocalPackageReference(pkg.GroupName, pkg.PackageName)] = pkg
 
 	destDir, err := ioutil.TempDir("", "package_definition_test")
 	g.Expect(err).To(BeNil())
 	defer os.RemoveAll(destDir)
 
-	fileCount, err := pkg.EmitDefinitions(destDir)
+	fileCount, err := pkg.EmitDefinitions(destDir, pkgs)
 	g.Expect(err).To(BeNil())
 	g.Expect(fileCount).To(Equal(0))
 


### PR DESCRIPTION
  - These references may be used by AsAst methods to learn more details
    about the structure of the packages being referenced (to aid in
    code generation).