### PR TITLE
Include kubebuilder subresource:status annotation

### DIFF
--- a/hack/generator/go.mod
+++ b/hack/generator/go.mod
@@ -26,7 +26,6 @@ require (
 	github.com/xeipuuv/gojsonschema v1.2.0
 	golang.org/x/sync v0.0.0-20190423024810-112230192c58
 	golang.org/x/text v0.3.3 // indirect
-	golang.org/x/tools v0.0.0-20190328211700-ab21143f2384
 	gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 // indirect
 	gopkg.in/ini.v1 v1.51.1 // indirect
 	gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c

--- a/hack/generator/pkg/astmodel/resource.go
+++ b/hack/generator/pkg/astmodel/resource.go
@@ -269,6 +269,12 @@ func (definition *ResourceType) AsDeclarations(codeGenerationContext *CodeGenera
 			},
 		}
 
+	if definition.status != nil {
+		comments = append(comments, &ast.Comment{
+			Text: "// +kubebuilder:subresource:status\n",
+		})
+	}
+
 	if definition.isStorageVersion {
 		comments = append(comments, &ast.Comment{
 			Text: "// +kubebuilder:storageversion\n",


### PR DESCRIPTION
  - This is required for proper functioning of controller
    status patching.