### PR TITLE
Fix path handling to run on Windows

### DIFF
--- a/hack/generator/pkg/codegen/pipeline_augment_status.go
+++ b/hack/generator/pkg/codegen/pipeline_augment_status.go
@@ -218,8 +218,10 @@ var skipDirectories = []string{
 }
 
 func shouldSkipDir(filePath string) bool {
+	p := filepath.ToSlash(filePath)
+
 	for _, skipDir := range skipDirectories {
-		if strings.Contains(filePath, skipDir) {
+		if strings.Contains(p, skipDir) {
 			return true
 		}
 	}

--- a/hack/generator/pkg/codegen/pipeline_augment_status_test.go
+++ b/hack/generator/pkg/codegen/pipeline_augment_status_test.go
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) Microsoft Corporation.
+ * Licensed under the MIT license.
+ */
+
 package codegen
 
 import (

--- a/hack/generator/pkg/codegen/pipeline_augment_status_test.go
+++ b/hack/generator/pkg/codegen/pipeline_augment_status_test.go
@@ -7,30 +7,47 @@ package codegen
 
 import (
 	. "github.com/onsi/gomega"
-
+	"runtime"
 	"testing"
 )
 
 func Test_ShouldSkipDir_GivenPath_HasExpectedResult(t *testing.T) {
-	cases := []struct {
+	linuxCases := []struct {
 		name       string
 		path       string
 		shouldSkip bool
 	}{
 		// Simple paths
 		{"Root", "/", false},
-		{"Drive", "D:\\", false},
 		{"Top level", "/foo/", false},
-		{"Top level, Windows", "D:\\foo\\", false},
 		{"Nested", "/foo/bar/", false},
-		{"Nested, Windows", "D:\\foo\\bar\\", false},
 		// Paths to skip
 		{"Skip top level", "/examples/", true},
-		{"Skip top level, Windows", "D:\\examples\\", true},
 		{"Skip nested", "/foo/examples/", true},
-		{"Skip nested, Windows", "D:\\foo\\examples\\", true},
 		{"Skip nested, trailing directory", "/foo/examples/bar/", true},
+	}
+
+	windowsCases := []struct {
+		name       string
+		path       string
+		shouldSkip bool
+	}{
+		// Simple paths
+		{"Drive", "D:\\", false},
+		{"Top level, Windows", "D:\\foo\\", false},
+		{"Nested, Windows", "D:\\foo\\bar\\", false},
+		// Paths to skip
+		{"Skip top level, Windows", "D:\\examples\\", true},
+		{"Skip nested, Windows", "D:\\foo\\examples\\", true},
 		{"Skip nested, trailing directory, Windows", "D:\\foo\\examples\\bar\\", true},
+	}
+
+	cases := linuxCases
+
+	// If testing on Windows, also test Windows paths
+	// Can't test Windows paths on Linux because *reasons*
+	if runtime.GOOS == "windows" {
+		cases = append(cases, windowsCases...)
 	}
 
 	for _, c := range cases {

--- a/hack/generator/pkg/codegen/pipeline_augment_status_test.go
+++ b/hack/generator/pkg/codegen/pipeline_augment_status_test.go
@@ -14,12 +14,18 @@ func Test_ShouldSkipDir_GivenPath_HasExpectedResult(t *testing.T) {
 	}{
 		// Simple paths
 		{"Root", "/", false},
+		{"Drive", "D:\\", false},
 		{"Top level", "/foo/", false},
+		{"Top level, Windows", "D:\\foo\\", false},
 		{"Nested", "/foo/bar/", false},
+		{"Nested, Windows", "D:\\foo\\bar\\", false},
 		// Paths to skip
 		{"Skip top level", "/examples/", true},
+		{"Skip top level, Windows", "D:\\examples\\", true},
 		{"Skip nested", "/foo/examples/", true},
+		{"Skip nested, Windows", "D:\\foo\\examples\\", true},
 		{"Skip nested, trailing directory", "/foo/examples/bar/", true},
+		{"Skip nested, trailing directory, Windows", "D:\\foo\\examples\\bar\\", true},
 	}
 
 	for _, c := range cases {

--- a/hack/generator/pkg/codegen/pipeline_augment_status_test.go
+++ b/hack/generator/pkg/codegen/pipeline_augment_status_test.go
@@ -1,0 +1,36 @@
+package codegen
+
+import (
+	. "github.com/onsi/gomega"
+
+	"testing"
+)
+
+func Test_ShouldSkipDir_GivenPath_HasExpectedResult(t *testing.T) {
+	cases := []struct {
+		name       string
+		path       string
+		shouldSkip bool
+	}{
+		// Simple paths
+		{"Root", "/", false},
+		{"Top level", "/foo/", false},
+		{"Nested", "/foo/bar/", false},
+		// Paths to skip
+		{"Skip top level", "/examples/", true},
+		{"Skip nested", "/foo/examples/", true},
+		{"Skip nested, trailing directory", "/foo/examples/bar/", true},
+	}
+
+	for _, c := range cases {
+		c := c
+		t.Run(c.name, func(t *testing.T) {
+			t.Parallel()
+			g := NewGomegaWithT(t)
+
+			skipped := shouldSkipDir(c.path)
+
+			g.Expect(skipped).To(Equal(c.shouldSkip))
+		})
+	}
+}

--- a/hack/generator/pkg/jsonast/schema_abstraction_openapi.go
+++ b/hack/generator/pkg/jsonast/schema_abstraction_openapi.go
@@ -7,12 +7,13 @@ package jsonast
 
 import (
 	"fmt"
-	"github.com/go-openapi/jsonpointer"
-	"github.com/go-openapi/spec"
-	"github.com/pkg/errors"
 	"io/ioutil"
 	"net/url"
 	"path/filepath"
+
+	"github.com/go-openapi/jsonpointer"
+	"github.com/go-openapi/spec"
+	"github.com/pkg/errors"
 )
 
 // OpenAPISchema implements the Schema abstraction for go-openapi

--- a/hack/generator/pkg/jsonast/schema_abstraction_openapi.go
+++ b/hack/generator/pkg/jsonast/schema_abstraction_openapi.go
@@ -7,12 +7,12 @@ package jsonast
 
 import (
 	"fmt"
-	"io/ioutil"
-	"net/url"
-
 	"github.com/go-openapi/jsonpointer"
 	"github.com/go-openapi/spec"
 	"github.com/pkg/errors"
+	"io/ioutil"
+	"net/url"
+	"path/filepath"
 )
 
 // OpenAPISchema implements the Schema abstraction for go-openapi
@@ -273,7 +273,8 @@ func (fileCache OpenAPISchemaCache) fetchFileRelative(baseFileName string, url *
 		return path, swagger, errors.Errorf("only relative URLs can be handled")
 	}
 
-	fileURL, err := url.Parse("file://" + baseFileName)
+	fileURL, err := url.Parse("file://" + filepath.ToSlash(baseFileName))
+
 	if err != nil {
 		return path, swagger, errors.Wrapf(err, "cannot convert filename to file URI")
 	}


### PR DESCRIPTION
Convert Windows file paths (containing `\`) to the canonical Go form (containing `/`) where necessary.