### PR TITLE
Allow property rewrites to specify match

### DIFF
--- a/hack/generator/azure-arm.yaml
+++ b/hack/generator/azure-arm.yaml
@@ -159,10 +159,6 @@ exportFilters:
     version: v20160301
     because: it generates types containing AnyType
   - action: exclude
-    group: microsoft.visualstudio
-    version: v20140226
-    because: it generates types containing AnyType
-  - action: exclude
     group: microsoft.vmwarecloudsimple
     version: v20190401
     because: it generates types containing AnyType
@@ -234,9 +230,14 @@ typeTransformers:
     because: NumberOrExpression is an ARM template artifact that doesn't make sense in CRDs
     target:
       name: float
-  - group: deploymenttemplate
-    name: ResourceBase
+  - name: "*"
     property: Tags
+    ifType: 
+        map:
+          key:
+            name: string
+          value:
+            name: any
     target:
       map:
         key: 

--- a/hack/generator/pkg/codegen/code_generator.go
+++ b/hack/generator/pkg/codegen/code_generator.go
@@ -48,12 +48,13 @@ func NewCodeGeneratorFromConfig(configuration *config.Configuration, idFactory a
 func corePipelineStages(idFactory astmodel.IdentifierFactory, configuration *config.Configuration) []PipelineStage {
 	return []PipelineStage{
 		augmentResourcesWithStatus(idFactory, configuration),
+		applyExportFilters(configuration), // should come after status types are loaded
+		stripUnreferencedTypeDefinitions(),
 		nameTypesForCRD(idFactory),
+		applyPropertyRewrites(configuration), // must come after nameTypesForCRD so that objects are all expanded
 		determineResourceOwnership(),
 		removeTypeAliases(),
 		improveResourcePluralization(),
-		applyExportFilters(configuration),
-		stripUnreferencedTypeDefinitions(),
 		createArmTypesAndCleanKubernetesTypes(idFactory),
 		checkForAnyType(),
 		checkForMissingStatusInformation(),

--- a/hack/generator/pkg/codegen/pipeline_apply_property_rewrites.go
+++ b/hack/generator/pkg/codegen/pipeline_apply_property_rewrites.go
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) Microsoft Corporation.
+ * Licensed under the MIT license.
+ */
+
+package codegen
+
+import (
+	"context"
+
+	"github.com/Azure/k8s-infra/hack/generator/pkg/astmodel"
+	"github.com/Azure/k8s-infra/hack/generator/pkg/config"
+	"k8s.io/klog/v2"
+)
+
+// applyPropertyRewrites applies any typeTransformers for properties.
+// It is its own pipeline stage so that we can apply it after the allOf/oneOf types have
+// been "lowered" to objects.
+func applyPropertyRewrites(config *config.Configuration) PipelineStage {
+
+	return MakePipelineStage(
+		"property-rewrites",
+		"Applying type transformers to properties",
+		func(ctx context.Context, types astmodel.Types) (astmodel.Types, error) {
+
+			newTypes := make(astmodel.Types, len(types))
+			for name, t := range types {
+
+				objectType, ok := t.Type().(*astmodel.ObjectType)
+				if !ok {
+					newTypes.Add(t)
+					continue
+				}
+
+				transformed := config.TransformTypeProperties(name, objectType)
+				if transformed != nil {
+					klog.V(2).Infof("Transforming %s.%s -> %s because %s",
+						name,
+						transformed.Property,
+						transformed.NewPropertyType.String(),
+						transformed.Because)
+
+					objectType = transformed.NewType
+				}
+
+				newTypes.Add(t.WithType(objectType))
+			}
+
+			return newTypes, nil
+		})
+}

--- a/hack/generator/pkg/config/configuration.go
+++ b/hack/generator/pkg/config/configuration.go
@@ -203,42 +203,13 @@ func (config *Configuration) TransformType(name astmodel.TypeName) (astmodel.Typ
 	return nil, ""
 }
 
-// PropertyTransformResult is the result of applying a property type transform
-type PropertyTransformResult struct {
-	NewType         *astmodel.ObjectType
-	Property        astmodel.PropertyName
-	NewPropertyType astmodel.Type
-	Because         string
-}
-
 // TransformTypeProperties applies any property transformers to the type
 func (config *Configuration) TransformTypeProperties(name astmodel.TypeName, objectType *astmodel.ObjectType) *PropertyTransformResult {
 
 	for _, transformer := range config.propertyTransformers {
-		if transformer.AppliesToType(name) {
-			found := false
-			var propName astmodel.PropertyName
-			var newProps []*astmodel.PropertyDefinition
-
-			for _, prop := range objectType.Properties() {
-				if transformer.propertyNameMatches(prop.PropertyName()) {
-					found = true
-					propName = prop.PropertyName()
-
-					newProps = append(newProps, prop.WithType(transformer.targetType))
-				} else {
-					newProps = append(newProps, prop)
-				}
-			}
-
-			if found {
-				return &PropertyTransformResult{
-					NewType:         objectType.WithProperties(newProps...),
-					Property:        propName,
-					NewPropertyType: transformer.targetType,
-					Because:         transformer.Because,
-				}
-			}
+		result := transformer.TransformProperty(name, objectType)
+		if result != nil {
+			return result
 		}
 	}
 

--- a/hack/generator/pkg/jsonast/jsonast.go
+++ b/hack/generator/pkg/jsonast/jsonast.go
@@ -483,14 +483,6 @@ func generateDefinitionsFor(
 		return nil, err
 	}
 
-	if obj, ok := result.(*astmodel.ObjectType); ok {
-		transformed := scanner.configuration.TransformTypeProperties(typeName, obj)
-		if transformed != nil {
-			klog.V(2).Infof("Transforming %s.%s -> %s because %s", typeName, transformed.Property, transformed.NewPropertyType.String(), transformed.Because)
-			result = transformed.NewType
-		}
-	}
-
 	if isResource {
 		result = astmodel.NewAzureResourceType(result, nil, typeName)
 	}


### PR DESCRIPTION
This allows us to implement a generic fix for `Tags` properties that have a type of `map[string]interface{}`. Also put it into its own pipeline stage as this removes a little complexity from `jsonast`. 