### PR TITLE
Try to enable coverpkg for integration tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,7 @@ test-cover: $(KUBECTL) $(KUBE_APISERVER) $(ETCD) header-check lint ## Run tests 
 	$(GO) test ./... -coverprofile=cover.out -coverpkg=./...
 
 test-cover-int: $(KUBECTL) $(KUBE_APISERVER) $(ETCD) header-check lint ## Run tests w/ code coverage (./cover.out)
-	$(GO) test ./... -tags integration -coverprofile=cover.out
+	$(GO) test ./... -tags integration -coverprofile=cover.out -coverpkg=./...
 
 $(KUBECTL) $(KUBE_APISERVER) $(ETCD) $(KUBEBUILDER): ## Install test asset kubectl, kube-apiserver, etcd
 	. ./scripts/fetch_ext_bins.sh && fetch_tools

--- a/hack/generator/main.go
+++ b/hack/generator/main.go
@@ -18,7 +18,7 @@ import (
 func main() {
 	flagSet := goflag.NewFlagSet(os.Args[0], goflag.ExitOnError)
 	klog.InitFlags(flagSet)
-	flagSet.Parse(os.Args[1:])
+	flagSet.Parse(os.Args[1:]) //nolint: error will never be returned due to ExitOnError
 	flag.CommandLine.AddGoFlagSet(flagSet)
 	cmd.Execute()
 }

--- a/hack/generator/main.go
+++ b/hack/generator/main.go
@@ -7,6 +7,8 @@ package main
 
 import (
 	goflag "flag"
+	"os"
+
 	flag "github.com/spf13/pflag"
 	"k8s.io/klog/v2"
 
@@ -14,8 +16,9 @@ import (
 )
 
 func main() {
-	klog.InitFlags(nil)
-	goflag.Parse()
-	flag.CommandLine.AddGoFlagSet(goflag.CommandLine)
+	flagSet := goflag.NewFlagSet(os.Args[0], goflag.ExitOnError)
+	klog.InitFlags(flagSet)
+	flagSet.Parse(os.Args[1:])
+	flag.CommandLine.AddGoFlagSet(flagSet)
 	cmd.Execute()
 }

--- a/main.go
+++ b/main.go
@@ -32,9 +32,13 @@ import (
 var (
 	scheme   = runtime.NewScheme()
 	setupLog = ctrl.Log.WithName("setup")
+	flagSet  = flag.NewFlagSet(os.Args[0], flag.ExitOnError)
 )
 
 func init() {
+	// must use our flagSet so it doesn’t conflict with other flag definitions using global flagset
+	// see: https://github.com/golang/go/issues/27336
+	klog.InitFlags(flagSet)
 
 	_ = clientgoscheme.AddToScheme(scheme)
 	_ = microsoftresourcesv20191001.AddToScheme(scheme)
@@ -48,16 +52,12 @@ func init() {
 }
 
 func main() {
-	// don’t do this in init() or it conflicts with other calls to InitFlags when used with coverpkg
-	// see: https://github.com/golang/go/issues/27336
-	klog.InitFlags(nil)
-
 	var metricsAddr string
 	var enableLeaderElection bool
-	flag.StringVar(&metricsAddr, "metrics-addr", ":8080", "The address the metric endpoint binds to.")
-	flag.BoolVar(&enableLeaderElection, "enable-leader-election", false,
+	flagSet.StringVar(&metricsAddr, "metrics-addr", ":8080", "The address the metric endpoint binds to.")
+	flagSet.BoolVar(&enableLeaderElection, "enable-leader-election", false,
 		"Enable leader election for controller manager. Enabling this will ensure there is only one active controller manager.")
-	flag.Parse()
+	flagSet.Parse(os.Args[1:])
 
 	ctrl.SetLogger(klogr.New())
 

--- a/main.go
+++ b/main.go
@@ -57,7 +57,7 @@ func main() {
 	flagSet.StringVar(&metricsAddr, "metrics-addr", ":8080", "The address the metric endpoint binds to.")
 	flagSet.BoolVar(&enableLeaderElection, "enable-leader-election", false,
 		"Enable leader election for controller manager. Enabling this will ensure there is only one active controller manager.")
-	flagSet.Parse(os.Args[1:])
+	flagSet.Parse(os.Args[1:]) //nolint: error will never be returned due to ExitOnError
 
 	ctrl.SetLogger(klogr.New())
 

--- a/main.go
+++ b/main.go
@@ -35,7 +35,6 @@ var (
 )
 
 func init() {
-	klog.InitFlags(nil)
 
 	_ = clientgoscheme.AddToScheme(scheme)
 	_ = microsoftresourcesv20191001.AddToScheme(scheme)
@@ -49,6 +48,10 @@ func init() {
 }
 
 func main() {
+	// don’t do this in init() or it conflicts with other calls to InitFlags when used with coverpkg
+	// see: https://github.com/golang/go/issues/27336
+	klog.InitFlags(nil)
+
 	var metricsAddr string
 	var enableLeaderElection bool
 	flag.StringVar(&metricsAddr, "metrics-addr", ":8080", "The address the metric endpoint binds to.")


### PR DESCRIPTION
Defining flags in `init` causes them to conflict when all packages are loaded, causing the tests to abort. Instead define the flags only inside the `main` function.