### PR TITLE
Rename comment helper methods for clarity

### DIFF
--- a/hack/generator/pkg/astmodel/comments.go
+++ b/hack/generator/pkg/astmodel/comments.go
@@ -26,19 +26,7 @@ func addWrappedComments(commentList *[]*ast.Comment, comments []string, width in
 
 func addWrappedComment(commentList *[]*ast.Comment, comment string, width int) {
 	for _, c := range formatComment(comment, width) {
-		line := strings.TrimSpace(c)
-
-		if !strings.HasPrefix(line, "//") {
-			line = "//" + line
-		}
-
-		if *commentList == nil {
-			line = "\n" + line
-		}
-
-		*commentList = append(*commentList, &ast.Comment{
-			Text: line,
-		})
+		addComment(commentList, c)
 	}
 }
 

--- a/hack/generator/pkg/astmodel/comments.go
+++ b/hack/generator/pkg/astmodel/comments.go
@@ -13,19 +13,19 @@ import (
 
 // Utility methods for adding comments
 
-func addDocComments(commentList *[]*ast.Comment, comments []string, width int) {
+func addWrappedComments(commentList *[]*ast.Comment, comments []string, width int) {
 	for _, comment := range comments {
 		// Skip empty comments
 		if comment == "" {
 			continue
 		}
 
-		addDocComment(commentList, comment, width)
+		addWrappedComment(commentList, comment, width)
 	}
 }
 
-func addDocComment(commentList *[]*ast.Comment, comment string, width int) {
-	for _, c := range formatDocComment(comment, width) {
+func addWrappedComment(commentList *[]*ast.Comment, comment string, width int) {
+	for _, c := range formatComment(comment, width) {
 		line := strings.TrimSpace(c)
 
 		if !strings.HasPrefix(line, "//") {
@@ -42,8 +42,24 @@ func addDocComment(commentList *[]*ast.Comment, comment string, width int) {
 	}
 }
 
-// formatDocComment splits the supplied comment string up ready for use as a documentation comment
-func formatDocComment(comment string, width int) []string {
+func addComment(commentList *[]*ast.Comment, comment string) {
+	line := strings.TrimSpace(comment)
+
+	if !strings.HasPrefix(line, "//") {
+		line = "//" + line
+	}
+
+	if *commentList == nil {
+		line = "\n" + line
+	}
+
+	*commentList = append(*commentList, &ast.Comment{
+		Text: line,
+	})
+}
+
+// formatComment splits the supplied comment string up ready for use as a documentation comment
+func formatComment(comment string, width int) []string {
 	// Remove markdown bolding
 	text := strings.ReplaceAll(comment, "**", "")
 

--- a/hack/generator/pkg/astmodel/comments_test.go
+++ b/hack/generator/pkg/astmodel/comments_test.go
@@ -48,7 +48,7 @@ func TestDocumentationCommentFormatting(t *testing.T) {
 		c := c
 		t.Run(c.comment, func(t *testing.T) {
 			g := NewGomegaWithT(t)
-			lines := formatDocComment(c.comment, 64)
+			lines := formatComment(c.comment, 64)
 			g.Expect(lines).To(Equal(c.results))
 		})
 	}

--- a/hack/generator/pkg/astmodel/enum_type.go
+++ b/hack/generator/pkg/astmodel/enum_type.go
@@ -78,7 +78,7 @@ func (enum *EnumType) createBaseDeclaration(
 		},
 	}
 
-	addDocComments(&declaration.Doc.List, description, 120)
+	addWrappedComments(&declaration.Doc.List, description, 120)
 
 	validationComment := GenerateKubebuilderComment(enum.CreateValidation())
 	declaration.Doc.List = append(

--- a/hack/generator/pkg/astmodel/enum_type.go
+++ b/hack/generator/pkg/astmodel/enum_type.go
@@ -81,9 +81,7 @@ func (enum *EnumType) createBaseDeclaration(
 	addWrappedComments(&declaration.Doc.List, description, 120)
 
 	validationComment := GenerateKubebuilderComment(enum.CreateValidation())
-	declaration.Doc.List = append(
-		declaration.Doc.List,
-		&ast.Comment{Text: "\n" + validationComment})
+	addComment(&declaration.Doc.List, validationComment)
 
 	return declaration
 }

--- a/hack/generator/pkg/astmodel/object_type.go
+++ b/hack/generator/pkg/astmodel/object_type.go
@@ -46,7 +46,7 @@ func (objectType *ObjectType) AsDeclarations(codeGenerationContext *CodeGenerati
 		},
 	}
 
-	addDocComments(&declaration.Doc.List, description, 200)
+	addWrappedComments(&declaration.Doc.List, description, 200)
 
 	result := []ast.Decl{declaration}
 	result = append(result, objectType.InterfaceImplementer.AsDeclarations(codeGenerationContext, name, nil)...)

--- a/hack/generator/pkg/astmodel/property_definition.go
+++ b/hack/generator/pkg/astmodel/property_definition.go
@@ -277,12 +277,12 @@ func (property *PropertyDefinition) AsField(codeGenerationContext *CodeGeneratio
 	// generate validation comments:
 	for _, validation := range property.validations {
 		// these are not doc comments but they must go here to be emitted before the property
-		addDocComment(&result.Doc.List, GenerateKubebuilderComment(validation), 200)
+		addComment(&result.Doc.List, GenerateKubebuilderComment(validation))
 	}
 
-	// generate doc comment:
+	// generate comment:
 	if property.description != "" {
-		addDocComment(&result.Doc.List, fmt.Sprintf("%s: %s", property.propertyName, property.description), 80)
+		addWrappedComment(&result.Doc.List, fmt.Sprintf("%s: %s", property.propertyName, property.description), 80)
 	}
 
 	return result

--- a/hack/generator/pkg/astmodel/resource.go
+++ b/hack/generator/pkg/astmodel/resource.go
@@ -264,16 +264,16 @@ func (definition *ResourceType) AsDeclarations(codeGenerationContext *CodeGenera
 
 	var comments []*ast.Comment
 
-	addDocComment(&comments, "// +kubebuilder:object:root=true\n", 120)
+	addComment(&comments, "// +kubebuilder:object:root=true")
 	if definition.status != nil {
-		addDocComment(&comments, "// +kubebuilder:subresource:status\n", 120)
+		addComment(&comments, "// +kubebuilder:subresource:status")
 	}
 
 	if definition.isStorageVersion {
-		addDocComment(&comments, "// +kubebuilder:storageversion\n", 120)
+		addComment(&comments, "// +kubebuilder:storageversion")
 	}
 
-	addDocComments(&comments, description, 200)
+	addWrappedComments(&comments, description, 200)
 
 	var declarations []ast.Decl
 	resourceDeclaration := &ast.GenDecl{
@@ -335,7 +335,7 @@ func (definition *ResourceType) resourceListTypeDecls(
 			},
 		}
 
-	addDocComments(&comments, description, 200)
+	addWrappedComments(&comments, description, 200)
 
 	return []ast.Decl{
 		&ast.GenDecl{

--- a/hack/generator/pkg/astmodel/type_definition.go
+++ b/hack/generator/pkg/astmodel/type_definition.go
@@ -73,7 +73,7 @@ func AsSimpleDeclarations(codeGenerationContext *CodeGenerationContext, name Typ
 	var docComments *ast.CommentGroup
 	if len(description) > 0 {
 		docComments = &ast.CommentGroup{}
-		addDocComments(&docComments.List, description, 120)
+		addWrappedComments(&docComments.List, description, 120)
 	}
 
 	return []ast.Decl{

--- a/hack/generator/pkg/codegen/testdata/ArmResource/Arm_test_simple_resource_array_properties.golden
+++ b/hack/generator/pkg/codegen/testdata/ArmResource/Arm_test_simple_resource_array_properties.golden
@@ -66,7 +66,6 @@ func (fakeResourceSpecArm FakeResource_SpecArm) GetType() string {
 }
 
 //Generated from: https://test.test/schemas/2020-01-01/test.json#/definitions/Color
-
 // +kubebuilder:validation:Enum={"blue","green","red"}
 type Color string
 

--- a/hack/generator/pkg/codegen/testdata/ArmResource/Arm_test_simple_resource_map_properties.golden
+++ b/hack/generator/pkg/codegen/testdata/ArmResource/Arm_test_simple_resource_map_properties.golden
@@ -66,7 +66,6 @@ func (fakeResourceSpecArm FakeResource_SpecArm) GetType() string {
 }
 
 //Generated from: https://test.test/schemas/2020-01-01/test.json#/definitions/Color
-
 // +kubebuilder:validation:Enum={"blue","green","red"}
 type Color string
 


### PR DESCRIPTION
Changes as follows:

* Rename `addDocComments()` to `addWrappedComments()` (plural form)
* Rename `addDocComment()` to `addWrappedComment()` (singular form)
* Rename `formatDocComment()` to `formatComment()` 
* Introduces `addComment` (no wordwrap)
