### PR TITLE
Linter updates: enable "bugs" preset

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -4,4 +4,9 @@ run:
 linters:
   enable:
     - gofmt
-    - exportloopref
+    - megacheck
+  presets:
+    - bugs
+    - unused
+  disable: 
+    - scopelint # obsoleted by exportloopref

--- a/controllers/generic_controller.go
+++ b/controllers/generic_controller.go
@@ -379,16 +379,15 @@ func (gr *GenericReconciler) reconcileDelete(ctx context.Context, metaObj azcore
 		return ctrl.Result{}, fmt.Errorf("unable to transform to resource with: %w", err)
 	}
 
-	switch resource.ProvisioningState {
-	case zips.DeletingProvisioningState:
+	if resource.ProvisioningState == zips.DeletingProvisioningState {
 		msg := "deleting... checking for updated state"
 		gr.Recorder.Event(metaObj, v1.EventTypeNormal, "ResourceDeleteInProgress", msg)
 		return gr.updateFromNonTerminalDeleteState(ctx, resource, metaObj)
-	default:
-		msg := fmt.Sprintf("start deleting resource in state %q", resource.ProvisioningState)
-		gr.Recorder.Event(metaObj, v1.EventTypeNormal, "ResourceDeleteStart", msg)
-		return gr.startDeleteOfResource(ctx, resource, metaObj)
 	}
+
+	msg := fmt.Sprintf("start deleting resource in state %q", resource.ProvisioningState)
+	gr.Recorder.Event(metaObj, v1.EventTypeNormal, "ResourceDeleteStart", msg)
+	return gr.startDeleteOfResource(ctx, resource, metaObj)
 }
 
 // startDeleteOfResource will begin the delete of a resource by telling Azure to start deleting it. The resource will be

--- a/hack/generator/pkg/astmodel/package_definition.go
+++ b/hack/generator/pkg/astmodel/package_definition.go
@@ -175,7 +175,7 @@ func emitGroupVersionFile(pkgDef *PackageDefinition, outputDir string) error {
 
 	gvFile := filepath.Join(outputDir, "groupversion_info"+CodeGeneratedFileSuffix)
 
-	err = ioutil.WriteFile(gvFile, buf.Bytes(), 0700)
+	err = ioutil.WriteFile(gvFile, buf.Bytes(), 0600)
 	if err != nil {
 		return errors.Wrapf(err, "error writing group version file %q", gvFile)
 	}

--- a/hack/generator/pkg/jsonast/jsonast.go
+++ b/hack/generator/pkg/jsonast/jsonast.go
@@ -170,10 +170,7 @@ func (scanner *SchemaScanner) GenerateDefinitions(ctx context.Context, schema *g
 		return nil, errors.Wrapf(err, "Unable to extract group for schema")
 	}
 
-	rootVersion, err := versionOf(url)
-	if err != nil {
-		return nil, errors.Wrapf(err, "Unable to extract version for schema")
-	}
+	rootVersion := versionOf(url)
 
 	rootPackage := astmodel.MakeLocalPackageReference(
 		scanner.idFactory.CreateGroupName(rootGroup),
@@ -416,21 +413,13 @@ func refHandler(ctx context.Context, scanner *SchemaScanner, schema *gojsonschem
 
 	url := schema.Ref.GetUrl()
 
-	// make a new topic based on the ref URL
-	name, err := objectTypeOf(url)
-	if err != nil {
-		return nil, err
-	}
-
 	group, err := groupOf(url)
 	if err != nil {
 		return nil, err
 	}
 
-	version, err := versionOf(url)
-	if err != nil {
-		return nil, err
-	}
+	name := objectTypeOf(url)
+	version := versionOf(url)
 
 	// produce a usable name:
 	typeName := astmodel.MakeTypeName(
@@ -793,10 +782,10 @@ func isURLPathSeparator(c rune) bool {
 }
 
 // Extract the name of an object from the supplied schema URL
-func objectTypeOf(url *url.URL) (string, error) {
+func objectTypeOf(url *url.URL) string {
 	fragmentParts := strings.FieldsFunc(url.Fragment, isURLPathSeparator)
 
-	return fragmentParts[len(fragmentParts)-1], nil
+	return fragmentParts[len(fragmentParts)-1]
 }
 
 // Extract the 'group' (here filename) of an object from the supplied schemaURL
@@ -826,17 +815,17 @@ func isResource(url *url.URL) bool {
 var versionRegex = regexp.MustCompile(`\d{4}-\d{2}-\d{2}`)
 
 // Extract the name of an object from the supplied schema URL
-func versionOf(url *url.URL) (string, error) {
+func versionOf(url *url.URL) string {
 	pathParts := strings.FieldsFunc(url.Path, isURLPathSeparator)
 
 	for _, p := range pathParts {
 		if versionRegex.MatchString(p) {
-			return p, nil
+			return p
 		}
 	}
 
 	// No version found, that's fine
-	return "", nil
+	return ""
 }
 
 func appendIfUniqueType(slice []astmodel.Type, item astmodel.Type) []astmodel.Type {

--- a/hack/generator/pkg/jsonast/jsonast.go
+++ b/hack/generator/pkg/jsonast/jsonast.go
@@ -774,9 +774,18 @@ func getPrimitiveType(name SchemaType) (*astmodel.PrimitiveType, error) {
 		return astmodel.FloatType, nil
 	case Bool:
 		return astmodel.BoolType, nil
-	default:
+	case AllOf:
+	case AnyOf:
+	case Array:
+	case Enum:
+	case Object:
+	case OneOf:
+	case Ref:
+	case Unknown:
 		return astmodel.AnyType, errors.Errorf("%s is not a simple type and no ast.NewIdent can be created", name)
 	}
+
+	panic(fmt.Sprintf("unhandled case in getPrimitiveType: %s", name)) // this is also checked by linter
 }
 
 func isURLPathSeparator(c rune) bool {

--- a/hack/generator/pkg/jsonast/object_type_of_test.go
+++ b/hack/generator/pkg/jsonast/object_type_of_test.go
@@ -18,8 +18,6 @@ func Test_ObjectTypeOf(t *testing.T) {
 	url, err := url.Parse("https://schema.management.azure.com/schemas/2015-01-01/Microsoft.Resources.json#/resourceDefinitions/deployments")
 	g.Expect(err).To(BeNil())
 
-	name, err := objectTypeOf(url)
-
+	name := objectTypeOf(url)
 	g.Expect(name).To(Equal("deployments"))
-	g.Expect(err).To(BeNil())
 }

--- a/hack/generator/pkg/jsonast/versionof_test.go
+++ b/hack/generator/pkg/jsonast/versionof_test.go
@@ -18,7 +18,6 @@ func Test_ExtractObjectAndVersion(t *testing.T) {
 	url, err := url.Parse("https://schema.management.azure.com/schemas/2015-01-01/Microsoft.Resources.json#/resourceDefinitions/deployments")
 	g.Expect(err).To(BeNil())
 
-	version, err := versionOf(url)
+	version := versionOf(url)
 	g.Expect(version).To(Equal("2015-01-01"))
-	g.Expect(err).To(BeNil())
 }

--- a/pkg/xform/type_refs.go
+++ b/pkg/xform/type_refs.go
@@ -58,7 +58,7 @@ func getResourceReferences(t reflect.Type) ([]TypeReferenceLocation, error) {
 	var refs []TypeReferenceLocation
 	var err error
 
-	switch t.Kind() {
+	switch t.Kind() { //nolint: don't check for exhaustiveness
 	case reflect.Ptr:
 		refs, err = gatherPtr(t)
 	case reflect.Struct:

--- a/pkg/zips/client.go
+++ b/pkg/zips/client.go
@@ -234,7 +234,7 @@ func (c *Client) Head(ctx context.Context, entityPath string, mw ...MiddlewareFu
 }
 
 func (c *Client) execute(ctx context.Context, method string, entityPath string, body io.Reader, mw ...MiddlewareFunc) (*http.Response, error) {
-	req, err := http.NewRequest(method, c.Host+strings.TrimPrefix(entityPath, "/"), body)
+	req, err := http.NewRequestWithContext(ctx, method, c.Host+strings.TrimPrefix(entityPath, "/"), body)
 	if err != nil {
 		tab.For(ctx).Error(err)
 		return nil, err


### PR DESCRIPTION
Enable the "`bugs`" preset: the important changes here (IMO) are that `gosec` and `exhaustive` get added. I removed the explicit inclusion of `exportloopref` as it is part of `bugs`, and also added `megacheck` to retain the `gosimple` linter which for some reason gets dropped otherwise with these changes.

Diff of output of `golangci-lint linters`:
 ```
Enabled by your configuration linters:
+asciicheck: Simple linter to check that your code does not contain non-ASCII identifiers [fast: true, auto-fix: false]
+bodyclose: checks whether HTTP response body is closed successfully [fast: true, auto-fix: false]
 deadcode: Finds unused code [fast: true, auto-fix: false]
 errcheck: Errcheck is a program for checking for unchecked errors in go programs. These unchecked errors can be critical bugs in some cases [fast: true, auto-fix: false]
+exhaustive: check exhaustiveness of enum switch statements [fast: true, auto-fix: false]
 exportloopref: checks for pointers to enclosing loop variables [fast: true, auto-fix: false]
 gofmt: Gofmt checks whether code was gofmt-ed. By default this tool runs with -s option to check for code simplification [fast: true, auto-fix: true]
+gosec (gas): Inspects source code for security problems [fast: true, auto-fix: false]
 gosimple (megacheck): Linter for Go source code that specializes in simplifying a code [fast: true, auto-fix: false]
 govet (vet, vetshadow): Vet examines Go source code and reports suspicious constructs, such as Printf calls whose arguments do not align with the format string [fast: true, auto-fix: false]
 ineffassign: Detects when assignments to existing variables are not used [fast: true, auto-fix: false]
+noctx: noctx finds sending http request without context.Context [fast: true, auto-fix: false]
+rowserrcheck: checks whether Err of rows is checked successfully [fast: true, auto-fix: false]
+sqlclosecheck: Checks that sql.Rows and sql.Stmt are closed. [fast: true, auto-fix: false]
 staticcheck (megacheck): Staticcheck is a go vet on steroids, applying a ton of static analysis checks [fast: true, auto-fix: false]
 structcheck: Finds unused struct fields [fast: true, auto-fix: false]
 typecheck: Like the front-end of a Go compiler, parses and type-checks Go code [fast: true, auto-fix: false]
+unparam: Reports unused function parameters [fast: true, auto-fix: false]
 unused (megacheck): Checks Go code for unused constants, variables, functions and types [fast: false, auto-fix: false]
 varcheck: Finds unused global variables and constants [fast: true, auto-fix: false]
```
 