### PR TITLE
Improve TypeVisitor and other cleanup

### DIFF
--- a/hack/generator/go.mod
+++ b/hack/generator/go.mod
@@ -26,6 +26,7 @@ require (
 	github.com/xeipuuv/gojsonschema v1.2.0
 	golang.org/x/sync v0.0.0-20190423024810-112230192c58
 	golang.org/x/text v0.3.3 // indirect
+	golang.org/x/tools v0.0.0-20190328211700-ab21143f2384
 	gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 // indirect
 	gopkg.in/ini.v1 v1.51.1 // indirect
 	gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c

--- a/hack/generator/pkg/astmodel/object_type.go
+++ b/hack/generator/pkg/astmodel/object_type.go
@@ -282,18 +282,11 @@ func (objectType *ObjectType) String() string {
 
 // IsObjectType returns true if the passed type is an object type OR if it is a wrapper type containing an object type
 func IsObjectType(t Type) bool {
-	switch o := t.(type) {
-	case *ObjectType:
-		return true
-	case ArmType:
-		wrapped := o.ObjectType()
-		return IsObjectType(&wrapped)
-	default:
-		return false
-	}
+	_, ok := t.(*ObjectType)
+	return ok
 }
 
 // IsObjectDefinition returns true if the passed definition is for a Arm type; false otherwise.
 func IsObjectDefinition(definition TypeDefinition) bool {
-	return IsArmType(definition.theType)
+	return IsObjectType(definition.theType)
 }

--- a/hack/generator/pkg/astmodel/reference_graph.go
+++ b/hack/generator/pkg/astmodel/reference_graph.go
@@ -16,7 +16,7 @@ type ReferenceGraph struct {
 }
 
 // CollectResourceDefinitions returns a TypeNameSet of all of the
-// resource definitions in the definitions passed in.
+// root definitions in the definitions passed in.
 func CollectResourceDefinitions(definitions Types) TypeNameSet {
 	resources := make(TypeNameSet)
 	for _, def := range definitions {

--- a/hack/generator/pkg/astmodel/types.go
+++ b/hack/generator/pkg/astmodel/types.go
@@ -62,12 +62,14 @@ func (types Types) Contains(name TypeName) bool {
 // TypesDisjointUnion merges this and other, with a safety check that no type is overwritten.
 // If an attempt is made to overwrite a type, this function panics
 func TypesDisjointUnion(s1 Types, s2 Types) Types {
+	result := s1.Copy()
+	result.AddTypes(s2)
+	return result
+}
+
+// Copy makes an independent copy of this set of types
+func (types Types) Copy() Types {
 	result := make(Types)
-	for _, o := range s1 {
-		result.Add(o)
-	}
-	for _, o := range s2 {
-		result.Add(o)
-	}
+	result.AddTypes(types)
 	return result
 }

--- a/hack/generator/pkg/codegen/pipeline_create_arm_types.go
+++ b/hack/generator/pkg/codegen/pipeline_create_arm_types.go
@@ -199,8 +199,8 @@ func transformTypeDefinition(
 	def astmodel.TypeDefinition,
 	handlers []conversionHandler) (astmodel.TypeDefinition, error) {
 
-	if !astmodel.IsObjectType(def.Type()) {
-		return astmodel.TypeDefinition{}, errors.Errorf("input type %q (%T) did not contain expected type Object", def.Name(), def.Type())
+	if !astmodel.IsObjectDefinition(def) && !astmodel.IsArmDefinition(def) {
+		return astmodel.TypeDefinition{}, errors.Errorf("input type %q (%T) did not contain expected type", def.Name(), def.Type())
 	}
 
 	visitor := astmodel.MakeTypeVisitor()

--- a/hack/generator/pkg/codegen/pipeline_create_arm_types.go
+++ b/hack/generator/pkg/codegen/pipeline_create_arm_types.go
@@ -364,11 +364,9 @@ func addArmConversionInterface(
 			isResource)), nil
 	}
 
-	transformedDef, err := transformTypeDefinition(
+	return transformTypeDefinition(
 		kubeDef,
 		[]conversionHandler{addInterfaceHandler})
-
-	return transformedDef, err
 }
 
 func convertArmPropertyTypeIfNeeded(definitions astmodel.Types, t astmodel.Type) (astmodel.Type, error) {

--- a/hack/generator/pkg/codegen/pipeline_create_arm_types.go
+++ b/hack/generator/pkg/codegen/pipeline_create_arm_types.go
@@ -61,9 +61,9 @@ func createArmTypes(
 		func(name astmodel.TypeName, resourceType *astmodel.ResourceType) (astmodel.TypeName, astmodel.TypeDefinition, error) {
 			armSpecDef, kubeSpecName, err := createArmResourceSpecDefinition(definitions, resourceType, idFactory)
 			if err != nil {
-				nilName := astmodel.TypeName{}
-				nilDef := astmodel.TypeDefinition{}
-				return nilName, nilDef, errors.Wrapf(err, "unable to create arm resource spec definition for resource %s", name)
+				emptyName := astmodel.TypeName{}
+				emptyDef := astmodel.TypeDefinition{}
+				return emptyName, emptyDef, errors.Wrapf(err, "unable to create arm resource spec definition for resource %s", name)
 			}
 
 			kubeNameToArmDefs[kubeSpecName] = armSpecDef
@@ -98,21 +98,21 @@ func modifyKubeTypes(
 		definitions,
 		// Resource handler
 		func(name astmodel.TypeName, resourceType *astmodel.ResourceType) (astmodel.TypeName, astmodel.TypeDefinition, error) {
-			nilName := astmodel.TypeName{}
-			nilDef := astmodel.TypeDefinition{}
+			emptyName := astmodel.TypeName{}
+			emptyDef := astmodel.TypeDefinition{}
 			kubernetesSpecDef, err := modifyKubeResourceSpecDefinition(definitions, idFactory, resourceType)
 			if err != nil {
-				return nilName, nilDef, errors.Wrapf(err, "unable to modify kube resource spec definition for resource %s", name)
+				return emptyName, emptyDef, errors.Wrapf(err, "unable to modify kube resource spec definition for resource %s", name)
 			}
 
 			armDef, ok := kubeNameToArmDefs[kubernetesSpecDef.Name()]
 			if !ok {
-				return nilName, nilDef, errors.Errorf("couldn't find arm def matching kube def %q", kubernetesSpecDef.Name())
+				return emptyName, emptyDef, errors.Errorf("couldn't find arm def matching kube def %q", kubernetesSpecDef.Name())
 			}
 
 			result, err := addArmConversionInterface(kubernetesSpecDef, armDef, idFactory, true)
 			if err != nil {
-				return nilName, nilDef, err
+				return emptyName, emptyDef, err
 			}
 
 			resultName := result.Name()
@@ -247,28 +247,28 @@ func createArmResourceSpecDefinition(
 	resourceType *astmodel.ResourceType,
 	idFactory astmodel.IdentifierFactory) (astmodel.TypeDefinition, astmodel.TypeName, error) {
 
-	nilName := astmodel.TypeName{}
-	nilDef := astmodel.TypeDefinition{}
+	emptyName := astmodel.TypeName{}
+	emptyDef := astmodel.TypeDefinition{}
 
 	resourceSpecDef, err := getResourceSpecDefinition(definitions, resourceType)
 	if err != nil {
-		return nilDef, nilName, err
+		return emptyDef, emptyName, err
 	}
 
 	armTypeDef, err := createArmTypeDefinition(definitions, resourceSpecDef)
 	if err != nil {
-		return nilDef, nilName, err
+		return emptyDef, emptyName, err
 	}
 
 	// ARM specs have a special interface that they need to implement, go ahead and create that here
 	armSpecObj, ok := armTypeDef.Type().(*astmodel.ObjectType)
 	if !ok {
-		return nilDef, nilName, errors.Errorf("Arm spec %q isn't of type ObjectType, instead: %T", armTypeDef.Name(), armTypeDef.Type())
+		return emptyDef, emptyName, errors.Errorf("Arm spec %q isn't of type ObjectType, instead: %T", armTypeDef.Name(), armTypeDef.Type())
 	}
 
 	iface, err := astmodel.NewArmSpecInterfaceImpl(idFactory, armSpecObj)
 	if err != nil {
-		return nilDef, nilName, err
+		return emptyDef, emptyName, err
 	}
 
 	updatedSpec := armSpecObj.WithInterface(iface)
@@ -352,8 +352,8 @@ func addArmConversionInterface(
 
 	objectType, err := astmodel.TypeAsObjectType(armDef.Type())
 	if err != nil {
-		nilDef := astmodel.TypeDefinition{}
-		return nilDef, errors.Errorf("ARM definition %q did not define an object type", armDef.Name())
+		emptyDef := astmodel.TypeDefinition{}
+		return emptyDef, errors.Errorf("ARM definition %q did not define an object type", armDef.Name())
 	}
 
 	addInterfaceHandler := func(t *astmodel.ObjectType) (*astmodel.ObjectType, error) {


### PR DESCRIPTION
A number of minor code gardening changes

* `MakeTypeVisitor()` now references named functions, giving better clarity of code than having them inline
* Changed naming of empty values to use `empty` prefix instead of `nil` (followup on PR #247)
* Simplified `IsObjectType()` to have a single responsibility and updated usage where an `ArmType` may reasonably appear
* Fixed bug in `IsObjectDefinition()`