### PR TITLE
Improve status info coverage

### DIFF
--- a/hack/generator/azure-arm.yaml
+++ b/hack/generator/azure-arm.yaml
@@ -169,6 +169,27 @@ exportFilters:
   - action: exclude
     group: microsoft.web
     because: it generates types containing AnyType
+# The following are very old versions that have missing or otherwise problematic Swagger specs:
+  - action: exclude
+    group: microsoft.insights
+    version: v20140401
+    because: old version with no Swagger information to generate Status types
+  - action: exclude
+    group: microsoft.storage
+    version: v20150801
+    because: old version with no Swagger information to generate Status types
+  - action: exclude
+    group: microsoft.servicefabric
+    version: v20160301
+    because: old version with no Swagger information to generate Status types
+  - action: exclude
+    group: microsoft.documentdb
+    version: v20150408
+    because: old version with no Swagger information to generate Status types
+  - action: exclude
+    group: microsoft.apimanagement
+    version: v20160707
+    because: missing information from Swagger spec
 # The following end up with AnyType in Status:
   - action: exclude
     group: microsoft.containerservice

--- a/hack/generator/azure-arm.yaml
+++ b/hack/generator/azure-arm.yaml
@@ -198,6 +198,14 @@ exportFilters:
     group: microsoft.insights
     version: v20190301
     because: it generates types containing AnyType
+  - action: exclude
+    group: microsoft.apimanagement
+    version: v20190101
+    because: it generates types containing AnyType
+  - action: exclude
+    group: microsoft.powerbi
+    version: v20160129
+    because: it generates types containing AnyType
 
 typeTransformers:
   - group: definitions

--- a/hack/generator/pkg/astmodel/type_name.go
+++ b/hack/generator/pkg/astmodel/type_name.go
@@ -18,6 +18,11 @@ type TypeName struct {
 	name             string
 }
 
+func SortTypeName(left, right TypeName) bool {
+	return left.PackageReference.packagePath < right.PackageReference.packagePath ||
+		(left.PackageReference.packagePath == right.PackageReference.packagePath && left.name < right.name)
+}
+
 // MakeTypeName is a factory method for creating a TypeName
 func MakeTypeName(pr PackageReference, name string) TypeName {
 	return TypeName{pr, name}

--- a/hack/generator/pkg/codegen/code_generator.go
+++ b/hack/generator/pkg/codegen/code_generator.go
@@ -56,6 +56,7 @@ func corePipelineStages(idFactory astmodel.IdentifierFactory, configuration *con
 		stripUnreferencedTypeDefinitions(),
 		createArmTypesAndCleanKubernetesTypes(idFactory),
 		checkForAnyType(),
+		checkForMissingStatusInformation(),
 	}
 }
 

--- a/hack/generator/pkg/codegen/pipeline_check_for_missing_status_information.go
+++ b/hack/generator/pkg/codegen/pipeline_check_for_missing_status_information.go
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) Microsoft Corporation.
+ * Licensed under the MIT license.
+ */
+
+package codegen
+
+import (
+	"context"
+	"sort"
+
+	"github.com/Azure/k8s-infra/hack/generator/pkg/astmodel"
+	"k8s.io/klog/v2"
+)
+
+// checkForMissingStatusInformation returns a stage that will check if there
+// are any resources with no status information
+func checkForMissingStatusInformation() PipelineStage {
+	return MakePipelineStage(
+		"statusCheck",
+		"Check for missing status information",
+		func(ctx context.Context, defs astmodel.Types) (astmodel.Types, error) {
+
+			var missingStatus []astmodel.TypeName
+
+			for typeName, typeDef := range defs {
+				if resourceType, ok := typeDef.Type().(*astmodel.ResourceType); ok {
+					if resourceType.StatusType() == nil {
+						missingStatus = append(missingStatus, typeName)
+					}
+				}
+			}
+
+			sort.Slice(missingStatus, func(i, j int) bool {
+				return astmodel.SortTypeName(missingStatus[i], missingStatus[j])
+			})
+
+			klog.Errorf("Missing status information for %v types", len(missingStatus))
+
+			for _, typeName := range missingStatus {
+				klog.V(2).Infof("No status information found for %v", typeName)
+			}
+
+			return defs, nil // TODO: return an error in future if status info is missing
+		})
+}

--- a/hack/generator/pkg/jsonast/schema_abstraction.go
+++ b/hack/generator/pkg/jsonast/schema_abstraction.go
@@ -20,6 +20,9 @@ type Schema interface {
 	title() *string
 	description() *string
 
+	// for extensions like x-ms-...
+	extensions() map[string]interface{}
+
 	hasType(schemaType SchemaType) bool
 
 	// complex things

--- a/hack/generator/pkg/jsonast/schema_abstraction_gojson.go
+++ b/hack/generator/pkg/jsonast/schema_abstraction_gojson.go
@@ -43,6 +43,10 @@ func (schema GoJSONSchema) title() *string {
 	return schema.inner.Title
 }
 
+func (schema GoJSONSchema) extensions() map[string]interface{} {
+	return nil
+}
+
 func (schema GoJSONSchema) hasType(schemaType SchemaType) bool {
 	return schema.inner.Types.Contains(string(schemaType))
 }

--- a/hack/generator/pkg/jsonast/swagger_type_extractor.go
+++ b/hack/generator/pkg/jsonast/swagger_type_extractor.go
@@ -311,16 +311,22 @@ func inferNameFromURLPath(operationPath string) (string, string, error) {
 		}
 
 		if reading {
-			if urlPart[0] != '{' {
-				name += strings.ToUpper(urlPart[0:1]) + urlPart[1:]
-				skippedLast = false
-			} else {
+			if urlPart == "default" {
+				// skip; shouldn’t be part of name
+				// TODO: I haven’t yet found where this is done in autorest/autorest.armresource to document this
+			} else if urlPart[0] == '{' {
+				// this is a url parameter
+
 				if skippedLast {
 					// this means two {parameters} in a row
 					return "", "", errors.Errorf("multiple parameters in path")
 				}
 
 				skippedLast = true
+			} else {
+				// normal part of path, uppercase first character
+				name += strings.ToUpper(urlPart[0:1]) + urlPart[1:]
+				skippedLast = false
 			}
 		} else if SwaggerGroupRegex.MatchString(urlPart) {
 			group = urlPart

--- a/hack/generator/pkg/jsonast/swagger_type_extractor.go
+++ b/hack/generator/pkg/jsonast/swagger_type_extractor.go
@@ -3,7 +3,7 @@
  * Licensed under the MIT license.
  */
 
-package codegen
+package jsonast
 
 import (
 	"context"
@@ -13,26 +13,42 @@ import (
 
 	"github.com/Azure/k8s-infra/hack/generator/pkg/astmodel"
 	"github.com/Azure/k8s-infra/hack/generator/pkg/config"
-	"github.com/Azure/k8s-infra/hack/generator/pkg/jsonast"
 	"github.com/go-openapi/spec"
 	"github.com/pkg/errors"
 	"k8s.io/klog/v2"
 )
 
-type typeExtractor struct {
+type SwaggerTypeExtractor struct {
 	idFactory astmodel.IdentifierFactory
 	config    *config.Configuration
-	cache     jsonast.OpenAPISchemaCache
+	cache     OpenAPISchemaCache
 	// group for output types (e.g. Microsoft.Network.Frontdoor)
 	outputGroup   string
 	outputVersion string
 }
 
-// extractTypes finds all operations in the Swagger spec that
+// NewSwaggerTypeExtractor creates a new SwaggerTypeExtractor
+func NewSwaggerTypeExtractor(
+	config *config.Configuration,
+	idFactory astmodel.IdentifierFactory,
+	outputGroup string,
+	outputVersion string,
+	cache OpenAPISchemaCache) SwaggerTypeExtractor {
+
+	return SwaggerTypeExtractor{
+		idFactory:     idFactory,
+		outputVersion: outputVersion,
+		outputGroup:   outputGroup,
+		cache:         cache,
+		config:        config,
+	}
+}
+
+// ExtractTypes finds all operations in the Swagger spec that
 // have a PUT verb and a path like "Microsoft.GroupName/…/resourceName/{resourceId}",
 // and extracts the types for those operations, into the 'resources' parameter.
 // Any additional types required by the resource types are placed into the 'otherTypes' parameter.
-func (extractor *typeExtractor) extractTypes(
+func (extractor *SwaggerTypeExtractor) ExtractTypes(
 	ctx context.Context,
 	filePath string,
 	swagger spec.Swagger,
@@ -41,7 +57,7 @@ func (extractor *typeExtractor) extractTypes(
 
 	packageName := extractor.idFactory.CreatePackageNameFromVersion(extractor.outputVersion)
 
-	scanner := jsonast.NewSchemaScanner(extractor.idFactory, extractor.config)
+	scanner := NewSchemaScanner(extractor.idFactory, extractor.config)
 
 	for rawOperationPath, op := range swagger.Paths.Paths {
 		put := op.Put
@@ -49,14 +65,21 @@ func (extractor *typeExtractor) extractTypes(
 			continue
 		}
 
+		resourceSchema := extractor.findARMResourceSchema(filePath, swagger, *put)
+		if resourceSchema == nil {
+			//klog.Warningf("No ARM schema found for %s in %q", rawOperationPath, filePath)
+			continue
+		}
+
 		for _, operationPath := range expandEnumsInPath(rawOperationPath, put.Parameters) {
+
 			resourceName, err := extractor.resourceNameFromOperationPath(packageName, operationPath)
 			if err != nil {
 				klog.Errorf("Error extracting resource name (%s): %s", filePath, err.Error())
 				continue
 			}
 
-			resourceType, err := extractor.resourceTypeFromOperation(ctx, scanner, swagger, filePath, put)
+			resourceType, err := scanner.RunHandlerForSchema(ctx, *resourceSchema)
 			if err != nil {
 				if err == context.Canceled {
 					return err
@@ -66,6 +89,7 @@ func (extractor *typeExtractor) extractTypes(
 			}
 
 			if resourceType == nil {
+				// this indicates a filtered-out type
 				continue
 			}
 
@@ -91,6 +115,122 @@ func (extractor *typeExtractor) extractTypes(
 	}
 
 	return nil
+}
+
+// Look at the responses of the PUT to determine if this represents an ARM resource,
+// and if so, return the schema for it.
+// see: https://github.com/Azure/autorest/issues/1936#issuecomment-286928591
+func (extractor *SwaggerTypeExtractor) findARMResourceSchema(
+	filePath string,
+	swagger spec.Swagger,
+	op spec.Operation) *Schema {
+
+	if op.Responses != nil {
+		for statusCode, response := range op.Responses.StatusCodeResponses {
+			// only check OK and Created (per above linked comment)
+			if statusCode == 200 || statusCode == 201 {
+				result := extractor.getARMResourceSchemaFromResponse(filePath, swagger, response)
+				if result != nil {
+					return result
+				}
+			}
+		}
+	}
+
+	// none found
+	return nil
+}
+
+func (extractor *SwaggerTypeExtractor) getARMResourceSchemaFromResponse(filePath string, swagger spec.Swagger, response spec.Response) *Schema {
+	if response.Schema != nil {
+		// the schema can either be directly included
+
+		schema := MakeOpenAPISchema(
+			*response.Schema,
+			swagger,
+			filePath,
+			extractor.outputGroup,
+			extractor.outputVersion,
+			extractor.cache)
+
+		if isMarkedAsARMResource(schema) {
+			return &schema
+		}
+	} else if response.Ref.GetURL() != nil {
+		// or it can be under a $ref
+
+		filePath, swagger, refSchema := loadRefSchema(swagger, response.Ref, filePath, extractor.cache)
+		schema := MakeOpenAPISchema(
+			refSchema,
+			swagger,
+			filePath,
+			extractor.outputGroup,
+			extractor.outputVersion,
+			extractor.cache)
+
+		if isMarkedAsARMResource(schema) {
+			return &schema
+		}
+	}
+
+	return nil
+}
+
+// a Schema represents an ARM resource if it (or anything reachable via $ref or AllOf)
+// is marked with x-ms-azure-resource, or if it (or anything reachable via $ref or AllOf)
+// has each of the properties: id,name,type.
+func isMarkedAsARMResource(schema Schema) bool {
+	hasID := false
+	hasName := false
+	hasType := false
+
+	var recurse func(schema Schema) bool
+	recurse = func(schema Schema) bool {
+		if schema.extensions()["x-ms-azure-resource"] == true {
+			return true
+		}
+
+		props := schema.properties()
+		if !hasID {
+			if idProp, ok := props["id"]; ok {
+				if idProp.hasType("string") {
+					hasID = true
+				}
+			}
+		}
+
+		if !hasName {
+			if nameProp, ok := props["name"]; ok {
+				if nameProp.hasType("string") {
+					hasName = true
+				}
+			}
+		}
+
+		if !hasType {
+			if typeProp, ok := props["type"]; ok {
+				if typeProp.hasType("string") {
+					hasType = true
+				}
+			}
+		}
+
+		if schema.isRef() {
+			return recurse(schema.refSchema())
+		}
+
+		if schema.hasAllOf() {
+			for _, allOf := range schema.allOf() {
+				if recurse(allOf) {
+					return true
+				}
+			}
+		}
+
+		return hasID && hasName && hasType
+	}
+
+	return recurse(schema)
 }
 
 func expandEnumsInPath(operationPath string, parameters []spec.Parameter) []string {
@@ -141,7 +281,7 @@ func enumValuesToStrings(enumValues []interface{}) []string {
 	return result
 }
 
-func (extractor *typeExtractor) resourceNameFromOperationPath(packageName string, operationPath string) (astmodel.TypeName, error) {
+func (extractor *SwaggerTypeExtractor) resourceNameFromOperationPath(packageName string, operationPath string) (astmodel.TypeName, error) {
 	_, name, err := inferNameFromURLPath(operationPath)
 	if err != nil {
 		return astmodel.TypeName{}, errors.Wrapf(err, "unable to infer name from path %q", operationPath)
@@ -149,30 +289,6 @@ func (extractor *typeExtractor) resourceNameFromOperationPath(packageName string
 
 	packageRef := astmodel.MakeLocalPackageReference(extractor.idFactory.CreateGroupName(extractor.outputGroup), packageName)
 	return astmodel.MakeTypeName(packageRef, name), nil
-}
-
-func (extractor *typeExtractor) resourceTypeFromOperation(
-	ctx context.Context,
-	scanner *jsonast.SchemaScanner,
-	schemaRoot spec.Swagger,
-	filePath string,
-	operation *spec.Operation) (astmodel.Type, error) {
-
-	for _, param := range operation.Parameters {
-		if param.In == "body" && param.Required { // assume this is the Resource
-			schema := jsonast.MakeOpenAPISchema(
-				*param.Schema,
-				schemaRoot,
-				filePath,
-				extractor.outputGroup,
-				extractor.outputVersion,
-				extractor.cache)
-
-			return scanner.RunHandlerForSchema(ctx, schema)
-		}
-	}
-
-	return nil, nil
 }
 
 // inferNameFromURLPath attempts to extract a name from a Swagger operation path
@@ -201,7 +317,7 @@ func inferNameFromURLPath(operationPath string) (string, string, error) {
 
 				skippedLast = true
 			}
-		} else if swaggerGroupRegex.MatchString(urlPart) {
+		} else if SwaggerGroupRegex.MatchString(urlPart) {
 			group = urlPart
 			reading = true
 		}
@@ -218,5 +334,6 @@ func inferNameFromURLPath(operationPath string) (string, string, error) {
 	return group, name, nil
 }
 
+// SwaggerGroupRegex matches a “group” (Swagger ‘namespace’)
 // based on: https://github.com/Azure/autorest/blob/85de19623bdce3ccc5000bae5afbf22a49bc4665/core/lib/pipeline/metadata-generation.ts#L25
-var swaggerGroupRegex = regexp.MustCompile(`[Mm]icrosoft\.[^/\\]+`)
+var SwaggerGroupRegex = regexp.MustCompile(`[Mm]icrosoft\.[^/\\]+`)

--- a/hack/generator/pkg/jsonast/swagger_type_extractor.go
+++ b/hack/generator/pkg/jsonast/swagger_type_extractor.go
@@ -305,8 +305,13 @@ func inferNameFromURLPath(operationPath string) (string, string, error) {
 	reading := false
 	skippedLast := false
 	for _, urlPart := range urlParts {
+		if len(urlPart) == 0 {
+			// skip empty parts
+			continue
+		}
+
 		if reading {
-			if len(urlPart) > 0 && urlPart[0] != '{' {
+			if urlPart[0] != '{' {
 				name += strings.ToUpper(urlPart[0:1]) + urlPart[1:]
 				skippedLast = false
 			} else {

--- a/hack/generator/pkg/jsonast/swagger_type_extractor.go
+++ b/hack/generator/pkg/jsonast/swagger_type_extractor.go
@@ -95,7 +95,7 @@ func (extractor *SwaggerTypeExtractor) ExtractTypes(
 
 			if existingResource, ok := resources[resourceName]; ok {
 				if !astmodel.TypeEquals(existingResource.Type(), resourceType) {
-					klog.Errorf("RESOURCE already defined differently 😱: %v", resourceName)
+					return errors.Errorf("resource already defined differently: %v", resourceName)
 				}
 			} else {
 				resources.Add(astmodel.MakeTypeDefinition(resourceName, resourceType))

--- a/hack/generator/pkg/jsonast/swagger_type_extractor_test.go
+++ b/hack/generator/pkg/jsonast/swagger_type_extractor_test.go
@@ -41,6 +41,15 @@ func Test_InferNameFromURLPath_FailsWithNoGroupName(t *testing.T) {
 	g.Expect(err.Error()).To(ContainSubstring("no group name"))
 }
 
+func Test_InferNameFromURLPath_SkipsDefault(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	group, name, err := inferNameFromURLPath("Microsoft.Storage/storageAccounts/{accountName}/blobServices/default/containers/{containerName}")
+	g.Expect(err).To(BeNil())
+	g.Expect(group).To(Equal("Microsoft.Storage"))
+	g.Expect(name).To(Equal("StorageAccountsBlobServicesContainers"))
+}
+
 func Test_expandEnumsInPath_ExpandsAnEnum(t *testing.T) {
 	g := NewGomegaWithT(t)
 

--- a/hack/generator/pkg/jsonast/swagger_type_extractor_test.go
+++ b/hack/generator/pkg/jsonast/swagger_type_extractor_test.go
@@ -3,7 +3,7 @@
  * Licensed under the MIT license.
  */
 
-package codegen
+package jsonast
 
 import (
 	"fmt"


### PR DESCRIPTION
With these changes there are ~~199~~ 24 types with missing status info:

* Make resource name lookup case-insensitive; Swagger has `Mediaservices` but the ARM Schema has `MediaServices` (I’m not sure how this name is being produced).
* Tighten up how we detect ARM resources; we should have been looking at the `PUT` _responses_, not the `PUT` body. 
* Exclude `/default/` part of operation path from resource name.
* Exclude some old versions of services with issues with Swagger specs (missing information or missing version).

`SwaggerTypeExtractor` has moved into `jsonast` as it seems to make more sense there; it uses the `Schema` abstraction types now.

This also fixes the 😱 log message (sadly).