### PR TITLE
Expand enums in Swagger operation paths

### DIFF
--- a/hack/generator/pkg/codegen/swagger_type_extractor_test.go
+++ b/hack/generator/pkg/codegen/swagger_type_extractor_test.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/go-openapi/spec"
 	. "github.com/onsi/gomega"
 )
 
@@ -38,4 +39,57 @@ func Test_InferNameFromURLPath_FailsWithNoGroupName(t *testing.T) {
 	_, _, err := inferNameFromURLPath("/resourceName/{resourceId}/{anotherParameter}")
 	g.Expect(err).To(Not(BeNil()))
 	g.Expect(err.Error()).To(ContainSubstring("no group name"))
+}
+
+func Test_expandEnumsInPath_ExpandsAnEnum(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	paths := expandEnumsInPath("/some/{value}", []spec.Parameter{
+		{
+			CommonValidations: spec.CommonValidations{
+				Enum: []interface{}{"yes", "no"},
+			},
+			ParamProps: spec.ParamProps{
+				In:       "path",
+				Name:     "value",
+				Required: true,
+			},
+		},
+	})
+
+	g.Expect(paths).To(ContainElements("/some/yes", "/some/no"))
+}
+
+func Test_expandEnumsInPath_ExpandsMultipleEnums(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	paths := expandEnumsInPath("/some/{value1}/{value2}", []spec.Parameter{
+		{
+			CommonValidations: spec.CommonValidations{
+				Enum: []interface{}{"yes", "no"},
+			},
+			ParamProps: spec.ParamProps{
+				In:       "path",
+				Name:     "value1",
+				Required: true,
+			},
+		},
+		{
+			CommonValidations: spec.CommonValidations{
+				Enum: []interface{}{"orange", "blue"},
+			},
+			ParamProps: spec.ParamProps{
+				In:       "path",
+				Name:     "value2",
+				Required: true,
+			},
+		},
+	})
+
+	g.Expect(paths).To(ContainElements(
+		"/some/yes/blue",
+		"/some/no/blue",
+		"/some/yes/orange",
+		"/some/no/orange",
+	))
 }

--- a/hack/generator/pkg/jsonast/schema_abstraction_openapi.go
+++ b/hack/generator/pkg/jsonast/schema_abstraction_openapi.go
@@ -149,9 +149,12 @@ func (schema *OpenAPISchema) additionalPropertiesSchema() Schema {
 	return schema.withNewSchema(*result)
 }
 
-func (schema *OpenAPISchema) enumValues() []string {
-	result := make([]string, len(schema.inner.Enum))
-	for i, enumValue := range schema.inner.Enum {
+// enumValuesToLiterals converts interface{}-typed values to their
+// literal go-lang representations
+// if you update this you might also need to update "codegen.enumValuesToStrings"
+func enumValuesToLiterals(enumValues []interface{}) []string {
+	result := make([]string, len(enumValues))
+	for i, enumValue := range enumValues {
 		if enumString, ok := enumValue.(string); ok {
 			result[i] = fmt.Sprintf("%q", enumString)
 		} else if enumStringer, ok := enumValue.(fmt.Stringer); ok {
@@ -159,11 +162,15 @@ func (schema *OpenAPISchema) enumValues() []string {
 		} else if enumFloat, ok := enumValue.(float64); ok {
 			result[i] = fmt.Sprintf("%g", enumFloat)
 		} else {
-			panic(fmt.Sprintf("unable to convert enum value (%v %T) to string", enumValue, enumValue))
+			panic(fmt.Sprintf("unable to convert enum value (%v %T) to literal", enumValue, enumValue))
 		}
 	}
 
 	return result
+}
+
+func (schema *OpenAPISchema) enumValues() []string {
+	return enumValuesToLiterals(schema.inner.Enum)
 }
 
 func (schema *OpenAPISchema) isRef() bool {


### PR DESCRIPTION
This reduces the number of missing-statuses from 288 to 257.

If there is an operation path like:

```
…/Microsoft.Network/dnszones/{zoneName}/{recordType}/{relativeRecordSetName}
```

And `recordType` is an enum parameter like:

```json
{
  "name": "recordType",
  "in": "path",
  "required": true,
  "type": "string",
  "description": "The type of DNS record.",
  "enum": [
    "A",
    "AAAA",
    "CNAME",
    "MX",
    "NS",
    "PTR",
    "SOA",
    "SRV",
    "TXT"
  ],
  "x-ms-enum": {
    "name": "RecordType"
  }
},
```

Then we expand the path into:

```
…/Microsoft.Network/dnszones/{zoneName}/A/{relativeRecordSetName}
…/Microsoft.Network/dnszones/{zoneName}/AAAA/{relativeRecordSetName}
…/Microsoft.Network/dnszones/{zoneName}/CNAME/{relativeRecordSetName}
…
```