### PR TITLE
Add Flags to Resource and Object types to aid internal flow

### DIFF
--- a/hack/generator/pkg/astmodel/flags.go
+++ b/hack/generator/pkg/astmodel/flags.go
@@ -1,0 +1,9 @@
+package astmodel
+
+type Flag string
+
+const (
+	OneOfFlag          Flag = "OneOf"
+	AnyOfFlag          Flag = "AnyOf"
+	StorageVariantFlag Flag = "Storage"
+)

--- a/hack/generator/pkg/astmodel/object_type.go
+++ b/hack/generator/pkg/astmodel/object_type.go
@@ -284,6 +284,21 @@ func (objectType *ObjectType) Equals(t Type) bool {
 			}
 		}
 
+		if len(objectType.interfaces) != len(st.interfaces) {
+			// Different number of interfaces, not equal
+			return false
+		}
+
+		for interfaceName := range st.interfaces {
+			_, ok := objectType.interfaces[interfaceName]
+			if !ok {
+				// Didn't find the interface, not equal
+				return false
+			}
+
+			// TODO: Compare interfaces themselves
+		}
+
 		// All properties match, equal
 		return true
 	}

--- a/hack/generator/pkg/astmodel/object_type.go
+++ b/hack/generator/pkg/astmodel/object_type.go
@@ -349,28 +349,32 @@ func (objectType *ObjectType) WithFunction(name string, function Function) *Obje
 // WithInterface creates a new ObjectType with a function (method) attached to it
 func (objectType *ObjectType) WithInterface(iface *InterfaceImplementation) *ObjectType {
 	// Create a copy of objectType to preserve immutability
-	result := *objectType
-
-	// Copy contents of old map into new map
-	result.interfaces = make(map[TypeName]*InterfaceImplementation)
-	for key, value := range objectType.interfaces {
-		result.interfaces[key] = value
-	}
-
+	result := objectType.copy()
 	result.interfaces[iface.Name()] = iface
-
-	return &result
+	return result
 }
 
 func (objectType *ObjectType) copy() *ObjectType {
 	result := NewObjectType()
 
+	// Copy properties
 	for key, value := range objectType.properties {
 		result.properties[key] = value
 	}
 
+	// Copy functions
 	for key, value := range objectType.functions {
 		result.functions[key] = value
+	}
+
+	// Copy interfaces
+	for key, value := range objectType.interfaces {
+		result.interfaces[key] = value
+	}
+
+	// Copy flags (including value in case we later give that meaning)
+	for flag, value := range objectType.flags {
+		result.flags[flag] = value
 	}
 
 	return result

--- a/hack/generator/pkg/astmodel/object_type.go
+++ b/hack/generator/pkg/astmodel/object_type.go
@@ -16,6 +16,10 @@ type ObjectType struct {
 	properties map[PropertyName]*PropertyDefinition
 	functions  map[string]Function
 	interfaces map[TypeName]*InterfaceImplementation
+
+	// flags are used to identify resources during processing;
+	// they have no direct representation in the generated code.
+	flags map[Flag]struct{}
 }
 
 // EmptyObjectType is an empty object
@@ -30,7 +34,21 @@ func NewObjectType() *ObjectType {
 		properties: make(map[PropertyName]*PropertyDefinition),
 		functions:  make(map[string]Function),
 		interfaces: make(map[TypeName]*InterfaceImplementation),
+		flags:      make(map[Flag]struct{}),
 	}
+}
+
+// AddFlag includes the specified flag on the resource
+func (objectType *ObjectType) AddFlag(flag Flag) *ObjectType {
+	result := objectType.copy()
+	result.flags[flag] = struct{}{}
+	return result
+}
+
+// HasFlag returns true if the specified flag is present on this resource
+func (objectType *ObjectType) HasFlag(flag Flag) bool {
+	_, ok := objectType.flags[flag]
+	return ok
 }
 
 func (objectType *ObjectType) AsDeclarations(codeGenerationContext *CodeGenerationContext, name TypeName, description []string) []ast.Decl {

--- a/hack/generator/pkg/astmodel/object_type_test.go
+++ b/hack/generator/pkg/astmodel/object_type_test.go
@@ -207,3 +207,37 @@ func Test_WithFunction_GivenEmptyObject_ReturnsPopulatedObject(t *testing.T) {
 	g.Expect(object.functions).To(HaveLen(1))
 	g.Expect(object.functions["Activate"].Equals(fn)).To(BeTrue())
 }
+
+/*
+ * AddFlag() tests
+ */
+
+func Test_ObjectTypeAddFlag_GivenFlag_ReturnsDifferentInstance(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	obj := EmptyObjectType.WithProperties(fullName, familyName, knownAs, gender)
+	flagged := obj.AddFlag("foo")
+
+	g.Expect(flagged).NotTo(BeIdenticalTo(obj))
+}
+
+/*
+ * HasFlag() tests
+ */
+
+func Test_ObjectTypeHasFlag_GivenResourceWithFlag_ReturnsTrue(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	obj := EmptyObjectType.WithProperties(fullName, familyName, knownAs, gender).AddFlag("foo")
+
+	g.Expect(obj.HasFlag("foo")).To(BeTrue())
+}
+
+func Test_ObjectTypeHasFlag_GivenResourceWithTwoFlags_ReturnsTrueForBoth(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	obj := EmptyObjectType.WithProperties(fullName, familyName, knownAs, gender).AddFlag("foo").AddFlag("bar")
+
+	g.Expect(obj.HasFlag("foo")).To(BeTrue())
+	g.Expect(obj.HasFlag("bar")).To(BeTrue())
+}

--- a/hack/generator/pkg/astmodel/object_type_test.go
+++ b/hack/generator/pkg/astmodel/object_type_test.go
@@ -72,6 +72,11 @@ func TestObjectType_Equals_WhenGivenType_ReturnsExpectedResult(t *testing.T) {
 	differentType := NewObjectType().WithProperties(fullName, clanName, knownAs, gender)
 	mapType := NewMapType(StringType, personType)
 
+	intf := NewInterface(
+		MakeTypeName(MakePackageReference("/foo/bar/baz"),
+			"myInterface"),
+		map[string]Function{})
+
 	cases := []struct {
 		name      string
 		thisType  Type
@@ -99,6 +104,9 @@ func TestObjectType_Equals_WhenGivenType_ReturnsExpectedResult(t *testing.T) {
 		// Expect not-equal for different property (but same property count)
 		{"Not-equal when different type", personType, differentType, false},
 		{"Not-equal when different type", differentType, personType, false},
+		// Sensitive to interfaces
+		{"Not-equal when different interfaces", personType, personType.WithInterface(intf), false},
+		{"Equal when same interface added to both", personType.WithInterface(intf), personType.WithInterface(intf), true},
 	}
 
 	for _, c := range cases {
@@ -225,7 +233,7 @@ func Test_ObjectTypeAddFlag_GivenFlag_ReturnsDifferentInstance(t *testing.T) {
  * HasFlag() tests
  */
 
-func Test_ObjectTypeHasFlag_GivenResourceWithFlag_ReturnsTrue(t *testing.T) {
+func Test_ObjectTypeHasFlag_GivenObjectTypeWithFlag_ReturnsTrue(t *testing.T) {
 	g := NewGomegaWithT(t)
 
 	obj := EmptyObjectType.WithProperties(fullName, familyName, knownAs, gender).AddFlag("foo")
@@ -233,7 +241,7 @@ func Test_ObjectTypeHasFlag_GivenResourceWithFlag_ReturnsTrue(t *testing.T) {
 	g.Expect(obj.HasFlag("foo")).To(BeTrue())
 }
 
-func Test_ObjectTypeHasFlag_GivenResourceWithTwoFlags_ReturnsTrueForBoth(t *testing.T) {
+func Test_ObjectTypeHasFlag_GivenObjectTypeWithTwoFlags_ReturnsTrueForBoth(t *testing.T) {
 	g := NewGomegaWithT(t)
 
 	obj := EmptyObjectType.WithProperties(fullName, familyName, knownAs, gender).AddFlag("foo").AddFlag("bar")

--- a/hack/generator/pkg/astmodel/resource.go
+++ b/hack/generator/pkg/astmodel/resource.go
@@ -132,15 +132,30 @@ func (resource *ResourceType) AsType(_ *CodeGenerationContext) ast.Expr {
 }
 
 // Equals returns true if the other type is also a ResourceType and has Equal fields
-func (definition *ResourceType) Equals(other Type) bool {
-	if definition == other {
+func (resource *ResourceType) Equals(other Type) bool {
+	if resource == other {
 		return true
 	}
 
+	if resource == nil || other == nil {
+		return false
+	}
+
 	if otherResource, ok := other.(*ResourceType); ok {
-		return TypeEquals(definition.spec, otherResource.spec) &&
-			TypeEquals(definition.status, otherResource.status) &&
-			definition.isStorageVersion == otherResource.isStorageVersion
+		if !TypeEquals(resource.spec, otherResource.spec) ||
+			!TypeEquals(resource.status, otherResource.status) ||
+			!resource.isStorageVersion == otherResource.isStorageVersion ||
+			len(resource.flags) != len(otherResource.flags) {
+			return false
+		}
+
+		for f := range resource.flags {
+			if _, ok := otherResource.flags[f]; !ok {
+				return false
+			}
+		}
+
+		return true
 	}
 
 	return false

--- a/hack/generator/pkg/astmodel/resource.go
+++ b/hack/generator/pkg/astmodel/resource.go
@@ -254,3 +254,14 @@ func (resource *ResourceType) AsDeclarations(codeGenerationContext *CodeGenerati
 
 	return declarations
 }
+
+func (resource *ResourceType) copy() *ResourceType {
+	result := *resource
+
+	result.flags = make(map[string]struct{})
+	for k, v := range resource.flags {
+		result.flags[k] = v
+	}
+
+	return &result
+}

--- a/hack/generator/pkg/astmodel/resource_test.go
+++ b/hack/generator/pkg/astmodel/resource_test.go
@@ -33,7 +33,7 @@ func Test_ResourceEquals(t *testing.T) {
 		// nil comparisons
 		{"Two nil values are equal", nil, nil, true},
 		{"Resource and nil values are inequal", resourceA, nil, false},
-		{"Resource and nil values are inequal", nil, resourceA, false},
+		{"Nil and resource values are also inequal", nil, resourceA, false},
 		// Sensitive to value differences
 		{"Sensitive to spec type", resourceA, resourceC, false},
 		{"Sensitive to status type", resourceA, resourceB, false},
@@ -52,4 +52,37 @@ func Test_ResourceEquals(t *testing.T) {
 			g.Expect(areEqual).To(Equal(c.expectedEqual))
 		})
 	}
+}
+
+/*
+ * AddFlag() tests
+ */
+
+func Test_ResourceAddFlag_GivenFlag_ReturnsDifferentInstance(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	resource := NewResourceType(StringType, StringType)
+	flagged := resource.AddFlag("foo")
+	g.Expect(flagged).NotTo(BeIdenticalTo(resource))
+}
+
+/*
+ * HasFlag() tests
+ */
+
+func Test_ResourceHasFlag_GivenResourceWithFlag_ReturnsTrue(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	resource := NewResourceType(StringType, StringType).AddFlag("foo")
+
+	g.Expect(resource.HasFlag("foo")).To(BeTrue())
+}
+
+func Test_ResourceHasFlag_GivenResourceWithTwoFlags_ReturnsTrueForBoth(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	resource := NewResourceType(StringType, StringType).AddFlag("foo").AddFlag("bar")
+
+	g.Expect(resource.HasFlag("foo")).To(BeTrue())
+	g.Expect(resource.HasFlag("bar")).To(BeTrue())
 }

--- a/hack/generator/pkg/astmodel/resource_test.go
+++ b/hack/generator/pkg/astmodel/resource_test.go
@@ -1,0 +1,1 @@
+package astmodel

--- a/hack/generator/pkg/astmodel/resource_test.go
+++ b/hack/generator/pkg/astmodel/resource_test.go
@@ -1,1 +1,55 @@
+/*
+ * Copyright (c) Microsoft Corporation.
+ * Licensed under the MIT license.
+ */
+
 package astmodel
+
+import (
+	. "github.com/onsi/gomega"
+	"testing"
+)
+
+/*
+ * Equals() tests
+ */
+
+func Test_ResourceEquals(t *testing.T) {
+	resourceA := NewResourceType(StringType, StringType)
+	resourceB := NewResourceType(StringType, IntType)
+	resourceC := NewResourceType(IntType, StringType)
+	resourceD := NewResourceType(StringType, StringType)
+
+	cases := []struct {
+		name          string
+		left          *ResourceType
+		right         *ResourceType
+		expectedEqual bool
+	}{
+		// Always equal to same reference, and to same underlying types
+		{"Equal to self", resourceA, resourceA, true},
+		{"Equal to self", resourceB, resourceB, true},
+		{"Equal to same values", resourceA, resourceD, true},
+		// nil comparisons
+		{"Two nil values are equal", nil, nil, true},
+		{"Resource and nil values are inequal", resourceA, nil, false},
+		{"Resource and nil values are inequal", nil, resourceA, false},
+		// Sensitive to value differences
+		{"Sensitive to spec type", resourceA, resourceC, false},
+		{"Sensitive to status type", resourceA, resourceB, false},
+		{"Sensitive to storage version", resourceA, resourceA.MarkAsStorageVersion(), false},
+		{"Sensitive to flag", resourceA, resourceA.AddFlag("foo"), false},
+	}
+
+	for _, c := range cases {
+		c := c
+		t.Run(c.name, func(t *testing.T) {
+			t.Parallel()
+			g := NewGomegaWithT(t)
+
+			areEqual := c.left.Equals(c.right)
+
+			g.Expect(areEqual).To(Equal(c.expectedEqual))
+		})
+	}
+}

--- a/hack/generator/pkg/astmodel/type_definition_test.go
+++ b/hack/generator/pkg/astmodel/type_definition_test.go
@@ -78,3 +78,42 @@ func createStringProperty(name string, description string) *PropertyDefinition {
 func createIntProperty(name string, description string) *PropertyDefinition {
 	return NewPropertyDefinition(PropertyName(name), name, IntType).WithDescription(description)
 }
+
+/*
+ * AddFlag() tests
+ */
+
+func Test_TypeDefinitionAddFlag_GivenFlag_ReturnsDifferentInstance(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	ref := MakePackageReference("/foo/bar/baz")
+	name := MakeTypeName(ref, "MyType")
+	def := MakeTypeDefinition(name, StringType)
+	flagged := def.AddFlag("foo")
+	g.Expect(flagged).NotTo(BeIdenticalTo(def))
+}
+
+/*
+ * HasFlag() tests
+ */
+
+func Test_TypeDefinitionHasFlag_GivenResourceWithFlag_ReturnsTrue(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	ref := MakePackageReference("/foo/bar/baz")
+	name := MakeTypeName(ref, "MyType")
+	def := MakeTypeDefinition(name, StringType).AddFlag("foo")
+
+	g.Expect(def.HasFlag("foo")).To(BeTrue())
+}
+
+func Test_TypeDefinitionHasFlag_GivenResourceWithTwoFlags_ReturnsTrueForBoth(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	ref := MakePackageReference("/foo/bar/baz")
+	name := MakeTypeName(ref, "MyType")
+	def := MakeTypeDefinition(name, StringType).AddFlag("foo").AddFlag("bar")
+
+	g.Expect(def.HasFlag("foo")).To(BeTrue())
+	g.Expect(def.HasFlag("bar")).To(BeTrue())
+}

--- a/hack/generator/pkg/codegen/pipeline_determine_resource_ownership.go
+++ b/hack/generator/pkg/codegen/pipeline_determine_resource_ownership.go
@@ -168,16 +168,11 @@ func extractChildResourceTypeNames(resourcesPropertyTypeDef astmodel.TypeDefinit
 	}
 
 	// Determine if this is a OneOf/AllOf
-	// TODO: Checking for the presence of the JSON marshal function is a bit of a hack...
-	if isObject && isObjectOneOfObject(resourcesPropertyTypeAsObject) {
+	if isObject && resourcesPropertyTypeAsObject.HasFlag(astmodel.OneOfFlag) {
 		return resolveResourcesTypeNames(resourcesPropertyTypeDef.Name(), resourcesPropertyTypeAsObject)
-	} else {
-		return []astmodel.TypeName{resourcesPropertyTypeDef.Name()}, nil
 	}
-}
 
-func isObjectOneOfObject(o *astmodel.ObjectType) bool {
-	return o.HasFunctionWithName(astmodel.JSONMarshalFunctionName)
+	return []astmodel.TypeName{resourcesPropertyTypeDef.Name()}, nil
 }
 
 func updateChildResourceDefinitionsWithOwner(

--- a/hack/generator/pkg/jsonast/jsonast.go
+++ b/hack/generator/pkg/jsonast/jsonast.go
@@ -693,7 +693,8 @@ func generateOneOfUnionType(ctx context.Context, subschemas []Schema, scanner *S
 	objectType := astmodel.NewObjectType().WithProperties(properties...)
 	objectType = objectType.WithFunction(
 		astmodel.JSONMarshalFunctionName,
-		astmodel.NewOneOfJSONMarshalFunction(objectType, scanner.idFactory))
+		astmodel.NewOneOfJSONMarshalFunction(objectType, scanner.idFactory)).
+		AddFlag(astmodel.OneOfFlag)
 
 	return objectType, nil
 }


### PR DESCRIPTION
Adds the ability to add a post-it note style flag to a type in one place so that you can recognize it elsewhere.