### PR TITLE
Add reference ids to PipelineStage

### DIFF
--- a/hack/generator/pkg/codegen/code_generator.go
+++ b/hack/generator/pkg/codegen/code_generator.go
@@ -73,10 +73,10 @@ func (generator *CodeGenerator) Generate(ctx context.Context) error {
 	var err error
 
 	for i, stage := range generator.pipeline {
-		klog.V(0).Infof("Pipeline stage %d/%d: %s", i+1, len(generator.pipeline), stage.Name)
+		klog.V(0).Infof("Pipeline stage %d/%d: %s", i+1, len(generator.pipeline), stage.description)
 		defs, err = stage.Action(ctx, defs)
 		if err != nil {
-			return errors.Wrapf(err, "Failed during pipeline stage %d/%d: %s", i+1, len(generator.pipeline), stage.Name)
+			return errors.Wrapf(err, "Failed during pipeline stage %d/%d: %s", i+1, len(generator.pipeline), stage.description)
 		}
 	}
 

--- a/hack/generator/pkg/codegen/pipeline_apply_export_filters.go
+++ b/hack/generator/pkg/codegen/pipeline_apply_export_filters.go
@@ -15,12 +15,12 @@ import (
 
 // applyExportFilters creates a PipelineStage to reduce our set of types for export
 func applyExportFilters(configuration *config.Configuration) PipelineStage {
-	return PipelineStage{
+	return MakePipelineStage(
+		"filterTypes",
 		"Filter generated types",
 		func(ctx context.Context, types astmodel.Types) (astmodel.Types, error) {
 			return filterTypes(configuration, types)
-		},
-	}
+		})
 }
 
 // filterTypes applies the configuration include/exclude filters to the generated definitions

--- a/hack/generator/pkg/codegen/pipeline_check_for_anytype.go
+++ b/hack/generator/pkg/codegen/pipeline_check_for_anytype.go
@@ -19,7 +19,8 @@ import (
 // checkForAnyType returns a stage that will return an error if there
 // are any uses of AnyType remaining in the passed defs.
 func checkForAnyType() PipelineStage {
-	return PipelineStage{
+	return MakePipelineStage(
+		"rogueCheck",
 		"Check for rogue AnyTypes",
 		func(ctx context.Context, defs astmodel.Types) (astmodel.Types, error) {
 			var badNames []astmodel.TypeName
@@ -38,8 +39,7 @@ func checkForAnyType() PipelineStage {
 				return nil, errors.Wrap(err, "summarising bad types")
 			}
 			return nil, errors.Errorf("AnyTypes found - add exclusions for: %s", strings.Join(packages, ", "))
-		},
-	}
+		})
 }
 
 func containsAnyType(theType astmodel.Type) bool {

--- a/hack/generator/pkg/codegen/pipeline_delete_generated_code.go
+++ b/hack/generator/pkg/codegen/pipeline_delete_generated_code.go
@@ -26,7 +26,7 @@ import (
 func deleteGeneratedCode(outputFolder string) PipelineStage {
 	return MakePipelineStage(
 		"deleteGenerated",
-		"Delete generated code from " + outputFolder,
+		"Delete generated code from "+outputFolder,
 		func(ctx context.Context, types astmodel.Types) (astmodel.Types, error) {
 			err := deleteGeneratedCodeFromFolder(ctx, outputFolder)
 			if err != nil {

--- a/hack/generator/pkg/codegen/pipeline_delete_generated_code.go
+++ b/hack/generator/pkg/codegen/pipeline_delete_generated_code.go
@@ -24,7 +24,8 @@ import (
 
 // deleteGeneratedCode creates a pipeline stage for cleanup of our output folder prior to generating files
 func deleteGeneratedCode(outputFolder string) PipelineStage {
-	return PipelineStage{
+	return MakePipelineStage(
+		"deleteGenerated",
 		"Delete generated code from " + outputFolder,
 		func(ctx context.Context, types astmodel.Types) (astmodel.Types, error) {
 			err := deleteGeneratedCodeFromFolder(ctx, outputFolder)
@@ -33,7 +34,7 @@ func deleteGeneratedCode(outputFolder string) PipelineStage {
 			}
 
 			return types, nil
-		}}
+		})
 }
 
 func deleteGeneratedCodeFromFolder(ctx context.Context, outputFolder string) error {

--- a/hack/generator/pkg/codegen/pipeline_export_generated_code.go
+++ b/hack/generator/pkg/codegen/pipeline_export_generated_code.go
@@ -20,7 +20,8 @@ import (
 // exportPackages creates a PipelineStage to export our generated code as a set of packages
 func exportPackages(outputPath string) PipelineStage {
 	description := fmt.Sprintf("Export packages to %q", outputPath)
-	return PipelineStage{
+	return MakePipelineStage(
+		"exportPackages",
 		description,
 		func(ctx context.Context, types astmodel.Types) (astmodel.Types, error) {
 			packages, err := CreatePackagesForDefinitions(types)
@@ -39,8 +40,7 @@ func exportPackages(outputPath string) PipelineStage {
 			}
 
 			return types, nil
-		},
-	}
+		})
 }
 
 // CreatePackagesForDefinitions groups type definitions into packages

--- a/hack/generator/pkg/codegen/pipeline_improve_resource_pluralization.go
+++ b/hack/generator/pkg/codegen/pipeline_improve_resource_pluralization.go
@@ -14,9 +14,10 @@ import (
 // improveResourcePluralization improves pluralization for resources
 func improveResourcePluralization() PipelineStage {
 
-	return PipelineStage{
-		Name: "Improve resource pluralization",
-		Action: func(ctx context.Context, types astmodel.Types) (astmodel.Types, error) {
+	return MakePipelineStage(
+		"pluralizeNames",
+		"Improve resource pluralization",
+		func(ctx context.Context, types astmodel.Types) (astmodel.Types, error) {
 
 			result := make(astmodel.Types)
 			for _, typeDef := range types {
@@ -37,6 +38,5 @@ func improveResourcePluralization() PipelineStage {
 			}
 
 			return result, nil
-		},
-	}
+		})
 }

--- a/hack/generator/pkg/codegen/pipeline_load_schema.go
+++ b/hack/generator/pkg/codegen/pipeline_load_schema.go
@@ -99,9 +99,10 @@ func loadSchemaIntoTypes(
 	schemaLoader schemaLoader) PipelineStage {
 	source := configuration.SchemaURL
 
-	return PipelineStage{
-		Name: "Load and walk schema",
-		Action: func(ctx context.Context, types astmodel.Types) (astmodel.Types, error) {
+	return MakePipelineStage(
+		"loadSchema",
+		"Load and walk schema",
+		func(ctx context.Context, types astmodel.Types) (astmodel.Types, error) {
 			klog.V(0).Infof("Loading JSON schema %q", source)
 
 			schema, err := schemaLoader(ctx, source)
@@ -119,6 +120,5 @@ func loadSchemaIntoTypes(
 			}
 
 			return defs, nil
-		},
-	}
+		})
 }

--- a/hack/generator/pkg/codegen/pipeline_name_types_for_crd.go
+++ b/hack/generator/pkg/codegen/pipeline_name_types_for_crd.go
@@ -14,9 +14,10 @@ import (
 // nameTypesForCRD - for CRDs all inner enums and objects must be named, so we do it here
 func nameTypesForCRD(idFactory astmodel.IdentifierFactory) PipelineStage {
 
-	return PipelineStage{
-		Name: "Name inner types for CRD",
-		Action: func(ctx context.Context, types astmodel.Types) (astmodel.Types, error) {
+	return MakePipelineStage(
+		"nameTypes",
+		"Name inner types for CRD",
+		func(ctx context.Context, types astmodel.Types) (astmodel.Types, error) {
 
 			result := make(astmodel.Types)
 
@@ -43,8 +44,7 @@ func nameTypesForCRD(idFactory astmodel.IdentifierFactory) PipelineStage {
 			}
 
 			return result, nil
-		},
-	}
+		})
 }
 
 func nameInnerTypes(

--- a/hack/generator/pkg/codegen/pipeline_remove_type_aliases.go
+++ b/hack/generator/pkg/codegen/pipeline_remove_type_aliases.go
@@ -15,7 +15,8 @@ import (
 
 // removeTypeAliases creates a pipeline stage removing type aliases
 func removeTypeAliases() PipelineStage {
-	return PipelineStage{
+	return MakePipelineStage(
+		"removeAliases",
 		"Remove type aliases",
 		func(ctx context.Context, types astmodel.Types) (astmodel.Types, error) {
 			visitor := astmodel.MakeTypeVisitor()
@@ -32,7 +33,7 @@ func removeTypeAliases() PipelineStage {
 			}
 
 			return result, nil
-		}}
+		})
 }
 
 func resolveTypeName(visitor *astmodel.TypeVisitor, name astmodel.TypeName, types astmodel.Types) astmodel.Type {

--- a/hack/generator/pkg/codegen/pipeline_stage.go
+++ b/hack/generator/pkg/codegen/pipeline_stage.go
@@ -17,7 +17,7 @@ type PipelineStage struct {
 	// Unique identifier used to manipulate the pipeline from code
 	id string
 	// Description of the stage to use when logging
-	description   string
+	description string
 	// Stage implementation
 	Action func(context.Context, astmodel.Types) (astmodel.Types, error)
 }
@@ -26,7 +26,7 @@ type PipelineStage struct {
 func MakePipelineStage(
 	id string,
 	description string,
-	action func(context.Context, astmodel.Types) (astmodel.Types, error)	) PipelineStage {
+	action func(context.Context, astmodel.Types) (astmodel.Types, error)) PipelineStage {
 	return PipelineStage{
 		id:          id,
 		description: description,

--- a/hack/generator/pkg/codegen/pipeline_stage.go
+++ b/hack/generator/pkg/codegen/pipeline_stage.go
@@ -14,6 +14,27 @@ import (
 // PipelineStage represents a composable stage of processing that can transform or process the set
 // of generated types
 type PipelineStage struct {
-	Name   string
+	// Unique identifier used to manipulate the pipeline from code
+	id string
+	// Description of the stage to use when logging
+	description   string
+	// Stage implementation
 	Action func(context.Context, astmodel.Types) (astmodel.Types, error)
+}
+
+// MakePipelineStage creates a new pipeline stage that's ready for execution
+func MakePipelineStage(
+	id string,
+	description string,
+	action func(context.Context, astmodel.Types) (astmodel.Types, error)	) PipelineStage {
+	return PipelineStage{
+		id:          id,
+		description: description,
+		Action:      action,
+	}
+}
+
+// HasId returns true if this stage has the specified id, false otherwise
+func (stage *PipelineStage) HasId(id string) bool {
+	return stage.id == id
 }

--- a/hack/generator/pkg/codegen/pipeline_strip_unused_types.go
+++ b/hack/generator/pkg/codegen/pipeline_strip_unused_types.go
@@ -12,13 +12,13 @@ import (
 )
 
 func stripUnreferencedTypeDefinitions() PipelineStage {
-	return PipelineStage{
+	return MakePipelineStage(
+		"stripUnreferenced",
 		"Strip unreferenced types",
 		func(ctx context.Context, defs astmodel.Types) (astmodel.Types, error) {
 			roots := astmodel.CollectResourceDefinitions(defs)
 			return StripUnusedDefinitions(roots, defs)
-		},
-	}
+		})
 }
 
 // StripUnusedDefinitions removes all types that aren't in roots or


### PR DESCRIPTION
To avoid the need to identify pipeline stages by doing string comparisons on their descriptions (which is brittle), I've restructured `PipeLineStage` to have an explicit `id`, along with a helper method `HasId()`.
