### PR TITLE
Move Types into a separate file and test

### DIFF
--- a/hack/generator/pkg/astmodel/type.go
+++ b/hack/generator/pkg/astmodel/type.go
@@ -31,19 +31,6 @@ type Type interface {
 	Equals(t Type) bool
 }
 
-// Types is the set of all types being generated
-type Types map[TypeName]TypeDefinition
-
-// Add adds a type to the set, with safety check that it has not already been defined
-func (types Types) Add(def TypeDefinition) {
-	key := def.Name()
-	if _, ok := types[key]; ok {
-		panic(fmt.Sprintf("type already defined: %v", key))
-	}
-
-	types[key] = def
-}
-
 // TypeEquals decides if the types are the same and handles the `nil` case
 func TypeEquals(left, right Type) bool {
 	if left == nil {

--- a/hack/generator/pkg/astmodel/types.go
+++ b/hack/generator/pkg/astmodel/types.go
@@ -39,15 +39,15 @@ func (types Types) Where(predicate func(definition TypeDefinition) bool) Types {
 	return result
 }
 
-// Except returns a new set of types including only those not present in otherTypes
+// Except returns a new set of types including only those not defined in otherTypes
 func (types Types) Except(otherTypes Types) Types {
 	return types.Where(func(def TypeDefinition) bool {
-		return !otherTypes.Contains(def)
+		return !otherTypes.Contains(def.Name())
 	})
 }
 
-// Contains returns true if the set contains the passed definition
-func (types Types) Contains(def TypeDefinition) bool {
-	_, ok := types[def.Name()]
+// Contains returns true if the set contains a definition for the specified name
+func (types Types) Contains(name TypeName) bool {
+	_, ok := types[name]
 	return ok
 }

--- a/hack/generator/pkg/astmodel/types.go
+++ b/hack/generator/pkg/astmodel/types.go
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) Microsoft Corporation.
+ * Licensed under the MIT license.
+ */
+
+package astmodel
+
+import "fmt"
+
+// Types is the set of all types being generated
+type Types map[TypeName]TypeDefinition
+
+// Add adds a type to the set, with safety check that it has not already been defined
+func (types Types) Add(def TypeDefinition) {
+	key := def.Name()
+	if _, ok := types[key]; ok {
+		panic(fmt.Sprintf("type already defined: %v", key))
+	}
+
+	types[key] = def
+}
+
+// AddAll adds multiple types to the set, with the same safety check as Add() to panic if a duplicate is included
+func (types Types) AddAll(otherTypes Types) {
+	for _, t := range otherTypes {
+		types.Add(t)
+	}
+}
+
+// Where returns a new set of types including only those that satisfy the predicate
+func (types Types) Where(predicate func(definition TypeDefinition) bool) Types {
+	result := make(Types, len(types))
+	for _, t := range types {
+		if predicate(t) {
+			result[t.Name()] = t
+		}
+	}
+
+	return result
+}
+
+// Except returns a new set of types including only those not present in otherTypes
+func (types Types) Except(otherTypes Types) Types {
+	return types.Where(func(def TypeDefinition) bool {
+		return !otherTypes.Contains(def)
+	})
+}
+
+// Contains returns true if the set contains the passed definition
+func (types Types) Contains(def TypeDefinition) bool {
+	_, ok := types[def.Name()]
+	return ok
+}

--- a/hack/generator/pkg/astmodel/types.go
+++ b/hack/generator/pkg/astmodel/types.go
@@ -29,7 +29,7 @@ func (types Types) AddAll(otherTypes Types) {
 
 // Where returns a new set of types including only those that satisfy the predicate
 func (types Types) Where(predicate func(definition TypeDefinition) bool) Types {
-	result := make(Types, len(types))
+	result := make(Types)
 	for _, t := range types {
 		if predicate(t) {
 			result[t.Name()] = t

--- a/hack/generator/pkg/astmodel/types.go
+++ b/hack/generator/pkg/astmodel/types.go
@@ -21,7 +21,14 @@ func (types Types) Add(def TypeDefinition) {
 }
 
 // AddAll adds multiple types to the set, with the same safety check as Add() to panic if a duplicate is included
-func (types Types) AddAll(otherTypes Types) {
+func (types Types) AddAll(otherTypes []TypeDefinition) {
+	for _, t := range otherTypes {
+		types.Add(t)
+	}
+}
+
+// AddTypes adds multiple types to the set, with the same safety check as Add() to panic if a duplicate is included
+func (types Types) AddTypes(otherTypes Types) {
 	for _, t := range otherTypes {
 		types.Add(t)
 	}

--- a/hack/generator/pkg/astmodel/types.go
+++ b/hack/generator/pkg/astmodel/types.go
@@ -7,7 +7,7 @@ package astmodel
 
 import "fmt"
 
-// Types is the set of all types being generated
+// Types is a map of TypeName to TypeDefinition, representing a set of types.
 type Types map[TypeName]TypeDefinition
 
 // Add adds a type to the set, with safety check that it has not already been defined

--- a/hack/generator/pkg/astmodel/types_test.go
+++ b/hack/generator/pkg/astmodel/types_test.go
@@ -87,7 +87,7 @@ func Test_TypesWhere_GivenPredicate_ReturnsExpectedSet(t *testing.T) {
 func Test_TypesExcept_GivenEmptySet_ReturnsExpectedSet(t *testing.T) {
 	g := NewGomegaWithT(t)
 
-	types := createTestTypes(alphaDefinition, betaDefinition, gammaDefinition, deltaDefinition);
+	types := createTestTypes(alphaDefinition, betaDefinition, gammaDefinition, deltaDefinition)
 	empty := make(Types)
 	set := types.Except(empty)
 
@@ -101,7 +101,7 @@ func Test_TypesExcept_GivenEmptySet_ReturnsExpectedSet(t *testing.T) {
 func Test_TypesExcept_GivenSelf_ReturnsEmptySet(t *testing.T) {
 	g := NewGomegaWithT(t)
 
-	types := createTestTypes(alphaDefinition, betaDefinition, gammaDefinition, deltaDefinition);
+	types := createTestTypes(alphaDefinition, betaDefinition, gammaDefinition, deltaDefinition)
 	set := types.Except(types)
 
 	g.Expect(len(set)).To(Equal(0))
@@ -110,8 +110,8 @@ func Test_TypesExcept_GivenSelf_ReturnsEmptySet(t *testing.T) {
 func Test_TypesExcept_GivenSubset_ReturnsExpectedSet(t *testing.T) {
 	g := NewGomegaWithT(t)
 
-	types := createTestTypes(alphaDefinition, betaDefinition, gammaDefinition, deltaDefinition);
-	subset := createTestTypes(alphaDefinition, betaDefinition);
+	types := createTestTypes(alphaDefinition, betaDefinition, gammaDefinition, deltaDefinition)
+	subset := createTestTypes(alphaDefinition, betaDefinition)
 	set := types.Except(subset)
 
 	g.Expect(len(set)).To(Equal(2))

--- a/hack/generator/pkg/astmodel/types_test.go
+++ b/hack/generator/pkg/astmodel/types_test.go
@@ -1,0 +1,140 @@
+/*
+ * Copyright (c) Microsoft Corporation.
+ * Licensed under the MIT license.
+ */
+
+package astmodel
+
+import (
+	. "github.com/onsi/gomega"
+	"testing"
+)
+
+var (
+	pkg             = MakePackageReference("foo")
+	alphaDefinition = createTestDefinition("alpha")
+	betaDefinition  = createTestDefinition("beta")
+	gammaDefinition = createTestDefinition("gamma")
+	deltaDefinition = createTestDefinition("delta")
+)
+
+/*
+ * Add() Tests
+ */
+
+func Test_TypesAdd_GivenType_ModifiesSet(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	types := make(Types)
+	types.Add(alphaDefinition)
+
+	g.Expect(types).To(ContainElement(alphaDefinition))
+}
+
+func Test_TypesAdd_GivenTypeAlreadyPresent_Panics(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	types := make(Types)
+	types.Add(alphaDefinition)
+
+	g.Expect(func() { types.Add(alphaDefinition) }).To(Panic())
+}
+
+/*
+ * AddAll() Tests
+ */
+
+func Test_TypesAddAll_GivenTypes_ModifiesSet(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	types := createTestTypes(alphaDefinition, betaDefinition)
+	otherTypes := createTestTypes(gammaDefinition, deltaDefinition)
+
+	types.AddAll(otherTypes)
+
+	g.Expect(types).To(ContainElements(gammaDefinition, deltaDefinition))
+}
+
+func Test_TypesAddAll_GivenOverlappingTypes_Panics(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	types := createTestTypes(alphaDefinition, betaDefinition)
+	otherTypes := createTestTypes(betaDefinition, deltaDefinition)
+
+	g.Expect(func() { types.AddAll(otherTypes) }).To(Panic())
+}
+
+/*
+ * Where() Tests
+ */
+
+func Test_TypesWhere_GivenPredicate_ReturnsExpectedSet(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	types := createTestTypes(alphaDefinition, betaDefinition, gammaDefinition, deltaDefinition).
+		Where(func(def TypeDefinition) bool {
+			return len(def.name.name) == 5
+		})
+
+	g.Expect(types).To(ContainElements(alphaDefinition, gammaDefinition, deltaDefinition))
+	g.Expect(types).NotTo(ContainElement(betaDefinition))
+}
+
+/*
+ * Except() tests
+ */
+
+func Test_TypesExcept_GivenEmptySet_ReturnsExpectedSet(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	types := createTestTypes(alphaDefinition, betaDefinition, gammaDefinition, deltaDefinition);
+	empty := make(Types)
+	set := types.Except(empty)
+
+	g.Expect(len(set)).To(Equal(len(types)))
+	g.Expect(set).To(ContainElement(alphaDefinition))
+	g.Expect(set).To(ContainElement(betaDefinition))
+	g.Expect(set).To(ContainElement(gammaDefinition))
+	g.Expect(set).To(ContainElement(deltaDefinition))
+}
+
+func Test_TypesExcept_GivenSelf_ReturnsEmptySet(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	types := createTestTypes(alphaDefinition, betaDefinition, gammaDefinition, deltaDefinition);
+	set := types.Except(types)
+
+	g.Expect(len(set)).To(Equal(0))
+}
+
+func Test_TypesExcept_GivenSubset_ReturnsExpectedSet(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	types := createTestTypes(alphaDefinition, betaDefinition, gammaDefinition, deltaDefinition);
+	subset := createTestTypes(alphaDefinition, betaDefinition);
+	set := types.Except(subset)
+
+	g.Expect(len(set)).To(Equal(2))
+	g.Expect(set).NotTo(ContainElement(alphaDefinition))
+	g.Expect(set).NotTo(ContainElement(betaDefinition))
+	g.Expect(set).To(ContainElement(gammaDefinition))
+	g.Expect(set).To(ContainElement(deltaDefinition))
+}
+
+/*
+ * Utility functions
+ */
+
+func createTestDefinition(name string) TypeDefinition {
+	n := MakeTypeName(pkg, name)
+	return MakeTypeDefinition(n, StringType)
+}
+
+func createTestTypes(defs ...TypeDefinition) Types {
+	result := make(Types)
+	for _, d := range defs {
+		result.Add(d)
+	}
+
+	return result
+}

--- a/hack/generator/pkg/astmodel/types_test.go
+++ b/hack/generator/pkg/astmodel/types_test.go
@@ -48,7 +48,7 @@ func Test_TypesAddAll_GivenTypes_ModifiesSet(t *testing.T) {
 	g := NewGomegaWithT(t)
 
 	types := createTestTypes(alphaDefinition, betaDefinition)
-	otherTypes := createTestTypes(gammaDefinition, deltaDefinition)
+	otherTypes := []TypeDefinition{gammaDefinition, deltaDefinition}
 
 	types.AddAll(otherTypes)
 
@@ -59,9 +59,33 @@ func Test_TypesAddAll_GivenOverlappingTypes_Panics(t *testing.T) {
 	g := NewGomegaWithT(t)
 
 	types := createTestTypes(alphaDefinition, betaDefinition)
-	otherTypes := createTestTypes(betaDefinition, deltaDefinition)
+	otherTypes := []TypeDefinition{betaDefinition, deltaDefinition}
 
 	g.Expect(func() { types.AddAll(otherTypes) }).To(Panic())
+}
+
+/*
+ * AddTypes() Tests
+ */
+
+func Test_TypesAddTypes_GivenTypes_ModifiesSet(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	types := createTestTypes(alphaDefinition, betaDefinition)
+	otherTypes := createTestTypes(gammaDefinition, deltaDefinition)
+
+	types.AddTypes(otherTypes)
+
+	g.Expect(types).To(ContainElements(gammaDefinition, deltaDefinition))
+}
+
+func Test_TypesAddTypes_GivenOverlappingTypes_Panics(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	types := createTestTypes(alphaDefinition, betaDefinition)
+	otherTypes := createTestTypes(betaDefinition, deltaDefinition)
+
+	g.Expect(func() { types.AddTypes(otherTypes) }).To(Panic())
 }
 
 /*


### PR DESCRIPTION
Move `Types` into a separate file, then adds additional functionality:

* `AddAll(otherTypes Types)` - adds all the types into this set, with the same check as for the existing `Add()`
* `Where(predicate func(definition TypeDefinition) bool) Types` - returns a new set of filtered types
* `Except(otherTypes Types) Types` - returns a new set containing only types not in `otherTypes`
* `Contains(def TypeDefinition) bool` - what it says on the tin. 😁 

Full unit test coverage.