### PR TITLE
Add ability to transform types of properties

### DIFF
--- a/hack/generator/azure-arm.yaml
+++ b/hack/generator/azure-arm.yaml
@@ -234,6 +234,16 @@ typeTransformers:
     because: NumberOrExpression is an ARM template artifact that doesn't make sense in CRDs
     target:
       name: float
+  - group: deploymenttemplate
+    name: ResourceBase
+    property: Tags
+    target:
+      map:
+        key: 
+          name: string
+        value:
+          name: string
+    because: Tags is defined as map[string]interface{} when it should be map[string]string
 
 status:
   schemaRoot: "./azure-rest-api-specs/specification"

--- a/hack/generator/pkg/astmodel/array_type.go
+++ b/hack/generator/pkg/astmodel/array_type.go
@@ -6,6 +6,7 @@
 package astmodel
 
 import (
+	"fmt"
 	"go/ast"
 )
 
@@ -59,4 +60,9 @@ func (array *ArrayType) Equals(t Type) bool {
 	}
 
 	return false
+}
+
+// String implements fmt.Stringer
+func (array *ArrayType) String() string {
+	return fmt.Sprintf("[]%s", array.element.String())
 }

--- a/hack/generator/pkg/astmodel/enum_type.go
+++ b/hack/generator/pkg/astmodel/enum_type.go
@@ -6,6 +6,7 @@
 package astmodel
 
 import (
+	"fmt"
 	"go/ast"
 	"go/token"
 	"sort"
@@ -175,4 +176,9 @@ func (enum *EnumType) BaseType() *PrimitiveType {
 
 func GetEnumValueId(name TypeName, value EnumValue) string {
 	return name.name + value.Identifier
+}
+
+// String implements fmt.Stringer
+func (enum *EnumType) String() string {
+	return fmt.Sprintf("(enum: %s)", enum.baseType.String())
 }

--- a/hack/generator/pkg/astmodel/map_type.go
+++ b/hack/generator/pkg/astmodel/map_type.go
@@ -6,6 +6,7 @@
 package astmodel
 
 import (
+	"fmt"
 	"go/ast"
 )
 
@@ -74,4 +75,9 @@ func (m *MapType) Equals(t Type) bool {
 	}
 
 	return false
+}
+
+// String implements fmt.Stringer
+func (m *MapType) String() string {
+	return fmt.Sprintf("map[%s]%s", m.key.String(), m.value.String())
 }

--- a/hack/generator/pkg/astmodel/object_type.go
+++ b/hack/generator/pkg/astmodel/object_type.go
@@ -342,3 +342,8 @@ func (objectType *ObjectType) copy() *ObjectType {
 
 	return result
 }
+
+// String implements fmt.Stringer
+func (objectType *ObjectType) String() string {
+	return "(object)"
+}

--- a/hack/generator/pkg/astmodel/optional_type.go
+++ b/hack/generator/pkg/astmodel/optional_type.go
@@ -6,6 +6,7 @@
 package astmodel
 
 import (
+	"fmt"
 	"go/ast"
 )
 
@@ -88,4 +89,9 @@ func (optional *OptionalType) Equals(t Type) bool {
 // BaseType returns the underlying type
 func (optional *OptionalType) BaseType() Type {
 	return optional.element
+}
+
+// String implements fmt.Stringer
+func (optional *OptionalType) String() string {
+	return fmt.Sprintf("(optional: %s)", optional.element.String())
 }

--- a/hack/generator/pkg/astmodel/primitive_type.go
+++ b/hack/generator/pkg/astmodel/primitive_type.go
@@ -65,3 +65,8 @@ func (prim *PrimitiveType) Equals(t Type) bool {
 func (prim *PrimitiveType) Name() string {
 	return prim.name
 }
+
+// String implements fmt.Stringer
+func (prim *PrimitiveType) String() string {
+	return prim.name
+}

--- a/hack/generator/pkg/astmodel/resource.go
+++ b/hack/generator/pkg/astmodel/resource.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"go/ast"
 	"go/token"
+
 	"k8s.io/klog/v2"
 
 	"github.com/pkg/errors"
@@ -253,4 +254,9 @@ func (definition *ResourceType) AsDeclarations(codeGenerationContext *CodeGenera
 	declarations = append(declarations, resourceDeclaration)
 
 	return declarations
+}
+
+// String implements fmt.Stringer
+func (*ResourceType) String() string {
+	return "(resource)"
 }

--- a/hack/generator/pkg/astmodel/type.go
+++ b/hack/generator/pkg/astmodel/type.go
@@ -29,6 +29,10 @@ type Type interface {
 
 	// Equals returns true if the passed type is the same as this one, false otherwise
 	Equals(t Type) bool
+
+	// Make sure all Types have a printable version for debugging/user info.
+	// This doesn't need to be a full representation of the type.
+	fmt.Stringer
 }
 
 // TypeEquals decides if the types are the same and handles the `nil` case

--- a/hack/generator/pkg/astmodel/type_name.go
+++ b/hack/generator/pkg/astmodel/type_name.go
@@ -82,7 +82,7 @@ func (typeName TypeName) Equals(t Type) bool {
 	return false
 }
 
-// String returns the string representation of the type name
+// String returns the string representation of the type name, and implements fmt.Stringer.
 func (typeName TypeName) String() string {
 	return fmt.Sprintf("%s/%s", typeName.PackageReference, typeName.name)
 }
@@ -91,6 +91,3 @@ func (typeName TypeName) String() string {
 func (typeName TypeName) Singular() TypeName {
 	return MakeTypeName(typeName.PackageReference, flect.Singularize(typeName.name))
 }
-
-// Ensure we implement Stringer
-var _ fmt.Stringer = &TypeName{}

--- a/hack/generator/pkg/config/configuration.go
+++ b/hack/generator/pkg/config/configuration.go
@@ -29,7 +29,11 @@ type Configuration struct {
 	// Filters used to control which types are created from the JSON schema
 	TypeFilters []*TypeFilter `yaml:"typeFilters"`
 	// Transformers used to remap types
-	TypeTransformers []*TypeTransformer `yaml:"typeTransformers"`
+	Transformers []*TypeTransformer `yaml:"typeTransformers"`
+
+	// after init TypeTransformers is split into property and non-property transformers
+	typeTransformers     []*TypeTransformer
+	propertyTransformers []*TypeTransformer
 }
 
 // NewConfiguration returns a new empty Configuration
@@ -114,12 +118,25 @@ func (config *Configuration) initialize(configPath string) error {
 		}
 	}
 
-	for _, transformer := range config.TypeTransformers {
+	// split Transformers into two sets
+	var typeTransformers []*TypeTransformer
+	var propertyTransformers []*TypeTransformer
+	for _, transformer := range config.Transformers {
 		err := transformer.Initialize()
 		if err != nil {
 			errs = append(errs, err)
 		}
+
+		if transformer.Property != "" {
+			propertyTransformers = append(propertyTransformers, transformer)
+		} else {
+			typeTransformers = append(typeTransformers, transformer)
+		}
 	}
+
+	config.Transformers = nil
+	config.typeTransformers = typeTransformers
+	config.propertyTransformers = propertyTransformers
 
 	// make Status.SchemaRoot an absolute path
 	absLocation, err := filepath.Abs(configPath)
@@ -175,12 +192,10 @@ func (config *Configuration) ShouldPrune(typeName astmodel.TypeName) (result Sho
 // TransformType uses the configured type transformers to transform a type name (reference) to a different type.
 // If no transformation is performed, nil is returned
 func (config *Configuration) TransformType(name astmodel.TypeName) (astmodel.Type, string) {
-	for _, transformer := range config.TypeTransformers {
-		if transformer.propertyRegex == nil { // exclude property transformers
-			result := transformer.TransformTypeName(name)
-			if result != nil {
-				return result, transformer.Because
-			}
+	for _, transformer := range config.typeTransformers {
+		result := transformer.TransformTypeName(name)
+		if result != nil {
+			return result, transformer.Because
 		}
 	}
 
@@ -199,34 +214,31 @@ type PropertyTransformResult struct {
 // TransformTypeProperties applies any property transformers to the type
 func (config *Configuration) TransformTypeProperties(name astmodel.TypeName, objectType *astmodel.ObjectType) *PropertyTransformResult {
 
-	for _, transformer := range config.TypeTransformers {
-		if transformer.propertyRegex != nil { // exclude non-property transformers
-			if transformer.AppliesToType(name) {
-				found := false
-				var propName astmodel.PropertyName
-				var newProps []*astmodel.PropertyDefinition
+	for _, transformer := range config.propertyTransformers {
+		if transformer.AppliesToType(name) {
+			found := false
+			var propName astmodel.PropertyName
+			var newProps []*astmodel.PropertyDefinition
 
-				for _, prop := range objectType.Properties() {
-					if transformer.propertyNameMatches(prop.PropertyName()) {
-						found = true
-						propName = prop.PropertyName()
+			for _, prop := range objectType.Properties() {
+				if transformer.propertyNameMatches(prop.PropertyName()) {
+					found = true
+					propName = prop.PropertyName()
 
-						newProps = append(newProps, prop.WithType(transformer.targetType))
-					} else {
-						newProps = append(newProps, prop)
-					}
-				}
-
-				if found {
-					return &PropertyTransformResult{
-						NewType:         objectType.WithProperties(newProps...),
-						Property:        propName,
-						NewPropertyType: transformer.targetType,
-						Because:         transformer.Because,
-					}
+					newProps = append(newProps, prop.WithType(transformer.targetType))
+				} else {
+					newProps = append(newProps, prop)
 				}
 			}
 
+			if found {
+				return &PropertyTransformResult{
+					NewType:         objectType.WithProperties(newProps...),
+					Property:        propName,
+					NewPropertyType: transformer.targetType,
+					Because:         transformer.Because,
+				}
+			}
 		}
 	}
 

--- a/hack/generator/pkg/config/type_transformer.go
+++ b/hack/generator/pkg/config/type_transformer.go
@@ -7,6 +7,7 @@ package config
 
 import (
 	"fmt"
+	"regexp"
 
 	"github.com/pkg/errors"
 
@@ -17,16 +18,55 @@ import (
 type TransformTarget struct {
 	PackagePath string `yaml:",omitempty"`
 	Name        string `yaml:",omitempty"`
+	Map         *MapType
+}
+
+type MapType struct {
+	Key   TransformTarget `yaml:",omitempty"`
+	Value TransformTarget `yaml:",omitempty"`
 }
 
 // A TypeTransformer is used to remap types
 type TypeTransformer struct {
 	TypeMatcher `yaml:",inline"`
 
+	// Property is a wildcard matching specific properties on the types selected by this filter
+	Property      string `yaml:",omitempty"`
+	propertyRegex *regexp.Regexp
+
 	Target TransformTarget
 
 	// This is used purely for "caching" the actual astmodel type after Initialize()
 	targetType astmodel.Type
+}
+
+func produceTargetType(target TransformTarget, descriptor string) (astmodel.Type, error) {
+	if target.Name != "" {
+		if target.PackagePath == "" {
+			return primitiveTypeTarget(target.Name)
+		}
+
+		return astmodel.MakeTypeName(
+			astmodel.MakePackageReference(target.PackagePath),
+			target.Name), nil
+	}
+
+	if target.Map != nil {
+		keyType, err := produceTargetType(target.Map.Key, descriptor+"/map/value")
+		if err != nil {
+			return nil, err
+		}
+
+		valueType, err := produceTargetType(target.Map.Value, descriptor+"/map/key")
+		if err != nil {
+			return nil, err
+		}
+
+		return astmodel.NewMapType(keyType, valueType), nil
+	}
+
+	return nil, errors.Errorf("no target type found in %s", descriptor)
+
 }
 
 func (transformer *TypeTransformer) Initialize() error {
@@ -35,47 +75,39 @@ func (transformer *TypeTransformer) Initialize() error {
 		return err
 	}
 
-	if transformer.Target.Name == "" {
-		return errors.Errorf(
-			"type transformer for group: %s, version: %s, name: %s is missing type name to transform to",
+	transformer.propertyRegex = createGlobbingRegex(transformer.Property)
+
+	targetType, err := produceTargetType(transformer.Target, "target")
+	if err != nil {
+		return errors.Wrapf(
+			err,
+			"type transformer for group: %s, version: %s, name: %s",
 			transformer.Group,
 			transformer.Version,
 			transformer.Name)
 	}
 
-	// Type has no package -- must be a primitive type
-	if transformer.Target.PackagePath == "" {
-		return transformer.initializePrimitiveTypeTarget()
-	}
-
-	transformer.targetType = astmodel.MakeTypeName(
-		astmodel.MakePackageReference(transformer.Target.PackagePath),
-		transformer.Target.Name)
+	transformer.targetType = targetType
 	return nil
 }
 
-func (transformer *TypeTransformer) initializePrimitiveTypeTarget() error {
-	switch transformer.Target.Name {
+func primitiveTypeTarget(name string) (astmodel.Type, error) {
+	switch name {
 	case "bool":
-		transformer.targetType = astmodel.BoolType
+		return astmodel.BoolType, nil
 	case "float":
-		transformer.targetType = astmodel.FloatType
+		return astmodel.FloatType, nil
 	case "int":
-		transformer.targetType = astmodel.IntType
+		return astmodel.IntType, nil
 	case "string":
-		transformer.targetType = astmodel.StringType
+		return astmodel.StringType, nil
 	default:
-		return errors.Errorf(
-			"type transformer for group: %s, version: %s, name: %s has unknown"+
-				"primtive type transformation target: %s",
-			transformer.Group,
-			transformer.Version,
-			transformer.Name,
-			transformer.Target.Name)
-
+		return nil, errors.Errorf("unknown primitive type transformation target: %s", name)
 	}
+}
 
-	return nil
+func (transformer *TypeTransformer) propertyNameMatches(propName astmodel.PropertyName) bool {
+	return transformer.matches(transformer.Property, &transformer.propertyRegex, string(propName))
 }
 
 // TransformTypeName transforms the type with the specified name into the TypeTransformer target type if

--- a/hack/generator/pkg/config/type_transformer.go
+++ b/hack/generator/pkg/config/type_transformer.go
@@ -52,12 +52,12 @@ func produceTargetType(target TransformTarget, descriptor string) (astmodel.Type
 	}
 
 	if target.Map != nil {
-		keyType, err := produceTargetType(target.Map.Key, descriptor+"/map/value")
+		keyType, err := produceTargetType(target.Map.Key, descriptor+"/map/key")
 		if err != nil {
 			return nil, err
 		}
 
-		valueType, err := produceTargetType(target.Map.Value, descriptor+"/map/key")
+		valueType, err := produceTargetType(target.Map.Value, descriptor+"/map/value")
 		if err != nil {
 			return nil, err
 		}

--- a/hack/generator/pkg/config/type_transformer_test.go
+++ b/hack/generator/pkg/config/type_transformer_test.go
@@ -6,8 +6,9 @@
 package config_test
 
 import (
-	"github.com/Azure/k8s-infra/hack/generator/pkg/config"
 	"testing"
+
+	"github.com/Azure/k8s-infra/hack/generator/pkg/config"
 
 	"github.com/Azure/k8s-infra/hack/generator/pkg/astmodel"
 	. "github.com/onsi/gomega"
@@ -91,4 +92,64 @@ func Test_TransformCanTransform_ToComplexType(t *testing.T) {
 
 	// Tutor should be student
 	g.Expect(transformer.TransformTypeName(tutor2019)).To(Equal(student2019))
+}
+
+func Test_TransformCanTransform_ToNestedMapType(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	transformer := config.TypeTransformer{
+		TypeMatcher: config.TypeMatcher{Name: "tutor"},
+		Target: config.TransformTarget{
+			Map: &config.MapType{
+				Key: config.TransformTarget{
+					Name: "string",
+				},
+				Value: config.TransformTarget{
+					Map: &config.MapType{
+						Key: config.TransformTarget{
+							Name: "int",
+						},
+						Value: config.TransformTarget{
+							Name: "float",
+						},
+					},
+				},
+			},
+		},
+	}
+	err := transformer.Initialize()
+	g.Expect(err).To(BeNil())
+
+	expected := astmodel.NewMapType(
+		astmodel.StringType,
+		astmodel.NewMapType(
+			astmodel.IntType,
+			astmodel.FloatType))
+
+	g.Expect(transformer.TransformTypeName(tutor2019)).To(Equal(expected))
+}
+
+func Test_TransformWithMissingMapValue_ReportsError(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	transformer := config.TypeTransformer{
+		TypeMatcher: config.TypeMatcher{Name: "tutor"},
+		Target: config.TransformTarget{
+			Map: &config.MapType{
+				Key: config.TransformTarget{
+					Name: "string",
+				},
+				Value: config.TransformTarget{
+					Map: &config.MapType{
+						Value: config.TransformTarget{
+							Name: "int",
+						},
+					},
+				},
+			},
+		},
+	}
+	err := transformer.Initialize()
+	g.Expect(err).To(Not(BeNil()))
+	g.Expect(err.Error()).To(ContainSubstring("no target type found in target/map/value/map/key"))
 }

--- a/hack/generator/pkg/config/type_transformer_test.go
+++ b/hack/generator/pkg/config/type_transformer_test.go
@@ -153,3 +153,30 @@ func Test_TransformWithMissingMapValue_ReportsError(t *testing.T) {
 	g.Expect(err).To(Not(BeNil()))
 	g.Expect(err.Error()).To(ContainSubstring("no target type found in target/map/value/map/key"))
 }
+
+func Test_TransformWithMissingTargetType_ReportsError(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	transformer := config.TypeTransformer{
+		TypeMatcher: config.TypeMatcher{Name: "tutor"},
+	}
+
+	err := transformer.Initialize()
+	g.Expect(err).To(Not(BeNil()))
+	g.Expect(err.Error()).To(ContainSubstring("no target type found"))
+}
+
+func Test_TransformWithNonExistentPrimitive_ReportsError(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	transformer := config.TypeTransformer{
+		TypeMatcher: config.TypeMatcher{Name: "tutor"},
+		Target: config.TransformTarget{
+			Name: "nemo",
+		},
+	}
+
+	err := transformer.Initialize()
+	g.Expect(err).To(Not(BeNil()))
+	g.Expect(err.Error()).To(ContainSubstring("unknown primitive type transformation target: nemo"))
+}

--- a/hack/generator/pkg/config/type_transformer_test.go
+++ b/hack/generator/pkg/config/type_transformer_test.go
@@ -166,6 +166,29 @@ func Test_TransformWithMissingTargetType_ReportsError(t *testing.T) {
 	g.Expect(err.Error()).To(ContainSubstring("no target type found"))
 }
 
+func Test_TransformWithMultipleTargets_ReportsError(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	transformer := config.TypeTransformer{
+		TypeMatcher: config.TypeMatcher{Name: "tutor"},
+		Target: config.TransformTarget{
+			Name: "int",
+			Map: &config.MapType{
+				Key: config.TransformTarget{
+					Name: "string",
+				},
+				Value: config.TransformTarget{
+					Name: "string",
+				},
+			},
+		},
+	}
+
+	err := transformer.Initialize()
+	g.Expect(err).To(Not(BeNil()))
+	g.Expect(err.Error()).To(ContainSubstring("multiple target types defined"))
+}
+
 func Test_TransformWithNonExistentPrimitive_ReportsError(t *testing.T) {
 	g := NewGomegaWithT(t)
 

--- a/hack/generator/pkg/jsonast/jsonast.go
+++ b/hack/generator/pkg/jsonast/jsonast.go
@@ -483,6 +483,14 @@ func generateDefinitionsFor(
 		return nil, err
 	}
 
+	if obj, ok := result.(*astmodel.ObjectType); ok {
+		transformed := scanner.configuration.TransformTypeProperties(typeName, obj)
+		if transformed != nil {
+			klog.V(2).Infof("Transforming %s.%s -> %s because %s", typeName, transformed.Property, transformed.NewPropertyType.String(), transformed.Because)
+			result = transformed.NewType
+		}
+	}
+
 	if isResource {
 		result = astmodel.NewAzureResourceType(result, nil, typeName)
 	}


### PR DESCRIPTION
This is useful to fixup some types that have properties with types that are problematic in CRDs, like `ResourceBase` in the main deployment template.

At the moment `deploymenttemplate` group is excluded by a filter but this will be included soon to address #211.