### PR TITLE
Extend property transformer to allow removing properties

### DIFF
--- a/hack/generator/azure-arm.yaml
+++ b/hack/generator/azure-arm.yaml
@@ -88,9 +88,6 @@ anyTypePackages:
   - microsoft.containerinstance/v20181001
   - microsoft.containerregistry/v20171001
   - microsoft.datafactory/v20180601
-  - microsoft.eventgrid/v20180101
-  - microsoft.eventgrid/v20190101
-  - microsoft.eventgrid/v20190601
   - microsoft.keyvault/v20150601
   - microsoft.kusto/v20190515
   - microsoft.kusto/v20191109
@@ -179,6 +176,24 @@ typeTransformers:
         value:
           name: string
     because: Tags is defined as map[string]interface{} when it should be map[string]string
+
+  # Removing map[string]interfaces{} that happen because the type has
+  # only readonly properties that have all been removed in the swagger
+  # -> deployment template conversion.
+
+  - group: microsoft.eventgrid
+    version: v20190601
+    name: Domains_Spec
+    property: Properties
+    remove: true
+    because: it has no writable properties in swagger
+
+  - group: microsoft.eventgrid
+    version: "*"
+    name: Topics_Spec
+    property: Properties
+    remove: true
+    because: it has no writable properties in swagger
 
 status:
   schemaRoot: "./azure-rest-api-specs/specification"

--- a/hack/generator/pkg/astmodel/object_type.go
+++ b/hack/generator/pkg/astmodel/object_type.go
@@ -295,6 +295,14 @@ func (objectType *ObjectType) WithProperties(properties ...*PropertyDefinition) 
 	return result
 }
 
+// WithoutProperties creates a new ObjectType from this one but
+// without any properties.
+func (objectType *ObjectType) WithoutProperties() *ObjectType {
+	result := objectType.copy()
+	result.properties = make(map[PropertyName]*PropertyDefinition)
+	return result
+}
+
 // WithoutProperty creates a new ObjectType without the specified field
 func (objectType *ObjectType) WithoutProperty(name PropertyName) *ObjectType {
 	// Create a copy of objectType to preserve immutability

--- a/hack/generator/pkg/astmodel/object_type_test.go
+++ b/hack/generator/pkg/astmodel/object_type_test.go
@@ -195,6 +195,20 @@ func Test_ObjectWithoutProperty_ReturnsExpectedObject(t *testing.T) {
 }
 
 /*
+ * WithoutProperties() Tests
+ */
+
+func Test_ObjectWithoutProperties_ReturnsExpectedObject(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	original := EmptyObjectType.WithProperties(fullName, familyName, knownAs, gender)
+	modified := original.WithoutProperties()
+
+	g.Expect(original).NotTo(Equal(modified))
+	g.Expect(modified.Properties()).To(HaveLen(0))
+}
+
+/*
  * WithFunction() tests
  */
 

--- a/hack/generator/pkg/codegen/pipeline_apply_property_rewrites.go
+++ b/hack/generator/pkg/codegen/pipeline_apply_property_rewrites.go
@@ -32,15 +32,10 @@ func applyPropertyRewrites(config *config.Configuration) PipelineStage {
 					continue
 				}
 
-				transformed := config.TransformTypeProperties(name, objectType)
-				if transformed != nil {
-					klog.V(2).Infof("Transforming %s.%s -> %s because %s",
-						name,
-						transformed.Property,
-						transformed.NewPropertyType.String(),
-						transformed.Because)
-
-					objectType = transformed.NewType
+				transformation := config.TransformTypeProperties(name, objectType)
+				if transformation != nil {
+					klog.V(2).Infof("Transforming %s", transformation)
+					objectType = transformation.NewType
 				}
 
 				newTypes.Add(t.WithType(objectType))


### PR DESCRIPTION
This enables deleting properties whose types have had all their fields removed in the Swagger -> JSON conversion because they're readonly. Property type transformers can now specify `remove: true` rather than a target type - this will remove the property from the matched type.

This was all that was preventing the EventGrid packages from being exported, so they've been removed from the anytypes config.