### PR TITLE
Allow for multiple lines of description for definitions

### DIFF
--- a/hack/generator/pkg/astmodel/array_type.go
+++ b/hack/generator/pkg/astmodel/array_type.go
@@ -22,7 +22,7 @@ func NewArrayType(element Type) *ArrayType {
 // assert we implemented Type correctly
 var _ Type = (*ArrayType)(nil)
 
-func (array *ArrayType) AsDeclarations(codeGenerationContext *CodeGenerationContext, name TypeName, description *string) []ast.Decl {
+func (array *ArrayType) AsDeclarations(codeGenerationContext *CodeGenerationContext, name TypeName, description []string) []ast.Decl {
 	return AsSimpleDeclarations(codeGenerationContext, name, description, array)
 }
 

--- a/hack/generator/pkg/astmodel/comments.go
+++ b/hack/generator/pkg/astmodel/comments.go
@@ -13,9 +13,21 @@ import (
 
 // Utility methods for adding comments
 
+func addDocComments(commentList *[]*ast.Comment, comments []string, width int) {
+	for _, comment := range comments {
+		// Skip empty comments
+		if comment == "" {
+			continue
+		}
+
+		addDocComment(commentList, comment, width)
+	}
+}
+
 func addDocComment(commentList *[]*ast.Comment, comment string, width int) {
 	for _, c := range formatDocComment(comment, width) {
 		line := strings.TrimSpace(c)
+
 		if !strings.HasPrefix(line, "//") {
 			line = "//" + line
 		}

--- a/hack/generator/pkg/astmodel/enum_type.go
+++ b/hack/generator/pkg/astmodel/enum_type.go
@@ -34,7 +34,7 @@ func NewEnumType(baseType *PrimitiveType, options []EnumValue) *EnumType {
 }
 
 // AsDeclarations converts the EnumType to a series of Go AST Decls
-func (enum *EnumType) AsDeclarations(codeGenerationContext *CodeGenerationContext, name TypeName, description *string) []ast.Decl {
+func (enum *EnumType) AsDeclarations(codeGenerationContext *CodeGenerationContext, name TypeName, description []string) []ast.Decl {
 	var specs []ast.Spec
 	for _, v := range enum.options {
 		s := enum.createValueDeclaration(name, v)
@@ -54,7 +54,10 @@ func (enum *EnumType) AsDeclarations(codeGenerationContext *CodeGenerationContex
 	return result
 }
 
-func (enum *EnumType) createBaseDeclaration(codeGenerationContext *CodeGenerationContext, name TypeName, description *string) ast.Decl {
+func (enum *EnumType) createBaseDeclaration(
+	codeGenerationContext *CodeGenerationContext,
+	name TypeName,
+	description []string) ast.Decl {
 	identifier := ast.NewIdent(name.Name())
 
 	typeSpecification := &ast.TypeSpec{
@@ -70,11 +73,7 @@ func (enum *EnumType) createBaseDeclaration(codeGenerationContext *CodeGeneratio
 		},
 	}
 
-	if description != nil {
-		declaration.Doc.List = append(
-			declaration.Doc.List,
-			&ast.Comment{Text: "\n/*" + *description + "*/"})
-	}
+	addDocComments(&declaration.Doc.List, description, 120)
 
 	validationComment := GenerateKubebuilderComment(enum.CreateValidation())
 	declaration.Doc.List = append(

--- a/hack/generator/pkg/astmodel/map_type.go
+++ b/hack/generator/pkg/astmodel/map_type.go
@@ -38,7 +38,7 @@ func NewStringMapType(value Type) *MapType {
 // assert that we implemented Type correctly
 var _ Type = (*MapType)(nil)
 
-func (m *MapType) AsDeclarations(codeGenerationContext *CodeGenerationContext, name TypeName, description *string) []ast.Decl {
+func (m *MapType) AsDeclarations(codeGenerationContext *CodeGenerationContext, name TypeName, description []string) []ast.Decl {
 	return AsSimpleDeclarations(codeGenerationContext, name, description, m)
 }
 

--- a/hack/generator/pkg/astmodel/object_type.go
+++ b/hack/generator/pkg/astmodel/object_type.go
@@ -31,7 +31,7 @@ func NewObjectType() *ObjectType {
 	}
 }
 
-func (objectType *ObjectType) AsDeclarations(codeGenerationContext *CodeGenerationContext, name TypeName, description *string) []ast.Decl {
+func (objectType *ObjectType) AsDeclarations(codeGenerationContext *CodeGenerationContext, name TypeName, description []string) []ast.Decl {
 	identifier := ast.NewIdent(name.Name())
 	declaration := &ast.GenDecl{
 		Tok: token.TYPE,
@@ -44,9 +44,7 @@ func (objectType *ObjectType) AsDeclarations(codeGenerationContext *CodeGenerati
 		},
 	}
 
-	if description != nil {
-		addDocComment(&declaration.Doc.List, *description, 200)
-	}
+	addDocComments(&declaration.Doc.List, description, 200)
 
 	result := []ast.Decl{declaration}
 	result = append(result, objectType.generateMethodDecls(codeGenerationContext, name)...)

--- a/hack/generator/pkg/astmodel/optional_type.go
+++ b/hack/generator/pkg/astmodel/optional_type.go
@@ -41,7 +41,7 @@ func isTypeOptional(t Type) bool {
 // assert we implemented Type correctly
 var _ Type = (*OptionalType)(nil)
 
-func (optional *OptionalType) AsDeclarations(codeGenerationContext *CodeGenerationContext, name TypeName, description *string) []ast.Decl {
+func (optional *OptionalType) AsDeclarations(codeGenerationContext *CodeGenerationContext, name TypeName, description []string) []ast.Decl {
 	return AsSimpleDeclarations(codeGenerationContext, name, description, optional)
 }
 

--- a/hack/generator/pkg/astmodel/primitive_type.go
+++ b/hack/generator/pkg/astmodel/primitive_type.go
@@ -33,12 +33,12 @@ var AnyType = &PrimitiveType{"interface{}"}
 var _ Type = (*PrimitiveType)(nil)
 
 // AsType implements Type for PrimitiveType returning an abstract syntax tree
-func (prim *PrimitiveType) AsType(codeGenerationContext *CodeGenerationContext) ast.Expr {
+func (prim *PrimitiveType) AsType(_ *CodeGenerationContext) ast.Expr {
 	return ast.NewIdent(prim.name)
 }
 
-func (prim *PrimitiveType) AsDeclarations(codeGenerationContext *CodeGenerationContext, name TypeName, description []string) []ast.Decl {
-	return AsSimpleDeclarations(codeGenerationContext, name, description, prim)
+func (prim *PrimitiveType) AsDeclarations(genContext *CodeGenerationContext, name TypeName, description []string) []ast.Decl {
+	return AsSimpleDeclarations(genContext, name, description, prim)
 }
 
 // RequiredImports returns a list of package required by this

--- a/hack/generator/pkg/astmodel/primitive_type.go
+++ b/hack/generator/pkg/astmodel/primitive_type.go
@@ -37,8 +37,8 @@ func (prim *PrimitiveType) AsType(codeGenerationContext *CodeGenerationContext) 
 	return ast.NewIdent(prim.name)
 }
 
-func (prim *PrimitiveType) AsDeclarations(CodeGenerationContext *CodeGenerationContext, name TypeName, description *string) []ast.Decl {
-	return AsSimpleDeclarations(CodeGenerationContext, name, description, prim)
+func (prim *PrimitiveType) AsDeclarations(codeGenerationContext *CodeGenerationContext, name TypeName, description []string) []ast.Decl {
+	return AsSimpleDeclarations(codeGenerationContext, name, description, prim)
 }
 
 // RequiredImports returns a list of package required by this

--- a/hack/generator/pkg/astmodel/resource.go
+++ b/hack/generator/pkg/astmodel/resource.go
@@ -92,11 +92,11 @@ func (definition *ResourceType) RequiredImports() []PackageReference {
 }
 
 // AsDeclarations converts the resource type to a set of go declarations
-func (definition *ResourceType) AsDeclarations(codeGenerationContext *CodeGenerationContext, typeName TypeName, description *string) []ast.Decl {
+func (definition *ResourceType) AsDeclarations(codeGenerationContext *CodeGenerationContext, name TypeName, description []string) []ast.Decl {
 
 	packageName, err := codeGenerationContext.GetImportedPackageName(MetaV1PackageReference)
 	if err != nil {
-		panic(errors.Wrapf(err, "resource definition for %s failed to import package", typeName))
+		panic(errors.Wrapf(err, "resource definition for %s failed to import package", name))
 	}
 
 	typeMetaField := defineField("", ast.NewIdent(fmt.Sprintf("%s.TypeMeta", packageName)), "`json:\",inline\"`")
@@ -119,7 +119,7 @@ func (definition *ResourceType) AsDeclarations(codeGenerationContext *CodeGenera
 		fields = append(fields, defineField("Status", definition.status.AsType(codeGenerationContext), "`json:\"spec,omitempty\"`"))
 	}
 
-	resourceIdentifier := ast.NewIdent(typeName.Name())
+	resourceIdentifier := ast.NewIdent(name.Name())
 	resourceTypeSpec := &ast.TypeSpec{
 		Name: resourceIdentifier,
 		Type: &ast.StructType{
@@ -140,9 +140,7 @@ func (definition *ResourceType) AsDeclarations(codeGenerationContext *CodeGenera
 		})
 	}
 
-	if description != nil {
-		addDocComment(&comments, *description, 200)
-	}
+	addDocComments(&comments, description, 200)
 
 	return []ast.Decl{
 		&ast.GenDecl{

--- a/hack/generator/pkg/astmodel/type.go
+++ b/hack/generator/pkg/astmodel/type.go
@@ -25,7 +25,7 @@ type Type interface {
 	AsType(codeGenerationContext *CodeGenerationContext) ast.Expr
 
 	// AsDeclarations renders as a Go abstract syntax tree for a declaration
-	AsDeclarations(codeGenerationContext *CodeGenerationContext, name TypeName, description *string) []ast.Decl
+	AsDeclarations(codeGenerationContext *CodeGenerationContext, name TypeName, description []string) []ast.Decl
 
 	// Equals returns true if the passed type is the same as this one, false otherwise
 	Equals(t Type) bool

--- a/hack/generator/pkg/astmodel/type_definition.go
+++ b/hack/generator/pkg/astmodel/type_definition.go
@@ -35,10 +35,7 @@ func (std TypeDefinition) Type() Type {
 // We return a new slice to preserve immutability
 func (std TypeDefinition) Description() []string {
 	var result []string
-	for _, s := range std.description {
-		result = append(result, s)
-	}
-
+	result = append(result, std.description...)
 	return result
 }
 

--- a/hack/generator/pkg/astmodel/type_definition.go
+++ b/hack/generator/pkg/astmodel/type_definition.go
@@ -13,7 +13,7 @@ import (
 // TypeDefinition is a name paired with a type
 type TypeDefinition struct {
 	name        TypeName
-	description *string
+	description []string
 	theType     Type
 }
 
@@ -32,15 +32,22 @@ func (std TypeDefinition) Type() Type {
 }
 
 // Description returns the description to be attached to this type definition (as a comment)
-func (std TypeDefinition) Description() *string {
-	return std.description
+// We return a new slice to preserve immutability
+func (std TypeDefinition) Description() []string {
+	var result []string
+	for _, s := range std.description {
+		result = append(result, s)
+	}
+
+	return result
 }
 
 func (std TypeDefinition) References() TypeNameSet {
 	return std.theType.References()
 }
 
-func (std TypeDefinition) WithDescription(desc *string) TypeDefinition {
+// WithDescription replaces the description of the definition with a new one (if any)
+func (std TypeDefinition) WithDescription(desc ...string) TypeDefinition {
 	std.description = desc
 	return std
 }
@@ -64,11 +71,11 @@ func (std TypeDefinition) AsDeclarations(codeGenerationContext *CodeGenerationCo
 }
 
 // AsSimpleDeclarations is a helper for types that only require a simple name/alias to be defined
-func AsSimpleDeclarations(codeGenerationContext *CodeGenerationContext, name TypeName, description *string, theType Type) []ast.Decl {
+func AsSimpleDeclarations(codeGenerationContext *CodeGenerationContext, name TypeName, description []string, theType Type) []ast.Decl {
 	var docComments *ast.CommentGroup
-	if description != nil {
+	if len(description) > 0 {
 		docComments = &ast.CommentGroup{}
-		addDocComment(&docComments.List, *description, 120)
+		addDocComments(&docComments.List, description, 120)
 	}
 
 	return []ast.Decl{

--- a/hack/generator/pkg/astmodel/type_definition.go
+++ b/hack/generator/pkg/astmodel/type_definition.go
@@ -44,8 +44,9 @@ func (def TypeDefinition) References() TypeNameSet {
 }
 
 // WithDescription replaces the description of the definition with a new one (if any)
-func (def TypeDefinition) WithDescription(desc ...string) TypeDefinition {
-	def.description = desc
+func (def TypeDefinition) WithDescription(desc []string) TypeDefinition {
+	var d []string
+	def.description = append(d, desc...)
 	return def
 }
 

--- a/hack/generator/pkg/astmodel/type_definition.go
+++ b/hack/generator/pkg/astmodel/type_definition.go
@@ -22,49 +22,49 @@ func MakeTypeDefinition(name TypeName, theType Type) TypeDefinition {
 }
 
 // Name returns the name being associated with the type
-func (std TypeDefinition) Name() TypeName {
-	return std.name
+func (def TypeDefinition) Name() TypeName {
+	return def.name
 }
 
 // Type returns the type being associated with the name
-func (std TypeDefinition) Type() Type {
-	return std.theType
+func (def TypeDefinition) Type() Type {
+	return def.theType
 }
 
 // Description returns the description to be attached to this type definition (as a comment)
 // We return a new slice to preserve immutability
-func (std TypeDefinition) Description() []string {
+func (def TypeDefinition) Description() []string {
 	var result []string
-	result = append(result, std.description...)
+	result = append(result, def.description...)
 	return result
 }
 
-func (std TypeDefinition) References() TypeNameSet {
-	return std.theType.References()
+func (def TypeDefinition) References() TypeNameSet {
+	return def.theType.References()
 }
 
 // WithDescription replaces the description of the definition with a new one (if any)
-func (std TypeDefinition) WithDescription(desc ...string) TypeDefinition {
-	std.description = desc
-	return std
+func (def TypeDefinition) WithDescription(desc ...string) TypeDefinition {
+	def.description = desc
+	return def
 }
 
 // WithType returns an updated TypeDefinition with the specified type
-func (std TypeDefinition) WithType(t Type) TypeDefinition {
-	result := std
+func (def TypeDefinition) WithType(t Type) TypeDefinition {
+	result := def
 	result.theType = t
 	return result
 }
 
 // WithName returns an updated TypeDefinition with the specified name
-func (std TypeDefinition) WithName(typeName TypeName) TypeDefinition {
-	result := std
+func (def TypeDefinition) WithName(typeName TypeName) TypeDefinition {
+	result := def
 	result.name = typeName
 	return result
 }
 
-func (std TypeDefinition) AsDeclarations(codeGenerationContext *CodeGenerationContext) []ast.Decl {
-	return std.theType.AsDeclarations(codeGenerationContext, std.name, std.description)
+func (def TypeDefinition) AsDeclarations(codeGenerationContext *CodeGenerationContext) []ast.Decl {
+	return def.theType.AsDeclarations(codeGenerationContext, def.name, def.description)
 }
 
 // AsSimpleDeclarations is a helper for types that only require a simple name/alias to be defined
@@ -90,8 +90,8 @@ func AsSimpleDeclarations(codeGenerationContext *CodeGenerationContext, name Typ
 }
 
 // RequiredImports returns a list of packages required by this type
-func (std TypeDefinition) RequiredImports() []PackageReference {
-	return std.theType.RequiredImports()
+func (def TypeDefinition) RequiredImports() []PackageReference {
+	return def.theType.RequiredImports()
 }
 
 // FileNameHint returns what a file that contains this name (if any) should be called

--- a/hack/generator/pkg/astmodel/type_definition_test.go
+++ b/hack/generator/pkg/astmodel/type_definition_test.go
@@ -52,7 +52,7 @@ func Test_TypeDefinitionWithDescription_GivenDescription_ReturnsExpected(t *test
 
 	ref := MakeTypeName(MakeLocalPackageReference(group, version), name)
 	objectType := NewObjectType().WithProperties(fullName, familyName, knownAs)
-	objectDefinition := MakeTypeDefinition(ref, objectType).WithDescription(description...)
+	objectDefinition := MakeTypeDefinition(ref, objectType).WithDescription(description)
 
 	g.Expect(objectDefinition.Description()).To(Equal(description))
 }

--- a/hack/generator/pkg/astmodel/type_definition_test.go
+++ b/hack/generator/pkg/astmodel/type_definition_test.go
@@ -48,13 +48,13 @@ func Test_TypeDefinitionWithDescription_GivenDescription_ReturnsExpected(t *test
 	const group = "group"
 	const version = "2020-01-01"
 
-	description := "This is my test description"
+	description := []string{"This is my test description"}
 
 	ref := MakeTypeName(MakeLocalPackageReference(group, version), name)
 	objectType := NewObjectType().WithProperties(fullName, familyName, knownAs)
-	objectDefinition := MakeTypeDefinition(ref, objectType).WithDescription(&description)
+	objectDefinition := MakeTypeDefinition(ref, objectType).WithDescription(description...)
 
-	g.Expect(objectDefinition.Description()).To(Equal(&description))
+	g.Expect(objectDefinition.Description()).To(Equal(description))
 }
 
 /*

--- a/hack/generator/pkg/astmodel/type_name.go
+++ b/hack/generator/pkg/astmodel/type_name.go
@@ -32,7 +32,7 @@ func (typeName TypeName) Name() string {
 // it is simply a reference to the name.
 var _ Type = TypeName{}
 
-func (typeName TypeName) AsDeclarations(codeGenerationContext *CodeGenerationContext, name TypeName, description *string) []ast.Decl {
+func (typeName TypeName) AsDeclarations(codeGenerationContext *CodeGenerationContext, name TypeName, description []string) []ast.Decl {
 	return AsSimpleDeclarations(codeGenerationContext, name, description, typeName)
 }
 

--- a/hack/generator/pkg/codegen/pipeline_export_generated_code.go
+++ b/hack/generator/pkg/codegen/pipeline_export_generated_code.go
@@ -101,7 +101,8 @@ func MarkLatestResourceVersionsForStorage(
 				// mark as storage version if it's the latest version
 				isLatestVersion := thisPackagePath == latestPackagePath
 				if isLatestVersion {
-					def = astmodel.MakeTypeDefinition(def.Name(), resourceType.MarkAsStorageVersion()).WithDescription(def.Description())
+					def = astmodel.MakeTypeDefinition(def.Name(), resourceType.MarkAsStorageVersion()).
+						WithDescription(def.Description()...)
 				}
 
 				resultPkg.AddDefinition(def)

--- a/hack/generator/pkg/codegen/pipeline_export_generated_code.go
+++ b/hack/generator/pkg/codegen/pipeline_export_generated_code.go
@@ -102,7 +102,7 @@ func MarkLatestResourceVersionsForStorage(
 				isLatestVersion := thisPackagePath == latestPackagePath
 				if isLatestVersion {
 					def = astmodel.MakeTypeDefinition(def.Name(), resourceType.MarkAsStorageVersion()).
-						WithDescription(def.Description()...)
+						WithDescription(def.Description())
 				}
 
 				resultPkg.AddDefinition(def)

--- a/hack/generator/pkg/codegen/pipeline_name_types_for_crd.go
+++ b/hack/generator/pkg/codegen/pipeline_name_types_for_crd.go
@@ -63,7 +63,7 @@ func nameInnerTypes(
 		enumName := astmodel.MakeTypeName(def.Name().PackageReference, idFactory.CreateEnumIdentifier(nameHint))
 
 		namedEnum := astmodel.MakeTypeDefinition(enumName, it)
-		namedEnum = namedEnum.WithDescription(getDescription(enumName)...)
+		namedEnum = namedEnum.WithDescription(getDescription(enumName))
 
 		resultTypes = append(resultTypes, namedEnum)
 
@@ -83,7 +83,7 @@ func nameInnerTypes(
 		objectName := astmodel.MakeTypeName(def.Name().PackageReference, nameHint)
 
 		namedObjectType := astmodel.MakeTypeDefinition(objectName, it.WithProperties(props...))
-		namedObjectType = namedObjectType.WithDescription(getDescription(objectName)...)
+		namedObjectType = namedObjectType.WithDescription(getDescription(objectName))
 
 		resultTypes = append(resultTypes, namedObjectType)
 
@@ -103,7 +103,7 @@ func nameInnerTypes(
 		resourceName := astmodel.MakeTypeName(def.Name().PackageReference, nameHint)
 
 		resource := astmodel.MakeTypeDefinition(resourceName, astmodel.NewResourceType(spec, status))
-		resource = resource.WithDescription(getDescription(resourceName)...)
+		resource = resource.WithDescription(getDescription(resourceName))
 
 		resultTypes = append(resultTypes, resource)
 

--- a/hack/generator/pkg/codegen/pipeline_name_types_for_crd.go
+++ b/hack/generator/pkg/codegen/pipeline_name_types_for_crd.go
@@ -22,12 +22,12 @@ func nameTypesForCRD(idFactory astmodel.IdentifierFactory) PipelineStage {
 			result := make(astmodel.Types)
 
 			// this is a little bit of a hack, better way to do it?
-			getDescription := func(typeName astmodel.TypeName) *string {
+			getDescription := func(typeName astmodel.TypeName) []string {
 				if typeDef, ok := types[typeName]; ok {
 					return typeDef.Description()
 				}
 
-				return nil
+				return []string{}
 			}
 
 			for typeName, typeDef := range types {
@@ -50,7 +50,7 @@ func nameTypesForCRD(idFactory astmodel.IdentifierFactory) PipelineStage {
 func nameInnerTypes(
 	def astmodel.TypeDefinition,
 	idFactory astmodel.IdentifierFactory,
-	getDescription func(astmodel.TypeName) *string) []astmodel.TypeDefinition {
+	getDescription func(typeName astmodel.TypeName) []string) []astmodel.TypeDefinition {
 
 	var resultTypes []astmodel.TypeDefinition
 
@@ -63,7 +63,7 @@ func nameInnerTypes(
 		enumName := astmodel.MakeTypeName(def.Name().PackageReference, idFactory.CreateEnumIdentifier(nameHint))
 
 		namedEnum := astmodel.MakeTypeDefinition(enumName, it)
-		namedEnum = namedEnum.WithDescription(getDescription(enumName))
+		namedEnum = namedEnum.WithDescription(getDescription(enumName)...)
 
 		resultTypes = append(resultTypes, namedEnum)
 
@@ -83,7 +83,7 @@ func nameInnerTypes(
 		objectName := astmodel.MakeTypeName(def.Name().PackageReference, nameHint)
 
 		namedObjectType := astmodel.MakeTypeDefinition(objectName, it.WithProperties(props...))
-		namedObjectType = namedObjectType.WithDescription(getDescription(objectName))
+		namedObjectType = namedObjectType.WithDescription(getDescription(objectName)...)
 
 		resultTypes = append(resultTypes, namedObjectType)
 
@@ -103,7 +103,7 @@ func nameInnerTypes(
 		resourceName := astmodel.MakeTypeName(def.Name().PackageReference, nameHint)
 
 		resource := astmodel.MakeTypeDefinition(resourceName, astmodel.NewResourceType(spec, status))
-		resource = resource.WithDescription(getDescription(resourceName))
+		resource = resource.WithDescription(getDescription(resourceName)...)
 
 		resultTypes = append(resultTypes, resource)
 

--- a/hack/generator/pkg/jsonast/jsonast.go
+++ b/hack/generator/pkg/jsonast/jsonast.go
@@ -489,7 +489,7 @@ func generateDefinitionsFor(
 		result = astmodel.NewResourceType(result, nil)
 	}
 
-	description := []string {
+	description := []string{
 		fmt.Sprintf("Generated from: %s", url.String()),
 	}
 	definition := astmodel.MakeTypeDefinition(typeName, result).WithDescription(description)

--- a/hack/generator/pkg/jsonast/jsonast.go
+++ b/hack/generator/pkg/jsonast/jsonast.go
@@ -490,7 +490,7 @@ func generateDefinitionsFor(
 	}
 
 	description := fmt.Sprintf("Generated from: %s", url.String())
-	definition := astmodel.MakeTypeDefinition(typeName, result).WithDescription(&description)
+	definition := astmodel.MakeTypeDefinition(typeName, result).WithDescription(description)
 
 	scanner.addTypeDefinition(definition)
 

--- a/hack/generator/pkg/jsonast/jsonast.go
+++ b/hack/generator/pkg/jsonast/jsonast.go
@@ -489,7 +489,9 @@ func generateDefinitionsFor(
 		result = astmodel.NewResourceType(result, nil)
 	}
 
-	description := fmt.Sprintf("Generated from: %s", url.String())
+	description := []string {
+		fmt.Sprintf("Generated from: %s", url.String()),
+	}
 	definition := astmodel.MakeTypeDefinition(typeName, result).WithDescription(description)
 
 	scanner.addTypeDefinition(definition)


### PR DESCRIPTION
I was doing a lot of string manipulation to add additional lines of description (comment) while generating storage types and it seemed silly to be converting back and forth from a string to a []string all the time.

Also fixes up the names of receivers for `TypeDefinition`.

Change summary (is this useful?)

```
 hack/generator/go.mod                              |  2 +
 hack/generator/pkg/astmodel/array_type.go          |  2 +-
 hack/generator/pkg/astmodel/comments.go            | 12 ++++++
 hack/generator/pkg/astmodel/enum_type.go           | 13 +++---
 hack/generator/pkg/astmodel/map_type.go            |  2 +-
 hack/generator/pkg/astmodel/object_type.go         |  6 +--
 hack/generator/pkg/astmodel/optional_type.go       |  2 +-
 hack/generator/pkg/astmodel/primitive_type.go      |  4 +-
 hack/generator/pkg/astmodel/resource.go            | 10 ++---
 hack/generator/pkg/astmodel/type.go                |  9 +++-
 hack/generator/pkg/astmodel/type_definition.go     | 50 ++++++++++++----------
 .../generator/pkg/astmodel/type_definition_test.go |  6 +--
 hack/generator/pkg/astmodel/type_name.go           |  2 +-
 hack/generator/pkg/codegen/code_generator.go       |  1 +
 .../pkg/codegen/pipeline_export_generated_code.go  |  3 +-
 .../pkg/codegen/pipeline_name_types_for_crd.go     | 12 +++---
 hack/generator/pkg/jsonast/jsonast.go              |  2 +-
 17 files changed, 80 insertions(+), 58 deletions(-)
```