### PR TITLE
Filter out AnyType packages in the check stage

### DIFF
--- a/hack/generator/azure-arm.yaml
+++ b/hack/generator/azure-arm.yaml
@@ -60,169 +60,103 @@ exportFilters:
     name: ResourceBase
     because: this type is not used
 
-  # Exclusions for packages that currently produce types including AnyType.
-  # TODO: get rid of these, either by chasing the teams generating
-  # weird json or by handling them differently in the generator.
-  - action: exclude
-    group: microsoft.authorization
-    because: it generates types containing AnyType
-  - action: exclude
-    group: microsoft.automation
-    version: v20151031
-    because: it generates types containing AnyType
-  - action: exclude
-    group: microsoft.cognitiveservices
-    version: v20170418
-    because: it generates types containing AnyType
-  - action: exclude
-    group: microsoft.compute
-    because: it generates types containing AnyType
-  - action: exclude
-    group: microsoft.compute.extensions
-    because: it generates types containing AnyType
-  - action: exclude
-    group: microsoft.compute.galleries
-    because: it generates types containing AnyType
-  - action: exclude
-    group: microsoft.containerinstance
-    because: it generates types containing AnyType
-  - action: exclude
-    group: microsoft.containerregistry
-    version: v20171001
-    because: it generates types containing AnyType
-  - action: exclude
-    group: microsoft.datafactory
-    version: v20180601
-    because: it generates types containing AnyType
-  - action: exclude
-    group: microsoft.eventgrid
-    because: it generates types containing AnyType
-  - action: exclude
-    group: microsoft.importexport
-    version: v20161101
-    because: it generates types containing AnyType
-  - action: exclude
-    group: microsoft.insights
-    version: v20180301
-    because: it generates types containing AnyType
-  - action: exclude
-    group: microsoft.keyvault
-    version: v20150601
-    because: it generates types containing AnyType
-  - action: exclude
-    group: microsoft.kusto
-    because: it generates types containing AnyType
-  - action: exclude
-    group: microsoft.logic
-    because: it generates types containing AnyType
-  - action: exclude
-    group: microsoft.machinelearning
-    version: v20170101
-    because: it generates types containing AnyType
-  - action: exclude
-    group: microsoft.machinelearningservices
-    version: v20200101
-    because: it generates types containing AnyType
-  - action: exclude
-    group: microsoft.migrate
-    version: v20191001
-    because: it generates types containing AnyType
-  - action: exclude
-    group: microsoft.netapp
-    because: it generates types containing AnyType
-  - action: exclude
-    group: microsoft.network
-    because: it generates types containing AnyType
-  - action: exclude
-    group: microsoft.notificationhubs
-    version: v20150401
-    because: it generates types containing AnyType
-  - action: exclude
-    group: microsoft.recoveryservices
-    because: it generates types containing AnyType
-  - action: exclude
-    group: microsoft.relay
-    because: it generates types containing AnyType
-  - action: exclude
-    group: microsoft.resources
-    because: it generates types containing AnyType
-  - action: exclude
-    group: microsoft.servicebus
-    version: v20170401
-    because: it generates types containing AnyType
-  - action: exclude
-    group: microsoft.storage
-    version: v20190601
-    because: it generates types containing AnyType
-  - action: exclude
-    group: microsoft.streamanalytics
-    version: v20160301
-    because: it generates types containing AnyType
-  - action: exclude
-    group: microsoft.vmwarecloudsimple
-    version: v20190401
-    because: it generates types containing AnyType
-  - action: exclude
-    group: microsoft.web
-    because: it generates types containing AnyType
-# The following are very old versions that have missing or otherwise problematic Swagger specs:
-  - action: exclude
-    group: microsoft.insights
-    version: v20140401
-    because: old version with no Swagger information to generate Status types
-  - action: exclude
-    group: microsoft.storage
-    version: v20150801
-    because: old version with no Swagger information to generate Status types
-  - action: exclude
-    group: microsoft.servicefabric
-    version: v20160301
-    because: old version with no Swagger information to generate Status types
-  - action: exclude
-    group: microsoft.documentdb
-    version: v20150408
-    because: old version with no Swagger information to generate Status types
-  - action: exclude
-    group: microsoft.apimanagement
-    version: v20160707
-    because: missing information from Swagger spec
-# The following end up with AnyType in Status:
-  - action: exclude
-    group: microsoft.containerservice
-    version: v20180331
-    because: it generates types containing AnyType
-  - action: exclude
-    group: microsoft.containerservice
-    version: v20190601
-    because: it generates types containing AnyType
-  - action: exclude
-    group: microsoft.insights
-    version: v20150501
-    because: it generates types containing AnyType
-  - action: exclude
-    group: microsoft.insights
-    version: v20160301
-    because: it generates types containing AnyType
-  - action: exclude
-    group: microsoft.insights
-    version: v20170401
-    because: it generates types containing AnyType
-  - action: exclude
-    group: microsoft.insights
-    version: v20180416
-    because: it generates types containing AnyType
-  - action: exclude
-    group: microsoft.insights
-    version: v20190301
-    because: it generates types containing AnyType
-  - action: exclude
-    group: microsoft.apimanagement
-    version: v20190101
-    because: it generates types containing AnyType
-  - action: exclude
-    group: microsoft.powerbi
-    version: v20160129
-    because: it generates types containing AnyType
+# Exclusions for packages that currently produce types including AnyType.
+# TODO: get rid of these, either by chasing the teams generating
+# weird json or by handling them differently in the generator.
+anyTypePackages:
+  - microsoft.authorization/v20180301
+  - microsoft.authorization/v20180501
+  - microsoft.authorization/v20190101
+  - microsoft.authorization/v20190601
+  - microsoft.authorization/v20190901
+  - microsoft.automation/v20151031
+  - microsoft.cognitiveservices/v20170418
+  - microsoft.compute.extensions/v20180601
+  - microsoft.compute.extensions/v20181001
+  - microsoft.compute.extensions/v20190301
+  - microsoft.compute.extensions/v20190701
+  - microsoft.compute.galleries/v20180601
+  - microsoft.compute.galleries/v20190301
+  - microsoft.compute/v20150801
+  - microsoft.compute/v20170330
+  - microsoft.compute/v20171201
+  - microsoft.compute/v20180601
+  - microsoft.compute/v20181001
+  - microsoft.compute/v20190301
+  - microsoft.compute/v20190701
+  - microsoft.containerinstance/v20180401
+  - microsoft.containerinstance/v20181001
+  - microsoft.containerregistry/v20171001
+  - microsoft.datafactory/v20180601
+  - microsoft.eventgrid/v20180101
+  - microsoft.eventgrid/v20190101
+  - microsoft.eventgrid/v20190601
+  - microsoft.keyvault/v20150601
+  - microsoft.kusto/v20190515
+  - microsoft.kusto/v20191109
+  - microsoft.kusto/v20200215
+  - microsoft.logic/v20160601
+  - microsoft.logic/v20161001
+  - microsoft.logic/v20170701
+  - microsoft.machinelearning/v20170101
+  - microsoft.machinelearningservices/v20200101
+  - microsoft.migrate/v20191001
+  - microsoft.netapp/v20170815
+  - microsoft.netapp/v20190501
+  - microsoft.network/v20170901
+  - microsoft.network/v20171001
+  - microsoft.network/v20171101
+  - microsoft.network/v20180101
+  - microsoft.network/v20180201
+  - microsoft.network/v20180401
+  - microsoft.network/v20180601
+  - microsoft.network/v20180701
+  - microsoft.network/v20180801
+  - microsoft.network/v20180901
+  - microsoft.network/v20181001
+  - microsoft.network/v20181101
+  - microsoft.network/v20181201
+  - microsoft.network/v20190201
+  - microsoft.network/v20190401
+  - microsoft.network/v20190601
+  - microsoft.network/v20190701
+  - microsoft.network/v20190801
+  - microsoft.network/v20190901
+  - microsoft.network/v20191101
+  - microsoft.network/v20191201
+  - microsoft.network/v20200301
+  - microsoft.network/v20200401
+  - microsoft.network/v20200501
+  - microsoft.recoveryservices/v20160601
+  - microsoft.recoveryservices/v20180110
+  - microsoft.relay/v20160701
+  - microsoft.relay/v20170401
+  - microsoft.resources/v20150101
+  - microsoft.resources/v20160201
+  - microsoft.resources/v20160901
+  - microsoft.resources/v20170510
+  - microsoft.resources/v20180501
+  - microsoft.resources/v20190501
+  - microsoft.servicebus/v20170401
+  - microsoft.storage/v20190601
+  - microsoft.streamanalytics/v20160301
+  - microsoft.vmwarecloudsimple/v20190401
+  - microsoft.web/v20140601
+  - microsoft.web/v20150801
+  - microsoft.web/v20160601
+  - microsoft.web/v20180201
+  - microsoft.web/v20181101
+  # The following end up with AnyType in Status
+  - microsoft.apimanagement/v20190101
+  - microsoft.containerservice/v20180331
+  - microsoft.containerservice/v20190601
+  - microsoft.insights/v20150501
+  - microsoft.insights/v20160301
+  - microsoft.insights/v20170401
+  - microsoft.insights/v20180301
+  - microsoft.insights/v20180416
+  - microsoft.insights/v20190301
+  - microsoft.powerbi/v20160129
 
 typeTransformers:
   - group: definitions

--- a/hack/generator/pkg/codegen/code_generator.go
+++ b/hack/generator/pkg/codegen/code_generator.go
@@ -57,7 +57,7 @@ func corePipelineStages(idFactory astmodel.IdentifierFactory, configuration *con
 		improveResourcePluralization(),
 		stripUnreferencedTypeDefinitions(),
 		createArmTypesAndCleanKubernetesTypes(idFactory),
-		checkForAnyType(),
+		checkForAnyType(configuration.AnyTypePackages),
 		checkForMissingStatusInformation(),
 	}
 }

--- a/hack/generator/pkg/codegen/pipeline_check_for_anytype.go
+++ b/hack/generator/pkg/codegen/pipeline_check_for_anytype.go
@@ -16,29 +16,53 @@ import (
 	"github.com/Azure/k8s-infra/hack/generator/pkg/astmodel"
 )
 
-// checkForAnyType returns a stage that will return an error if there
-// are any uses of AnyType remaining in the passed defs.
-func checkForAnyType() PipelineStage {
+// checkForAnyType returns a stage that will check for any defs
+// containing AnyTypes. It accepts a set of packages that we expect to
+// contain types with AnyTypes. Those packages will be quietly
+// filtered out of the output of the stage, but if there are more
+// AnyTypes in other packages they'll be reported as an error. The
+// stage will also return an error if there are packages that we
+// expect to have AnyTypes but turn out not to.
+func checkForAnyType(packages []string) PipelineStage {
+	expectedPackages := make(map[string]struct{}, len(packages))
+	for _, p := range packages {
+		expectedPackages[p] = struct{}{}
+	}
+
 	return MakePipelineStage(
 		"rogueCheck",
 		"Check for rogue AnyTypes",
 		func(ctx context.Context, defs astmodel.Types) (astmodel.Types, error) {
 			var badNames []astmodel.TypeName
+			output := make(astmodel.Types)
 			for name, def := range defs {
 				if containsAnyType(def.Type()) {
 					badNames = append(badNames, name)
 				}
+
+				packageName, err := packageName(name)
+				if err != nil {
+					return nil, err
+				}
+				// We only want to include this type in the output if
+				// it's not in a package that we know contains
+				// AnyTypes.
+				if _, found := expectedPackages[packageName]; found {
+					continue
+				}
+				output.Add(def)
 			}
 
-			if len(badNames) == 0 {
-				return defs, nil
-			}
-
-			packages, err := groupNamesIntoPackages(badNames)
+			badPackages, err := collectBadPackages(badNames, expectedPackages)
 			if err != nil {
 				return nil, errors.Wrap(err, "summarising bad types")
 			}
-			return nil, errors.Errorf("AnyTypes found - add exclusions for: %s", strings.Join(packages, ", "))
+
+			if len(badPackages) > 0 {
+				return nil, errors.Errorf("AnyTypes found - add exclusions for: %s", strings.Join(badPackages, ", "))
+			}
+
+			return output, nil
 		})
 }
 
@@ -55,19 +79,34 @@ func containsAnyType(theType astmodel.Type) bool {
 	return found
 }
 
-func groupNamesIntoPackages(names []astmodel.TypeName) ([]string, error) {
+func packageName(name astmodel.TypeName) (string, error) {
+	group, version, err := name.PackageReference.GroupAndPackage()
+	if err != nil {
+		return "", err
+	}
+	return group + "/" + version, nil
+}
+
+func collectBadPackages(
+	names []astmodel.TypeName,
+	expectedPackages map[string]struct{},
+) ([]string, error) {
 	grouped := make(map[string][]string)
 	for _, name := range names {
-		group, version, err := name.PackageReference.GroupAndPackage()
+		groupVersion, err := packageName(name)
 		if err != nil {
 			return nil, err
 		}
-		groupVersion := group + "/" + version
 		grouped[groupVersion] = append(grouped[groupVersion], name.Name())
 	}
 
 	var groupNames []string
 	for groupName := range grouped {
+		// Only complain about this package if it's one we don't know about.
+		if _, found := expectedPackages[groupName]; found {
+			delete(expectedPackages, groupName)
+			continue
+		}
 		groupNames = append(groupNames, groupName)
 	}
 	sort.Strings(groupNames)
@@ -77,6 +116,18 @@ func groupNamesIntoPackages(names []astmodel.TypeName) ([]string, error) {
 			sort.Strings(grouped[groupName])
 			klog.Infof("%s: %v", groupName, grouped[groupName])
 		}
+	}
+
+	// Complain if there were some packages where we expected problems
+	// but didn't see any.
+	if len(expectedPackages) > 0 {
+		var leftovers []string
+		for value := range expectedPackages {
+			leftovers = append(leftovers, value)
+		}
+		sort.Strings(leftovers)
+		return nil, errors.Errorf(
+			"no AnyTypes found in: %s", strings.Join(leftovers, ", "))
 	}
 
 	return groupNames, nil

--- a/hack/generator/pkg/codegen/pipeline_check_for_anytype_test.go
+++ b/hack/generator/pkg/codegen/pipeline_check_for_anytype_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/Azure/k8s-infra/hack/generator/pkg/astmodel"
+	"github.com/pkg/errors"
 
 	. "github.com/onsi/gomega"
 )
@@ -35,8 +36,72 @@ func TestFindsAnytypes(t *testing.T) {
 	// One that's fine.
 	add(p3, "C", astmodel.NewArrayType(astmodel.IntType))
 
-	results, err := checkForAnyType().Action(context.Background(), defs)
+	results, err := checkForAnyType(nil).Action(context.Background(), defs)
 
 	g.Expect(results).To(HaveLen(0))
 	g.Expect(err).To(MatchError("AnyTypes found - add exclusions for: horo.logy/v20200730, road.train/v20200730"))
+}
+
+func TestIgnoresExpectedAnyTypePackages(t *testing.T) {
+	g := NewGomegaWithT(t)
+	p1 := astmodel.MakeLocalPackageReference("horo.logy", "v20200730")
+	p2 := astmodel.MakeLocalPackageReference("road.train", "v20200730")
+	p3 := astmodel.MakeLocalPackageReference("wah.wah", "v20200730")
+
+	defs := make(astmodel.Types)
+	add := func(p astmodel.PackageReference, n string, t astmodel.Type) {
+		defs.Add(astmodel.MakeTypeDefinition(astmodel.MakeTypeName(p, n), t))
+	}
+	// A couple of types in the same package...
+	add(p1, "A", astmodel.AnyType)
+	add(p1, "B", astmodel.NewObjectType().WithProperties(
+		astmodel.NewPropertyDefinition("Field1", "field1", astmodel.BoolType),
+		astmodel.NewPropertyDefinition("Field2", "field2", astmodel.AnyType),
+	))
+	// One in another...
+	add(p2, "A", astmodel.NewMapType(astmodel.StringType, astmodel.AnyType))
+	// One that's fine.
+	add(p3, "C", astmodel.NewArrayType(astmodel.IntType))
+
+	exclusions := []string{"horo.logy/v20200730", "road.train/v20200730"}
+	results, err := checkForAnyType(exclusions).Action(context.Background(), defs)
+	g.Expect(err).To(BeNil())
+
+	expected := make(astmodel.Types)
+	expected.Add(astmodel.MakeTypeDefinition(
+		astmodel.MakeTypeName(p3, "C"), astmodel.NewArrayType(astmodel.IntType),
+	))
+	g.Expect(results).To(Equal(expected))
+}
+
+func TestComplainsAboutUnneededExclusions(t *testing.T) {
+	g := NewGomegaWithT(t)
+	p1 := astmodel.MakeLocalPackageReference("horo.logy", "v20200730")
+	p2 := astmodel.MakeLocalPackageReference("road.train", "v20200730")
+	p3 := astmodel.MakeLocalPackageReference("wah.wah", "v20200730")
+
+	defs := make(astmodel.Types)
+	add := func(p astmodel.PackageReference, n string, t astmodel.Type) {
+		defs.Add(astmodel.MakeTypeDefinition(astmodel.MakeTypeName(p, n), t))
+	}
+	// A couple of types in the same package...
+	add(p1, "A", astmodel.AnyType)
+	add(p1, "B", astmodel.NewObjectType().WithProperties(
+		astmodel.NewPropertyDefinition("Field1", "field1", astmodel.BoolType),
+		astmodel.NewPropertyDefinition("Field2", "field2", astmodel.AnyType),
+	))
+	// One in another...
+	add(p2, "A", astmodel.NewMapType(astmodel.StringType, astmodel.AnyType))
+	// One that's fine.
+	add(p3, "C", astmodel.NewArrayType(astmodel.IntType))
+
+	exclusions := []string{
+		"people.vultures/20200821",
+		"horo.logy/v20200730",
+		"gamma.knife/v20200821",
+		"road.train/v20200730",
+	}
+	results, err := checkForAnyType(exclusions).Action(context.Background(), defs)
+	g.Expect(results).To(HaveLen(0))
+	g.Expect(errors.Cause(err)).To(MatchError("no AnyTypes found in: gamma.knife/v20200821, people.vultures/20200821"))
 }

--- a/hack/generator/pkg/config/configuration.go
+++ b/hack/generator/pkg/config/configuration.go
@@ -24,6 +24,9 @@ type Configuration struct {
 	Status StatusConfiguration `yaml:"status"`
 	// The folder where the code should be generated
 	OutputPath string `yaml:"outputPath"`
+	// AnyTypePackages lists packages which we expect to generate
+	// interface{} fields.
+	AnyTypePackages []string `yaml:"anyTypePackages"`
 	// Filters used to control which types are exported
 	ExportFilters []*ExportFilter `yaml:"exportFilters"`
 	// Filters used to control which types are created from the JSON schema


### PR DESCRIPTION
This allows the pipeline stage to check for unnecessarily excluded packages so we know to remove a filter when we fix a case that generates AnyTypes in the output.

Move the list of packages with AnyTypes out of the filters and into
a separate configuration item.