### PR TITLE
Resources should be able to implement interfaces

### DIFF
--- a/hack/generated/pkg/genruntime/base_types.go
+++ b/hack/generated/pkg/genruntime/base_types.go
@@ -1,0 +1,20 @@
+package genruntime
+
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+type MetaObject interface {
+	runtime.Object
+	metav1.Object
+	KubernetesResource
+}
+
+type KubernetesResource interface {
+	// Owner returns the ResourceReference of the owner, or nil if there is no owner
+	Owner() *ResourceReference
+
+	// AzureName returns the Azure name of the resource
+	AzureName() string
+}

--- a/hack/generated/pkg/genruntime/base_types.go
+++ b/hack/generated/pkg/genruntime/base_types.go
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) Microsoft Corporation.
+ * Licensed under the MIT license.
+ */
+
 package genruntime
 
 import (
@@ -5,12 +10,15 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 )
 
+// MetaObject represents an arbitrary k8s-infra custom resource
 type MetaObject interface {
 	runtime.Object
 	metav1.Object
 	KubernetesResource
 }
 
+// KubernetesResource is an Azure resource. This interface contains the common set of
+// methods that apply to all k8s-infra resources.
 type KubernetesResource interface {
 	// Owner returns the ResourceReference of the owner, or nil if there is no owner
 	Owner() *ResourceReference

--- a/hack/generated/pkg/genruntime/resource_reference.go
+++ b/hack/generated/pkg/genruntime/resource_reference.go
@@ -5,6 +5,8 @@
 
 package genruntime
 
+import "reflect"
+
 // KnownResourceReference is a resource reference to a known type.
 type KnownResourceReference struct {
 	// This is the name of the Kubernetes resource to reference.
@@ -28,4 +30,23 @@ type ResourceReference struct {
 	// Note: Version is not required here because references are all about linking one Kubernetes
 	// resource to another, and Kubernetes resources are uniquely identified by group, kind, (optionally namespace) and
 	// name - the versions are just giving a different view on the same resource
+}
+
+// LookupOwnerGroupKind looks up an owners group and kind annotations using reflection.
+// This is primarily used to convert from a KnownResourceReference to the more general
+// ResourceReference
+func LookupOwnerGroupKind(v interface{}) (string, string) {
+	t := reflect.TypeOf(v)
+	field, _ := t.FieldByName("Owner")
+
+	group, ok := field.Tag.Lookup("group")
+	if !ok {
+		panic("Couldn't find owner group tag")
+	}
+	kind, ok := field.Tag.Lookup("kind")
+	if !ok {
+		panic("Couldn't find %s owner kind tag")
+	}
+
+	return group, kind
 }

--- a/hack/generator/pkg/astbuilder/builder.go
+++ b/hack/generator/pkg/astbuilder/builder.go
@@ -219,7 +219,7 @@ func ReturnIfNotOk(returns ...ast.Expr) *ast.IfStmt {
 // 	if <toCheck> == nil {
 // 		return <returns...>
 //	}
-func ReturnIfNil(toCheck *ast.Ident, returns ...ast.Expr) ast.Stmt {
+func ReturnIfNil(toCheck ast.Expr, returns ...ast.Expr) ast.Stmt {
 	return ReturnIfExpr(
 		&ast.BinaryExpr{
 			X:  toCheck,
@@ -267,5 +267,14 @@ func FormatError(formatString string, args ...ast.Expr) *ast.CallExpr {
 			Sel: ast.NewIdent("Errorf"),
 		},
 		Args: callArgs,
+	}
+}
+
+// AddrOf returns a statement that gets the address of the provided expression.
+//	&<expr>
+func AddrOf(exp ast.Expr) *ast.UnaryExpr {
+	return &ast.UnaryExpr{
+		Op: token.AND,
+		X:  exp,
 	}
 }

--- a/hack/generator/pkg/astmodel/armconversion/convert_from_arm_function_builder.go
+++ b/hack/generator/pkg/astmodel/armconversion/convert_from_arm_function_builder.go
@@ -72,7 +72,7 @@ func (builder *convertFromArmBuilder) functionDeclaration() *ast.FuncDecl {
 						Sel: ast.NewIdent("KnownResourceReference"),
 					},
 					Names: []*ast.Ident{
-						ast.NewIdent("owner"),
+						ast.NewIdent(builder.idFactory.CreateIdentifier(astmodel.OwnerProperty, astmodel.NotExported)),
 					},
 				},
 				{
@@ -180,7 +180,7 @@ func (builder *convertFromArmBuilder) ownerPropertyHandler(
 	toProp *astmodel.PropertyDefinition,
 	_ *astmodel.ObjectType) []ast.Stmt {
 
-	if toProp.PropertyName() != astmodel.PropertyName("Owner") || !builder.isResource {
+	if toProp.PropertyName() != builder.idFactory.CreatePropertyName(astmodel.OwnerProperty, astmodel.Exported) || !builder.isResource {
 		return nil
 	}
 
@@ -190,7 +190,7 @@ func (builder *convertFromArmBuilder) ownerPropertyHandler(
 			Sel: ast.NewIdent(string(toProp.PropertyName())),
 		},
 		token.ASSIGN,
-		ast.NewIdent("owner"))
+		ast.NewIdent(builder.idFactory.CreateIdentifier(astmodel.OwnerProperty, astmodel.NotExported)))
 	return []ast.Stmt{result}
 }
 
@@ -492,7 +492,7 @@ func (builder *convertFromArmBuilder) convertComplexTypeNameProperty(
 					Sel: ast.NewIdent(builder.methodName),
 				},
 				Args: []ast.Expr{
-					ast.NewIdent("owner"),
+					ast.NewIdent(builder.idFactory.CreateIdentifier(astmodel.OwnerProperty, astmodel.NotExported)),
 					params.source,
 				},
 			}))

--- a/hack/generator/pkg/astmodel/armconversion/shared.go
+++ b/hack/generator/pkg/astmodel/armconversion/shared.go
@@ -114,7 +114,7 @@ func NewArmTransformerImpl(
 		},
 	}
 
-	result := astmodel.NewInterface(
+	result := astmodel.NewInterfaceImplementation(
 		astmodel.MakeTypeName(astmodel.MakeGenRuntimePackageReference(), "ArmTransformer"),
 		funcs)
 

--- a/hack/generator/pkg/astmodel/armconversion/shared.go
+++ b/hack/generator/pkg/astmodel/armconversion/shared.go
@@ -45,12 +45,11 @@ var once sync.Once
 var azureNameProperty *astmodel.PropertyDefinition
 
 func initializeAzureName(idFactory astmodel.IdentifierFactory) {
-	azureName := "azureName"
 	azureNameFieldDescription := "The name of the resource in Azure. This is often the same as" +
 		" the name of the resource in Kubernetes but it doesn't have to be."
 	azureNameProperty = astmodel.NewPropertyDefinition(
-		idFactory.CreatePropertyName(azureName, astmodel.Exported),
-		azureName,
+		idFactory.CreatePropertyName(astmodel.AzureNameProperty, astmodel.Exported),
+		idFactory.CreateIdentifier(astmodel.AzureNameProperty, astmodel.NotExported),
 		astmodel.StringType).WithDescription(azureNameFieldDescription)
 }
 

--- a/hack/generator/pkg/astmodel/interface_implementation.go
+++ b/hack/generator/pkg/astmodel/interface_implementation.go
@@ -11,8 +11,8 @@ type InterfaceImplementation struct {
 	functions map[string]Function
 }
 
-// NewInterface creates a new interface implementation with the given name and set of functions
-func NewInterface(name TypeName, functions map[string]Function) *InterfaceImplementation {
+// NewInterfaceImplementation creates a new interface implementation with the given name and set of functions
+func NewInterfaceImplementation(name TypeName, functions map[string]Function) *InterfaceImplementation {
 	return &InterfaceImplementation{name: name, functions: functions}
 }
 

--- a/hack/generator/pkg/astmodel/interface_implementer.go
+++ b/hack/generator/pkg/astmodel/interface_implementer.go
@@ -1,0 +1,168 @@
+/*
+ * Copyright (c) Microsoft Corporation.
+ * Licensed under the MIT license.
+ */
+
+package astmodel
+
+import (
+	"go/ast"
+	"go/token"
+	"sort"
+)
+
+// TODO: need to add tests for this probably
+type InterfaceImplementer struct { // TODO: Do we like this name?
+	interfaces map[TypeName]*InterfaceImplementation
+}
+
+// WithInterface creates a new ObjectType with a function (method) attached to it
+func (interfaceImplementer InterfaceImplementer) WithInterface(iface *InterfaceImplementation) InterfaceImplementer {
+	result := interfaceImplementer.copy()
+	result.interfaces[iface.Name()] = iface
+
+	return result
+}
+
+//func (interfaceImplementer *InterfaceImplementer) Interfaces() {
+//	panic("TODO")
+//}
+
+func (interfaceImplementer InterfaceImplementer) References() TypeNameSet {
+	var results TypeNameSet
+	for _, iface := range interfaceImplementer.interfaces {
+		for ref := range iface.References() {
+			results = results.Add(ref)
+		}
+	}
+
+	return results
+}
+
+func (interfaceImplementer InterfaceImplementer) AsType(codeGenerationContext *CodeGenerationContext) ast.Expr {
+	panic("InterfaceImplementer cannot be used as a standalone type")
+}
+
+func (interfaceImplementer InterfaceImplementer) AsDeclarations(
+	codeGenerationContext *CodeGenerationContext,
+	typeName TypeName,
+	_ []string) []ast.Decl {
+
+	var result []ast.Decl
+
+	// First interfaces must be ordered by name for deterministic output
+	var ifaceNames []TypeName
+	for ifaceName := range interfaceImplementer.interfaces {
+		ifaceNames = append(ifaceNames, ifaceName)
+	}
+
+	sort.Slice(ifaceNames, func(i int, j int) bool {
+		return ifaceNames[i].name < ifaceNames[j].name
+	})
+
+	for _, ifaceName := range ifaceNames {
+		iface := interfaceImplementer.interfaces[ifaceName]
+
+		result = append(result, interfaceImplementer.generateInterfaceImplAssertion(codeGenerationContext, iface, typeName))
+
+		var funcNames []string
+		for funcName := range iface.functions {
+			funcNames = append(funcNames, funcName)
+		}
+
+		sort.Strings(funcNames)
+
+		for _, methodName := range funcNames {
+			function := iface.functions[methodName]
+			result = append(result, function.AsFunc(codeGenerationContext, typeName, methodName))
+		}
+	}
+
+	return result
+}
+
+func (interfaceImplementer InterfaceImplementer) Equals(t Type) bool {
+
+	otherInterfaceImplementer, ok := t.(InterfaceImplementer)
+	if !ok {
+		return false
+	}
+
+	if len(interfaceImplementer.interfaces) != len(otherInterfaceImplementer.interfaces) {
+		return false
+	}
+
+	for ifaceName, iface := range interfaceImplementer.interfaces {
+		otherIface, ok := otherInterfaceImplementer.interfaces[ifaceName]
+		if !ok {
+			return false
+		}
+
+		if !iface.Equals(otherIface) {
+			return false
+		}
+	}
+
+	return true
+}
+
+// TODO: Do we actually want to impl this - I kinda feel like we actually don't?
+// TODO: maybe we want an interface with _most_ of these methods but not AsType?
+var _ Type = InterfaceImplementer{}
+
+func (interfaceImplementer InterfaceImplementer) RequiredImports() []PackageReference {
+	var result []PackageReference
+
+	for _, i := range interfaceImplementer.interfaces {
+		result = append(result, i.RequiredImports()...)
+	}
+
+	return result
+}
+
+func (interfaceImplementer InterfaceImplementer) generateInterfaceImplAssertion(
+	codeGenerationContext *CodeGenerationContext,
+	iface *InterfaceImplementation,
+	typeName TypeName) ast.Decl {
+
+	ifacePackageName, err := codeGenerationContext.GetImportedPackageName(iface.name.PackageReference)
+	if err != nil {
+		panic(err)
+	}
+
+	typeAssertion := &ast.GenDecl{
+		Tok: token.VAR,
+		Specs: []ast.Spec{
+			&ast.ValueSpec{
+				Type: &ast.SelectorExpr{
+					X:   ast.NewIdent(ifacePackageName),
+					Sel: ast.NewIdent(iface.name.name),
+				},
+				Names: []*ast.Ident{
+					ast.NewIdent("_"),
+				},
+				Values: []ast.Expr{
+					&ast.UnaryExpr{
+						Op: token.AND,
+						X: &ast.CompositeLit{
+							Type: ast.NewIdent(typeName.name),
+						},
+					},
+				},
+			},
+		},
+	}
+
+	return typeAssertion
+}
+
+func (interfaceImplementer InterfaceImplementer) copy() InterfaceImplementer {
+	result := interfaceImplementer
+
+	result.interfaces = make(map[TypeName]*InterfaceImplementation, len(interfaceImplementer.interfaces))
+	for k, v := range interfaceImplementer.interfaces {
+		result.interfaces[k] = v
+	}
+
+	return result
+}

--- a/hack/generator/pkg/astmodel/interface_implementer.go
+++ b/hack/generator/pkg/astmodel/interface_implementer.go
@@ -11,8 +11,7 @@ import (
 	"sort"
 )
 
-// TODO: need to add tests for this probably
-type InterfaceImplementer struct { // TODO: Do we like this name?
+type InterfaceImplementer struct {
 	interfaces map[TypeName]*InterfaceImplementation
 }
 
@@ -22,20 +21,16 @@ func MakeInterfaceImplementer() InterfaceImplementer {
 }
 
 // WithInterface creates a new ObjectType with a function (method) attached to it
-func (interfaceImplementer InterfaceImplementer) WithInterface(iface *InterfaceImplementation) InterfaceImplementer {
-	result := interfaceImplementer.copy()
+func (i InterfaceImplementer) WithInterface(iface *InterfaceImplementation) InterfaceImplementer {
+	result := i.copy()
 	result.interfaces[iface.Name()] = iface
 
 	return result
 }
 
-//func (interfaceImplementer *InterfaceImplementer) Interfaces() {
-//	panic("TODO")
-//}
-
-func (interfaceImplementer InterfaceImplementer) References() TypeNameSet {
+func (i InterfaceImplementer) References() TypeNameSet {
 	var results TypeNameSet
-	for _, iface := range interfaceImplementer.interfaces {
+	for _, iface := range i.interfaces {
 		for ref := range iface.References() {
 			results = results.Add(ref)
 		}
@@ -44,11 +39,7 @@ func (interfaceImplementer InterfaceImplementer) References() TypeNameSet {
 	return results
 }
 
-func (interfaceImplementer InterfaceImplementer) AsType(codeGenerationContext *CodeGenerationContext) ast.Expr {
-	panic("InterfaceImplementer cannot be used as a standalone type")
-}
-
-func (interfaceImplementer InterfaceImplementer) AsDeclarations(
+func (i InterfaceImplementer) AsDeclarations(
 	codeGenerationContext *CodeGenerationContext,
 	typeName TypeName,
 	_ []string) []ast.Decl {
@@ -57,7 +48,7 @@ func (interfaceImplementer InterfaceImplementer) AsDeclarations(
 
 	// First interfaces must be ordered by name for deterministic output
 	var ifaceNames []TypeName
-	for ifaceName := range interfaceImplementer.interfaces {
+	for ifaceName := range i.interfaces {
 		ifaceNames = append(ifaceNames, ifaceName)
 	}
 
@@ -66,9 +57,9 @@ func (interfaceImplementer InterfaceImplementer) AsDeclarations(
 	})
 
 	for _, ifaceName := range ifaceNames {
-		iface := interfaceImplementer.interfaces[ifaceName]
+		iface := i.interfaces[ifaceName]
 
-		result = append(result, interfaceImplementer.generateInterfaceImplAssertion(codeGenerationContext, iface, typeName))
+		result = append(result, i.generateInterfaceImplAssertion(codeGenerationContext, iface, typeName))
 
 		var funcNames []string
 		for funcName := range iface.functions {
@@ -86,19 +77,14 @@ func (interfaceImplementer InterfaceImplementer) AsDeclarations(
 	return result
 }
 
-func (interfaceImplementer InterfaceImplementer) Equals(t Type) bool {
+func (i InterfaceImplementer) Equals(other InterfaceImplementer) bool {
 
-	otherInterfaceImplementer, ok := t.(InterfaceImplementer)
-	if !ok {
+	if len(i.interfaces) != len(other.interfaces) {
 		return false
 	}
 
-	if len(interfaceImplementer.interfaces) != len(otherInterfaceImplementer.interfaces) {
-		return false
-	}
-
-	for ifaceName, iface := range interfaceImplementer.interfaces {
-		otherIface, ok := otherInterfaceImplementer.interfaces[ifaceName]
+	for ifaceName, iface := range i.interfaces {
+		otherIface, ok := other.interfaces[ifaceName]
 		if !ok {
 			return false
 		}
@@ -111,21 +97,17 @@ func (interfaceImplementer InterfaceImplementer) Equals(t Type) bool {
 	return true
 }
 
-// TODO: Do we actually want to impl this - I kinda feel like we actually don't?
-// TODO: maybe we want an interface with _most_ of these methods but not AsType?
-var _ Type = InterfaceImplementer{}
-
-func (interfaceImplementer InterfaceImplementer) RequiredImports() []PackageReference {
+func (i InterfaceImplementer) RequiredImports() []PackageReference {
 	var result []PackageReference
 
-	for _, i := range interfaceImplementer.interfaces {
+	for _, i := range i.interfaces {
 		result = append(result, i.RequiredImports()...)
 	}
 
 	return result
 }
 
-func (interfaceImplementer InterfaceImplementer) generateInterfaceImplAssertion(
+func (i InterfaceImplementer) generateInterfaceImplAssertion(
 	codeGenerationContext *CodeGenerationContext,
 	iface *InterfaceImplementation,
 	typeName TypeName) ast.Decl {
@@ -161,11 +143,11 @@ func (interfaceImplementer InterfaceImplementer) generateInterfaceImplAssertion(
 	return typeAssertion
 }
 
-func (interfaceImplementer InterfaceImplementer) copy() InterfaceImplementer {
-	result := interfaceImplementer
+func (i InterfaceImplementer) copy() InterfaceImplementer {
+	result := i
 
-	result.interfaces = make(map[TypeName]*InterfaceImplementation, len(interfaceImplementer.interfaces))
-	for k, v := range interfaceImplementer.interfaces {
+	result.interfaces = make(map[TypeName]*InterfaceImplementation, len(i.interfaces))
+	for k, v := range i.interfaces {
 		result.interfaces[k] = v
 	}
 

--- a/hack/generator/pkg/astmodel/interface_implementer.go
+++ b/hack/generator/pkg/astmodel/interface_implementer.go
@@ -16,6 +16,11 @@ type InterfaceImplementer struct { // TODO: Do we like this name?
 	interfaces map[TypeName]*InterfaceImplementation
 }
 
+// MakeInterfaceImplementer returns an interface implementer
+func MakeInterfaceImplementer() InterfaceImplementer {
+	return InterfaceImplementer{}
+}
+
 // WithInterface creates a new ObjectType with a function (method) attached to it
 func (interfaceImplementer InterfaceImplementer) WithInterface(iface *InterfaceImplementation) InterfaceImplementer {
 	result := interfaceImplementer.copy()

--- a/hack/generator/pkg/astmodel/interface_implementer_test.go
+++ b/hack/generator/pkg/astmodel/interface_implementer_test.go
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) Microsoft Corporation.
+ * Licensed under the MIT license.
+ */
+
+package astmodel
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+)
+
+func makeInterfaceImplForTest() *InterfaceImplementation {
+	pr := MakeLocalPackageReference("group", "package")
+
+	return NewInterfaceImplementation(MakeTypeName(pr, "foo"), nil)
+}
+
+func Test_InterfaceImplementerWithInterface_ReturnsNewInstance(t *testing.T) {
+
+	g := NewGomegaWithT(t)
+
+	original := InterfaceImplementer{}
+	updated := original.WithInterface(makeInterfaceImplForTest())
+
+	g.Expect(updated).ToNot(Equal(original))
+	g.Expect(len(updated.interfaces)).To(Equal(1))
+}

--- a/hack/generator/pkg/astmodel/kubernetes_resource_interface.go
+++ b/hack/generator/pkg/astmodel/kubernetes_resource_interface.go
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) Microsoft Corporation.
+ * Licensed under the MIT license.
+ */
+
+package astmodel
+
+import (
+	"go/ast"
+)
+
+// NewArmTransformerImpl creates a new interface with the specified ARM conversion functions
+func NewKubernetesResourceInterfaceImpl(
+	resource *ResourceType) *InterfaceImplementation { // TODO: Is taking resource here right...?
+
+	//funcs := map[string]astmodel.Function{
+	//	"ConvertToArm": &ArmConversionFunction{
+	//		armTypeName: armTypeName,
+	//		armType:     armType,
+	//		idFactory:   idFactory,
+	//		direction:   ConversionDirectionToArm,
+	//		isResource:  isResource,
+	//	},
+	//	"PopulateFromArm": &ArmConversionFunction{
+	//		armTypeName: armTypeName,
+	//		armType:     armType,
+	//		idFactory:   idFactory,
+	//		direction:   ConversionDirectionFromArm,
+	//		isResource:  isResource,
+	//	},
+	//}
+	//
+	//result := astmodel.NewInterfaceImplementation(
+	//	astmodel.MakeTypeName(astmodel.MakeGenRuntimePackageReference(), "ArmTransformer"),
+	//	funcs)
+	//
+	//return result
+
+	return nil
+}
+
+type KubernetesResourceOwnerFunction struct {
+}
+
+func (k KubernetesResourceOwnerFunction) RequiredImports() []PackageReference {
+	panic("implement me")
+}
+
+func (k KubernetesResourceOwnerFunction) References() TypeNameSet {
+	panic("implement me")
+}
+
+func (k KubernetesResourceOwnerFunction) AsFunc(codeGenerationContext *CodeGenerationContext, receiver TypeName, methodName string) *ast.FuncDecl {
+	panic("implement me")
+}
+
+func (k KubernetesResourceOwnerFunction) Equals(f Function) bool {
+	panic("implement me")
+}
+
+var _ Function = &KubernetesResourceOwnerFunction{}

--- a/hack/generator/pkg/astmodel/kubernetes_resource_interface.go
+++ b/hack/generator/pkg/astmodel/kubernetes_resource_interface.go
@@ -6,56 +6,208 @@
 package astmodel
 
 import (
+	"fmt"
+	"github.com/Azure/k8s-infra/hack/generator/pkg/astbuilder"
 	"go/ast"
+	"go/token"
 )
 
 // NewArmTransformerImpl creates a new interface with the specified ARM conversion functions
 func NewKubernetesResourceInterfaceImpl(
-	resource *ResourceType) *InterfaceImplementation { // TODO: Is taking resource here right...?
+	idFactory IdentifierFactory,
+	spec *ObjectType) *InterfaceImplementation {
 
-	//funcs := map[string]astmodel.Function{
-	//	"ConvertToArm": &ArmConversionFunction{
-	//		armTypeName: armTypeName,
-	//		armType:     armType,
-	//		idFactory:   idFactory,
-	//		direction:   ConversionDirectionToArm,
-	//		isResource:  isResource,
-	//	},
-	//	"PopulateFromArm": &ArmConversionFunction{
-	//		armTypeName: armTypeName,
-	//		armType:     armType,
-	//		idFactory:   idFactory,
-	//		direction:   ConversionDirectionFromArm,
-	//		isResource:  isResource,
-	//	},
-	//}
-	//
-	//result := astmodel.NewInterfaceImplementation(
-	//	astmodel.MakeTypeName(astmodel.MakeGenRuntimePackageReference(), "ArmTransformer"),
-	//	funcs)
-	//
-	//return result
+	funcs := map[string]Function{
+		"Owner": &kubernetesResourceFunction{
+			spec:      spec,
+			idFactory: idFactory,
+			asFunc:    ownerFunction,
+		},
+		"AzureName": &kubernetesResourceFunction{
+			spec:      spec,
+			idFactory: idFactory,
+			asFunc:    azureNameFunction,
+		},
+	}
 
-	return nil
+	result := NewInterfaceImplementation(
+		MakeTypeName(MakeGenRuntimePackageReference(), "KubernetesResource"),
+		funcs)
+
+	return result
 }
 
-type KubernetesResourceOwnerFunction struct {
+type kubernetesResourceFunction struct {
+	spec      *ObjectType
+	idFactory IdentifierFactory
+
+	asFunc func(f *kubernetesResourceFunction, codeGenerationContext *CodeGenerationContext, receiver TypeName, methodName string) *ast.FuncDecl
 }
 
-func (k KubernetesResourceOwnerFunction) RequiredImports() []PackageReference {
-	panic("implement me")
+var _ Function = &kubernetesResourceFunction{}
+
+func (k *kubernetesResourceFunction) RequiredImports() []PackageReference {
+	// We only require GenRuntime
+	return []PackageReference{
+		MakeGenRuntimePackageReference(),
+	}
 }
 
-func (k KubernetesResourceOwnerFunction) References() TypeNameSet {
-	panic("implement me")
+func (k *kubernetesResourceFunction) References() TypeNameSet {
+	return k.spec.References()
 }
 
-func (k KubernetesResourceOwnerFunction) AsFunc(codeGenerationContext *CodeGenerationContext, receiver TypeName, methodName string) *ast.FuncDecl {
-	panic("implement me")
+func (k *kubernetesResourceFunction) AsFunc(codeGenerationContext *CodeGenerationContext, receiver TypeName, methodName string) *ast.FuncDecl {
+	return k.asFunc(k, codeGenerationContext, receiver, methodName)
 }
 
-func (k KubernetesResourceOwnerFunction) Equals(f Function) bool {
-	panic("implement me")
+func (k *kubernetesResourceFunction) Equals(f Function) bool {
+	typedF, ok := f.(*kubernetesResourceFunction)
+	if !ok {
+		return false
+	}
+
+	return k.spec.Equals(typedF.spec)
 }
 
-var _ Function = &KubernetesResourceOwnerFunction{}
+func ownerFunction(k *kubernetesResourceFunction, codeGenerationContext *CodeGenerationContext, receiver TypeName, methodName string) *ast.FuncDecl {
+	receiverIdent := ast.NewIdent(k.idFactory.CreateIdentifier(receiver.Name(), NotExported))
+	receiverType := receiver.AsType(codeGenerationContext)
+
+	// We need to ensure spec has an owner, then we want to return that
+	_, ok := k.spec.Property("Owner")
+	if !ok {
+		panic(fmt.Sprintf("Resource spec %q doesn't have owner property", receiver))
+	}
+
+	specSelector := &ast.SelectorExpr{
+		X:   receiverIdent,
+		Sel: ast.NewIdent("Spec"),
+	}
+
+	groupIdent := ast.NewIdent("group")
+	kindIdent := ast.NewIdent("kind")
+
+	return astbuilder.DefineFunc(
+		astbuilder.FuncDetails{
+			Name:          ast.NewIdent(methodName),
+			ReceiverIdent: receiverIdent,
+			ReceiverType: &ast.StarExpr{
+				X: receiverType,
+			},
+			Comment: "returns the ResourceReference of the owner, or nil if there is no owner",
+			Params:  nil,
+			Returns: []*ast.Field{
+				{
+					Type: &ast.StarExpr{
+						X: &ast.SelectorExpr{
+							X:   ast.NewIdent(GenRuntimePackageName),
+							Sel: ast.NewIdent("ResourceReference"),
+						},
+					},
+				},
+			},
+			Body: []ast.Stmt{
+				lookupGroupAndKindStmt(groupIdent, kindIdent, specSelector),
+				&ast.ReturnStmt{
+					Results: []ast.Expr{
+						createResourceReference(groupIdent, kindIdent, specSelector),
+					},
+				},
+			},
+		})
+}
+
+func lookupGroupAndKindStmt(
+	groupIdent *ast.Ident,
+	kindIdent *ast.Ident,
+	specSelector *ast.SelectorExpr) *ast.AssignStmt {
+
+	return &ast.AssignStmt{
+		Lhs: []ast.Expr{
+			groupIdent,
+			kindIdent,
+		},
+		Tok: token.DEFINE,
+		Rhs: []ast.Expr{
+			&ast.CallExpr{
+				Fun: &ast.SelectorExpr{
+					X:   ast.NewIdent(GenRuntimePackageName),
+					Sel: ast.NewIdent("LookupOwnerGroupKind"),
+				},
+				Args: []ast.Expr{
+					specSelector,
+				},
+			},
+		},
+	}
+}
+
+func createResourceReference(
+	groupIdent *ast.Ident,
+	kindIdent *ast.Ident,
+	specSelector *ast.SelectorExpr) ast.Expr {
+	return astbuilder.AddrOf(
+		&ast.CompositeLit{
+			Type: &ast.SelectorExpr{
+				X:   ast.NewIdent(GenRuntimePackageName),
+				Sel: ast.NewIdent("ResourceReference"),
+			},
+			Elts: []ast.Expr{
+				&ast.KeyValueExpr{
+					Key: ast.NewIdent("Name"),
+					Value: &ast.SelectorExpr{
+						X: &ast.SelectorExpr{
+							X:   specSelector,
+							Sel: ast.NewIdent("Owner"),
+						},
+						Sel: ast.NewIdent("Name"),
+					},
+				},
+				&ast.KeyValueExpr{
+					Key:   ast.NewIdent("Group"),
+					Value: groupIdent,
+				},
+				&ast.KeyValueExpr{
+					Key:   ast.NewIdent("Kind"),
+					Value: kindIdent,
+				},
+			},
+		})
+}
+
+func azureNameFunction(k *kubernetesResourceFunction, codeGenerationContext *CodeGenerationContext, receiver TypeName, methodName string) *ast.FuncDecl {
+	receiverIdent := ast.NewIdent(k.idFactory.CreateIdentifier(receiver.Name(), NotExported))
+	receiverType := receiver.AsType(codeGenerationContext)
+
+	specSelector := &ast.SelectorExpr{
+		X:   receiverIdent,
+		Sel: ast.NewIdent("Spec"),
+	}
+
+	return astbuilder.DefineFunc(
+		astbuilder.FuncDetails{
+			Name:          ast.NewIdent(methodName),
+			ReceiverIdent: receiverIdent,
+			ReceiverType: &ast.StarExpr{
+				X: receiverType,
+			},
+			Comment: "returns the Azure name of the resource",
+			Params:  nil,
+			Returns: []*ast.Field{
+				{
+					Type: ast.NewIdent("string"),
+				},
+			},
+			Body: []ast.Stmt{
+				&ast.ReturnStmt{
+					Results: []ast.Expr{
+						&ast.SelectorExpr{
+							X:   specSelector,
+							Sel: ast.NewIdent("AzureName"),
+						},
+					},
+				},
+			},
+		})
+}

--- a/hack/generator/pkg/astmodel/object_type.go
+++ b/hack/generator/pkg/astmodel/object_type.go
@@ -29,7 +29,7 @@ func NewObjectType() *ObjectType {
 	return &ObjectType{
 		properties:           make(map[PropertyName]*PropertyDefinition),
 		functions:            make(map[string]Function),
-		InterfaceImplementer: InterfaceImplementer{},
+		InterfaceImplementer: MakeInterfaceImplementer(),
 	}
 }
 

--- a/hack/generator/pkg/astmodel/object_type.go
+++ b/hack/generator/pkg/astmodel/object_type.go
@@ -15,21 +15,21 @@ import (
 type ObjectType struct {
 	properties map[PropertyName]*PropertyDefinition
 	functions  map[string]Function
-	interfaces map[TypeName]*InterfaceImplementation
+	InterfaceImplementer
 }
 
 // EmptyObjectType is an empty object
 var EmptyObjectType = NewObjectType()
 
 // Ensure ObjectType implements the Type interface correctly
-var _ Type = (*ObjectType)(nil)
+var _ Type = &ObjectType{}
 
 // NewObjectType is a factory method for creating a new ObjectType
 func NewObjectType() *ObjectType {
 	return &ObjectType{
-		properties: make(map[PropertyName]*PropertyDefinition),
-		functions:  make(map[string]Function),
-		interfaces: make(map[TypeName]*InterfaceImplementation),
+		properties:           make(map[PropertyName]*PropertyDefinition),
+		functions:            make(map[string]Function),
+		InterfaceImplementer: InterfaceImplementer{},
 	}
 }
 
@@ -49,7 +49,7 @@ func (objectType *ObjectType) AsDeclarations(codeGenerationContext *CodeGenerati
 	addDocComments(&declaration.Doc.List, description, 200)
 
 	result := []ast.Decl{declaration}
-	result = append(result, objectType.generateInterfaceDecls(codeGenerationContext, name)...)
+	result = append(result, objectType.InterfaceImplementer.AsDeclarations(codeGenerationContext, name, nil)...)
 	result = append(result, objectType.generateMethodDecls(codeGenerationContext, name)...)
 	return result
 }
@@ -62,73 +62,6 @@ func (objectType *ObjectType) generateMethodDecls(codeGenerationContext *CodeGen
 	}
 
 	return result
-}
-
-func (objectType *ObjectType) generateInterfaceDecls(codeGenerationContext *CodeGenerationContext, typeName TypeName) []ast.Decl {
-	var result []ast.Decl
-
-	// First interfaces must be ordered by name for deterministic output
-	var ifaceNames []TypeName
-	for ifaceName := range objectType.interfaces {
-		ifaceNames = append(ifaceNames, ifaceName)
-	}
-
-	sort.Slice(ifaceNames, func(i int, j int) bool {
-		return ifaceNames[i].name < ifaceNames[j].name
-	})
-
-	for _, ifaceName := range ifaceNames {
-		iface := objectType.interfaces[ifaceName]
-
-		result = append(result, objectType.generateInterfaceImplAssertion(codeGenerationContext, iface, typeName))
-
-		var funcNames []string
-		for funcName := range iface.functions {
-			funcNames = append(funcNames, funcName)
-		}
-
-		sort.Strings(funcNames)
-
-		for _, methodName := range funcNames {
-			function := iface.functions[methodName]
-			result = append(result, function.AsFunc(codeGenerationContext, typeName, methodName))
-		}
-	}
-
-	return result
-}
-
-func (objectType *ObjectType) generateInterfaceImplAssertion(codeGenerationContext *CodeGenerationContext, iface *InterfaceImplementation, typeName TypeName) ast.Decl {
-
-	ifacePackageName, err := codeGenerationContext.GetImportedPackageName(iface.name.PackageReference)
-	if err != nil {
-		panic(err)
-	}
-
-	typeAssertion := &ast.GenDecl{
-		Tok: token.VAR,
-		Specs: []ast.Spec{
-			&ast.ValueSpec{
-				Type: &ast.SelectorExpr{
-					X:   ast.NewIdent(ifacePackageName),
-					Sel: ast.NewIdent(iface.name.name),
-				},
-				Names: []*ast.Ident{
-					ast.NewIdent("_"),
-				},
-				Values: []ast.Expr{
-					&ast.UnaryExpr{
-						Op: token.AND,
-						X: &ast.CompositeLit{
-							Type: ast.NewIdent(typeName.name),
-						},
-					},
-				},
-			},
-		},
-	}
-
-	return typeAssertion
 }
 
 func defineField(fieldName string, fieldType ast.Expr, tag string) *ast.Field {
@@ -203,9 +136,7 @@ func (objectType *ObjectType) RequiredImports() []PackageReference {
 		result = append(result, function.RequiredImports()...)
 	}
 
-	for _, i := range objectType.interfaces {
-		result = append(result, i.RequiredImports()...)
-	}
+	result = append(result, objectType.InterfaceImplementer.RequiredImports()...)
 
 	return result
 }
@@ -266,8 +197,7 @@ func (objectType *ObjectType) Equals(t Type) bool {
 			}
 		}
 
-		// All properties match, equal
-		return true
+		return objectType.InterfaceImplementer.Equals(st.InterfaceImplementer)
 	}
 
 	return false
@@ -324,17 +254,9 @@ func (objectType *ObjectType) WithFunction(name string, function Function) *Obje
 // WithInterface creates a new ObjectType with a function (method) attached to it
 func (objectType *ObjectType) WithInterface(iface *InterfaceImplementation) *ObjectType {
 	// Create a copy of objectType to preserve immutability
-	result := *objectType
-
-	// Copy contents of old map into new map
-	result.interfaces = make(map[TypeName]*InterfaceImplementation)
-	for key, value := range objectType.interfaces {
-		result.interfaces[key] = value
-	}
-
-	result.interfaces[iface.Name()] = iface
-
-	return &result
+	result := objectType.copy()
+	result.InterfaceImplementer = result.InterfaceImplementer.WithInterface(iface)
+	return result
 }
 
 func (objectType *ObjectType) copy() *ObjectType {
@@ -347,6 +269,8 @@ func (objectType *ObjectType) copy() *ObjectType {
 	for key, value := range objectType.functions {
 		result.functions[key] = value
 	}
+
+	result.InterfaceImplementer = objectType.InterfaceImplementer.copy()
 
 	return result
 }

--- a/hack/generator/pkg/astmodel/object_type_test.go
+++ b/hack/generator/pkg/astmodel/object_type_test.go
@@ -221,3 +221,23 @@ func Test_WithFunction_GivenEmptyObject_ReturnsPopulatedObject(t *testing.T) {
 	g.Expect(object.functions).To(HaveLen(1))
 	g.Expect(object.functions["Activate"].Equals(fn)).To(BeTrue())
 }
+
+/*
+ * WithInterface() tests
+ */
+func Test_WithInterface_ReturnsExpectedObject(t *testing.T) {
+	g := NewGomegaWithT(t)
+	empty := EmptyObjectType
+
+	// This is just a simple interface which actually has no functions
+	ifaceName := MakeTypeName(MakeLocalPackageReference("group", "2020-01-01"), "SampleInterface")
+	iface := NewInterfaceImplementation(
+		ifaceName,
+		make(map[string]Function))
+
+	object := empty.WithInterface(iface)
+
+	g.Expect(empty).NotTo(Equal(object)) // Ensure the original wasn't modified
+	g.Expect(object.interfaces).To(HaveLen(1))
+	g.Expect(object.interfaces[ifaceName]).To(Equal(iface))
+}

--- a/hack/generator/pkg/codegen/code_generator.go
+++ b/hack/generator/pkg/codegen/code_generator.go
@@ -57,6 +57,7 @@ func corePipelineStages(idFactory astmodel.IdentifierFactory, configuration *con
 		improveResourcePluralization(),
 		stripUnreferencedTypeDefinitions(),
 		createArmTypesAndCleanKubernetesTypes(idFactory),
+		applyKubernetesResourceInterface(idFactory),
 		checkForAnyType(configuration.AnyTypePackages),
 		checkForMissingStatusInformation(),
 	}

--- a/hack/generator/pkg/codegen/pipeline_apply_kubernetes_resource_interface.go
+++ b/hack/generator/pkg/codegen/pipeline_apply_kubernetes_resource_interface.go
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) Microsoft Corporation.
+ * Licensed under the MIT license.
+ */
+
+package codegen
+
+import (
+	"context"
+	"github.com/pkg/errors"
+
+	"github.com/Azure/k8s-infra/hack/generator/pkg/astmodel"
+)
+
+// applyKubernetesResourceInterface ensures that every Resource implements the KubernetesResource interface
+func applyKubernetesResourceInterface(idFactory astmodel.IdentifierFactory) PipelineStage {
+
+	return MakePipelineStage(
+		"applyKubernetesResourceInterface",
+		"Ensures that every resource implements the KubernetesResource interface",
+		func(ctx context.Context, types astmodel.Types) (astmodel.Types, error) {
+
+			result := make(astmodel.Types)
+			for _, typeDef := range types {
+				if resource, ok := typeDef.Type().(*astmodel.ResourceType); ok {
+
+					specName, ok := resource.SpecType().(astmodel.TypeName)
+					if !ok {
+						return nil, errors.Errorf("Resource %q spec was not of type TypeName, instead: %T", typeDef.Name(), typeDef.Type())
+					}
+
+					spec, ok := types[specName]
+					if !ok {
+						return nil, errors.Errorf("Couldn't find resource spec %q", specName)
+					}
+
+					specObject, ok := spec.Type().(*astmodel.ObjectType)
+					if !ok {
+						return nil, errors.Errorf("Spec %q was not of type ObjectType, instead %T", specName, spec.Type())
+					}
+
+					typeWithInterfaceImpl := resource.WithInterface(
+						astmodel.NewKubernetesResourceInterfaceImpl(idFactory, specObject))
+					newDef := typeDef.WithType(typeWithInterfaceImpl)
+					result.Add(newDef)
+				} else {
+					result.Add(typeDef)
+				}
+			}
+
+			return result, nil
+		})
+}

--- a/hack/generator/pkg/codegen/pipeline_create_arm_types.go
+++ b/hack/generator/pkg/codegen/pipeline_create_arm_types.go
@@ -394,8 +394,8 @@ func createOwnerProperty(idFactory astmodel.IdentifierFactory, ownerTypeName *as
 		"KnownResourceReference")
 
 	prop := astmodel.NewPropertyDefinition(
-		idFactory.CreatePropertyName("owner", astmodel.Exported),
-		"owner",
+		idFactory.CreatePropertyName(astmodel.OwnerProperty, astmodel.Exported),
+		idFactory.CreateIdentifier(astmodel.OwnerProperty, astmodel.NotExported),
 		knownResourceReferenceType)
 
 	group, _, err := ownerTypeName.PackageReference.GroupAndPackage()

--- a/hack/generator/pkg/codegen/testdata/ArmResource/Arm_test_dependent_resource_and_ownership.golden
+++ b/hack/generator/pkg/codegen/testdata/ArmResource/Arm_test_dependent_resource_and_ownership.golden
@@ -17,6 +17,19 @@ type A struct {
 	Spec              A_Spec `json:"spec,omitempty"`
 }
 
+var _ genruntime.KubernetesResource = &A{}
+
+// AzureName returns the Azure name of the resource
+func (a *A) AzureName() string {
+	return a.Spec.AzureName
+}
+
+// Owner returns the ResourceReference of the owner, or nil if there is no owner
+func (a *A) Owner() *genruntime.ResourceReference {
+	group, kind := genruntime.LookupOwnerGroupKind(a.Spec)
+	return &genruntime.ResourceReference{Name: a.Spec.Owner.Name, Group: group, Kind: kind}
+}
+
 // +kubebuilder:object:root=true
 //Generated from: https://test.test/schemas/2020-01-01/test.json#/resourceDefinitions/A
 type AList struct {
@@ -39,6 +52,19 @@ type B struct {
 	Spec              B_Spec `json:"spec,omitempty"`
 }
 
+var _ genruntime.KubernetesResource = &B{}
+
+// AzureName returns the Azure name of the resource
+func (b *B) AzureName() string {
+	return b.Spec.AzureName
+}
+
+// Owner returns the ResourceReference of the owner, or nil if there is no owner
+func (b *B) Owner() *genruntime.ResourceReference {
+	group, kind := genruntime.LookupOwnerGroupKind(b.Spec)
+	return &genruntime.ResourceReference{Name: b.Spec.Owner.Name, Group: group, Kind: kind}
+}
+
 // +kubebuilder:object:root=true
 //Generated from: https://test.test/schemas/2020-01-01/test.json#/resourceDefinitions/B
 type BList struct {
@@ -59,6 +85,19 @@ type C struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 	Spec              C_Spec `json:"spec,omitempty"`
+}
+
+var _ genruntime.KubernetesResource = &C{}
+
+// AzureName returns the Azure name of the resource
+func (c *C) AzureName() string {
+	return c.Spec.AzureName
+}
+
+// Owner returns the ResourceReference of the owner, or nil if there is no owner
+func (c *C) Owner() *genruntime.ResourceReference {
+	group, kind := genruntime.LookupOwnerGroupKind(c.Spec)
+	return &genruntime.ResourceReference{Name: c.Spec.Owner.Name, Group: group, Kind: kind}
 }
 
 // +kubebuilder:object:root=true

--- a/hack/generator/pkg/codegen/testdata/ArmResource/Arm_test_dependent_resource_and_ownership.golden
+++ b/hack/generator/pkg/codegen/testdata/ArmResource/Arm_test_dependent_resource_and_ownership.golden
@@ -101,13 +101,13 @@ type A_Spec struct {
 var _ genruntime.ArmTransformer = &A_Spec{}
 
 // ConvertToArm converts from a Kubernetes CRD object to an ARM object
-func (aSpec *A_Spec) ConvertToArm(owningName string) (interface{}, error) {
+func (aSpec *A_Spec) ConvertToArm(name string) (interface{}, error) {
 	if aSpec == nil {
 		return nil, nil
 	}
 	result := A_SpecArm{}
 	result.ApiVersion = aSpec.ApiVersion
-	result.Name = genruntime.CreateArmResourceNameForDeployment(owningName, aSpec.AzureName)
+	result.Name = name
 	result.Type = ASpecTypeMicrosoftAzureA
 	return result, nil
 }
@@ -150,13 +150,13 @@ type B_Spec struct {
 var _ genruntime.ArmTransformer = &B_Spec{}
 
 // ConvertToArm converts from a Kubernetes CRD object to an ARM object
-func (bSpec *B_Spec) ConvertToArm(owningName string) (interface{}, error) {
+func (bSpec *B_Spec) ConvertToArm(name string) (interface{}, error) {
 	if bSpec == nil {
 		return nil, nil
 	}
 	result := B_SpecArm{}
 	result.ApiVersion = bSpec.ApiVersion
-	result.Name = genruntime.CreateArmResourceNameForDeployment(owningName, bSpec.AzureName)
+	result.Name = name
 	result.Type = BSpecTypeMicrosoftAzureB
 	return result, nil
 }
@@ -199,13 +199,13 @@ type C_Spec struct {
 var _ genruntime.ArmTransformer = &C_Spec{}
 
 // ConvertToArm converts from a Kubernetes CRD object to an ARM object
-func (cSpec *C_Spec) ConvertToArm(owningName string) (interface{}, error) {
+func (cSpec *C_Spec) ConvertToArm(name string) (interface{}, error) {
 	if cSpec == nil {
 		return nil, nil
 	}
 	result := C_SpecArm{}
 	result.ApiVersion = cSpec.ApiVersion
-	result.Name = genruntime.CreateArmResourceNameForDeployment(owningName, cSpec.AzureName)
+	result.Name = name
 	result.Type = CSpecTypeMicrosoftAzureC
 	return result, nil
 }

--- a/hack/generator/pkg/codegen/testdata/ArmResource/Arm_test_simple_resource_array_properties.golden
+++ b/hack/generator/pkg/codegen/testdata/ArmResource/Arm_test_simple_resource_array_properties.golden
@@ -78,14 +78,14 @@ type FakeResource_Spec struct {
 var _ genruntime.ArmTransformer = &FakeResource_Spec{}
 
 // ConvertToArm converts from a Kubernetes CRD object to an ARM object
-func (fakeResourceSpec *FakeResource_Spec) ConvertToArm(owningName string) (interface{}, error) {
+func (fakeResourceSpec *FakeResource_Spec) ConvertToArm(name string) (interface{}, error) {
 	if fakeResourceSpec == nil {
 		return nil, nil
 	}
 	result := FakeResource_SpecArm{}
 	result.ApiVersion = fakeResourceSpec.ApiVersion
 	for _, item := range fakeResourceSpec.ArrayFoo {
-		elem, err := item.ConvertToArm(owningName)
+		elem, err := item.ConvertToArm(name)
 		if err != nil {
 			return nil, err
 		}
@@ -95,7 +95,7 @@ func (fakeResourceSpec *FakeResource_Spec) ConvertToArm(owningName string) (inte
 	for _, item := range fakeResourceSpec.ArrayOfArrays {
 		var elemTyped []FooArm
 		for _, item := range item {
-			elem, err := item.ConvertToArm(owningName)
+			elem, err := item.ConvertToArm(name)
 			if err != nil {
 				return nil, err
 			}
@@ -109,7 +109,7 @@ func (fakeResourceSpec *FakeResource_Spec) ConvertToArm(owningName string) (inte
 		elemTyped := make(map[string]FooArm)
 		if item != nil {
 			for key, value := range item {
-				elem, err := value.ConvertToArm(owningName)
+				elem, err := value.ConvertToArm(name)
 				if err != nil {
 					return nil, err
 				}
@@ -119,7 +119,7 @@ func (fakeResourceSpec *FakeResource_Spec) ConvertToArm(owningName string) (inte
 		}
 		result.ArrayOfMaps = append(result.ArrayOfMaps, elemTyped)
 	}
-	result.Name = genruntime.CreateArmResourceNameForDeployment(owningName, fakeResourceSpec.AzureName)
+	result.Name = name
 	result.Type = FakeResourceSpecTypeMicrosoftAzureFakeResource
 	return result, nil
 }
@@ -185,7 +185,7 @@ type Foo struct {
 var _ genruntime.ArmTransformer = &Foo{}
 
 // ConvertToArm converts from a Kubernetes CRD object to an ARM object
-func (foo *Foo) ConvertToArm(owningName string) (interface{}, error) {
+func (foo *Foo) ConvertToArm(name string) (interface{}, error) {
 	if foo == nil {
 		return nil, nil
 	}

--- a/hack/generator/pkg/codegen/testdata/ArmResource/Arm_test_simple_resource_array_properties.golden
+++ b/hack/generator/pkg/codegen/testdata/ArmResource/Arm_test_simple_resource_array_properties.golden
@@ -17,6 +17,19 @@ type FakeResource struct {
 	Spec              FakeResource_Spec `json:"spec,omitempty"`
 }
 
+var _ genruntime.KubernetesResource = &FakeResource{}
+
+// AzureName returns the Azure name of the resource
+func (fakeResource *FakeResource) AzureName() string {
+	return fakeResource.Spec.AzureName
+}
+
+// Owner returns the ResourceReference of the owner, or nil if there is no owner
+func (fakeResource *FakeResource) Owner() *genruntime.ResourceReference {
+	group, kind := genruntime.LookupOwnerGroupKind(fakeResource.Spec)
+	return &genruntime.ResourceReference{Name: fakeResource.Spec.Owner.Name, Group: group, Kind: kind}
+}
+
 // +kubebuilder:object:root=true
 //Generated from: https://test.test/schemas/2020-01-01/test.json#/resourceDefinitions/FakeResource
 type FakeResourceList struct {

--- a/hack/generator/pkg/codegen/testdata/ArmResource/Arm_test_simple_resource_complex_properties.golden
+++ b/hack/generator/pkg/codegen/testdata/ArmResource/Arm_test_simple_resource_complex_properties.golden
@@ -17,6 +17,19 @@ type FakeResource struct {
 	Spec              FakeResource_Spec `json:"spec,omitempty"`
 }
 
+var _ genruntime.KubernetesResource = &FakeResource{}
+
+// AzureName returns the Azure name of the resource
+func (fakeResource *FakeResource) AzureName() string {
+	return fakeResource.Spec.AzureName
+}
+
+// Owner returns the ResourceReference of the owner, or nil if there is no owner
+func (fakeResource *FakeResource) Owner() *genruntime.ResourceReference {
+	group, kind := genruntime.LookupOwnerGroupKind(fakeResource.Spec)
+	return &genruntime.ResourceReference{Name: fakeResource.Spec.Owner.Name, Group: group, Kind: kind}
+}
+
 // +kubebuilder:object:root=true
 //Generated from: https://test.test/schemas/2020-01-01/test.json#/resourceDefinitions/FakeResource
 type FakeResourceList struct {

--- a/hack/generator/pkg/codegen/testdata/ArmResource/Arm_test_simple_resource_complex_properties.golden
+++ b/hack/generator/pkg/codegen/testdata/ArmResource/Arm_test_simple_resource_complex_properties.golden
@@ -74,21 +74,21 @@ type FakeResource_Spec struct {
 var _ genruntime.ArmTransformer = &FakeResource_Spec{}
 
 // ConvertToArm converts from a Kubernetes CRD object to an ARM object
-func (fakeResourceSpec *FakeResource_Spec) ConvertToArm(owningName string) (interface{}, error) {
+func (fakeResourceSpec *FakeResource_Spec) ConvertToArm(name string) (interface{}, error) {
 	if fakeResourceSpec == nil {
 		return nil, nil
 	}
 	result := FakeResource_SpecArm{}
 	result.ApiVersion = fakeResourceSpec.ApiVersion
 	result.Color = fakeResourceSpec.Color
-	foo, err := fakeResourceSpec.Foo.ConvertToArm(owningName)
+	foo, err := fakeResourceSpec.Foo.ConvertToArm(name)
 	if err != nil {
 		return nil, err
 	}
 	result.Foo = foo.(FooArm)
-	result.Name = genruntime.CreateArmResourceNameForDeployment(owningName, fakeResourceSpec.AzureName)
+	result.Name = name
 	if fakeResourceSpec.OptionalFoo != nil {
-		optionalFoo, err := fakeResourceSpec.OptionalFoo.ConvertToArm(owningName)
+		optionalFoo, err := fakeResourceSpec.OptionalFoo.ConvertToArm(name)
 		if err != nil {
 			return nil, err
 		}
@@ -140,7 +140,7 @@ type Foo struct {
 var _ genruntime.ArmTransformer = &Foo{}
 
 // ConvertToArm converts from a Kubernetes CRD object to an ARM object
-func (foo *Foo) ConvertToArm(owningName string) (interface{}, error) {
+func (foo *Foo) ConvertToArm(name string) (interface{}, error) {
 	if foo == nil {
 		return nil, nil
 	}

--- a/hack/generator/pkg/codegen/testdata/ArmResource/Arm_test_simple_resource_map_properties.golden
+++ b/hack/generator/pkg/codegen/testdata/ArmResource/Arm_test_simple_resource_map_properties.golden
@@ -78,7 +78,7 @@ type FakeResource_Spec struct {
 var _ genruntime.ArmTransformer = &FakeResource_Spec{}
 
 // ConvertToArm converts from a Kubernetes CRD object to an ARM object
-func (fakeResourceSpec *FakeResource_Spec) ConvertToArm(owningName string) (interface{}, error) {
+func (fakeResourceSpec *FakeResource_Spec) ConvertToArm(name string) (interface{}, error) {
 	if fakeResourceSpec == nil {
 		return nil, nil
 	}
@@ -87,7 +87,7 @@ func (fakeResourceSpec *FakeResource_Spec) ConvertToArm(owningName string) (inte
 	result.MapFoo = make(map[string]FooArm)
 	if fakeResourceSpec.MapFoo != nil {
 		for key, value := range fakeResourceSpec.MapFoo {
-			elem, err := value.ConvertToArm(owningName)
+			elem, err := value.ConvertToArm(name)
 			if err != nil {
 				return nil, err
 			}
@@ -100,7 +100,7 @@ func (fakeResourceSpec *FakeResource_Spec) ConvertToArm(owningName string) (inte
 		for key, value := range fakeResourceSpec.MapOfArrays {
 			var elemTyped []FooArm
 			for _, item := range value {
-				elem, err := item.ConvertToArm(owningName)
+				elem, err := item.ConvertToArm(name)
 				if err != nil {
 					return nil, err
 				}
@@ -117,7 +117,7 @@ func (fakeResourceSpec *FakeResource_Spec) ConvertToArm(owningName string) (inte
 			elemTyped := make(map[string]FooArm)
 			if value != nil {
 				for key, value := range value {
-					elem, err := value.ConvertToArm(owningName)
+					elem, err := value.ConvertToArm(name)
 					if err != nil {
 						return nil, err
 					}
@@ -128,7 +128,7 @@ func (fakeResourceSpec *FakeResource_Spec) ConvertToArm(owningName string) (inte
 			result.MapOfMaps[key] = elemTyped
 		}
 	}
-	result.Name = genruntime.CreateArmResourceNameForDeployment(owningName, fakeResourceSpec.AzureName)
+	result.Name = name
 	result.Type = FakeResourceSpecTypeMicrosoftAzureFakeResource
 	return result, nil
 }
@@ -203,7 +203,7 @@ type Foo struct {
 var _ genruntime.ArmTransformer = &Foo{}
 
 // ConvertToArm converts from a Kubernetes CRD object to an ARM object
-func (foo *Foo) ConvertToArm(owningName string) (interface{}, error) {
+func (foo *Foo) ConvertToArm(name string) (interface{}, error) {
 	if foo == nil {
 		return nil, nil
 	}

--- a/hack/generator/pkg/codegen/testdata/ArmResource/Arm_test_simple_resource_map_properties.golden
+++ b/hack/generator/pkg/codegen/testdata/ArmResource/Arm_test_simple_resource_map_properties.golden
@@ -17,6 +17,19 @@ type FakeResource struct {
 	Spec              FakeResource_Spec `json:"spec,omitempty"`
 }
 
+var _ genruntime.KubernetesResource = &FakeResource{}
+
+// AzureName returns the Azure name of the resource
+func (fakeResource *FakeResource) AzureName() string {
+	return fakeResource.Spec.AzureName
+}
+
+// Owner returns the ResourceReference of the owner, or nil if there is no owner
+func (fakeResource *FakeResource) Owner() *genruntime.ResourceReference {
+	group, kind := genruntime.LookupOwnerGroupKind(fakeResource.Spec)
+	return &genruntime.ResourceReference{Name: fakeResource.Spec.Owner.Name, Group: group, Kind: kind}
+}
+
 // +kubebuilder:object:root=true
 //Generated from: https://test.test/schemas/2020-01-01/test.json#/resourceDefinitions/FakeResource
 type FakeResourceList struct {

--- a/hack/generator/pkg/codegen/testdata/ArmResource/Arm_test_simple_resource_renders_spec.golden
+++ b/hack/generator/pkg/codegen/testdata/ArmResource/Arm_test_simple_resource_renders_spec.golden
@@ -17,6 +17,19 @@ type FakeResource struct {
 	Spec              FakeResource_Spec `json:"spec,omitempty"`
 }
 
+var _ genruntime.KubernetesResource = &FakeResource{}
+
+// AzureName returns the Azure name of the resource
+func (fakeResource *FakeResource) AzureName() string {
+	return fakeResource.Spec.AzureName
+}
+
+// Owner returns the ResourceReference of the owner, or nil if there is no owner
+func (fakeResource *FakeResource) Owner() *genruntime.ResourceReference {
+	group, kind := genruntime.LookupOwnerGroupKind(fakeResource.Spec)
+	return &genruntime.ResourceReference{Name: fakeResource.Spec.Owner.Name, Group: group, Kind: kind}
+}
+
 // +kubebuilder:object:root=true
 //Generated from: https://test.test/schemas/2020-01-01/test.json#/resourceDefinitions/FakeResource
 type FakeResourceList struct {

--- a/hack/generator/pkg/codegen/testdata/ArmResource/Arm_test_simple_resource_renders_spec.golden
+++ b/hack/generator/pkg/codegen/testdata/ArmResource/Arm_test_simple_resource_renders_spec.golden
@@ -57,13 +57,13 @@ type FakeResource_Spec struct {
 var _ genruntime.ArmTransformer = &FakeResource_Spec{}
 
 // ConvertToArm converts from a Kubernetes CRD object to an ARM object
-func (fakeResourceSpec *FakeResource_Spec) ConvertToArm(owningName string) (interface{}, error) {
+func (fakeResourceSpec *FakeResource_Spec) ConvertToArm(name string) (interface{}, error) {
 	if fakeResourceSpec == nil {
 		return nil, nil
 	}
 	result := FakeResource_SpecArm{}
 	result.ApiVersion = fakeResourceSpec.ApiVersion
-	result.Name = genruntime.CreateArmResourceNameForDeployment(owningName, fakeResourceSpec.AzureName)
+	result.Name = name
 	result.Type = FakeResourceSpecTypeMicrosoftAzureFakeResource
 	return result, nil
 }


### PR DESCRIPTION
- Added InterfaceImplementer, for sharing interface implementation code between ResourceType and ObjectType (and possibly others in the future).
- Add KubernetesResource interface and implementation. This will be needed by the controller.
- A few minor cleanups for generated ConvertToArm methods.