### PR TITLE
Add pipeline stage to simplify types

### DIFF
--- a/hack/generator/pkg/astmodel/object_type.go
+++ b/hack/generator/pkg/astmodel/object_type.go
@@ -86,6 +86,7 @@ func (objectType *ObjectType) Properties() []*PropertyDefinition {
 		result = append(result, property)
 	}
 
+	// Sorted so that it's always consistent
 	sort.Slice(result, func(left int, right int) bool {
 		return result[left].propertyName < result[right].propertyName
 	})
@@ -107,12 +108,7 @@ func (objectType *ObjectType) HasFunctionWithName(name string) bool {
 // AsType implements Type for ObjectType
 func (objectType *ObjectType) AsType(codeGenerationContext *CodeGenerationContext) ast.Expr {
 
-	// Copy the slice of properties and sort it
 	properties := objectType.Properties()
-	sort.Slice(properties, func(i int, j int) bool {
-		return properties[i].propertyName < properties[j].propertyName
-	})
-
 	fields := make([]*ast.Field, len(properties))
 	for i, f := range properties {
 		fields[i] = f.AsField(codeGenerationContext)

--- a/hack/generator/pkg/astmodel/resource.go
+++ b/hack/generator/pkg/astmodel/resource.go
@@ -148,6 +148,13 @@ func (definition *ResourceType) WithStatus(statusType Type) *ResourceType {
 	return &result
 }
 
+// WithSpec returns a new resource that has the specified spec type
+func (definition *ResourceType) WithSpec(specType Type) *ResourceType {
+	result := *definition
+	result.spec = specType
+	return &result
+}
+
 // WithInterface creates a new Resource with a function (method) attached to it
 func (definition *ResourceType) WithInterface(iface *InterfaceImplementation) *ResourceType {
 	// Create a copy of objectType to preserve immutability

--- a/hack/generator/pkg/astmodel/type_visitor.go
+++ b/hack/generator/pkg/astmodel/type_visitor.go
@@ -176,7 +176,7 @@ func identityVisitOfResourceType(this *TypeVisitor, it *ResourceType, ctx interf
 		return nil, errors.Wrapf(err, "failed to visit resource status type %v", it.status)
 	}
 
-	return NewResourceType(visitedSpec, visitedStatus).WithOwner(it.Owner()), nil
+	return it.WithSpec(visitedSpec).WithStatus(visitedStatus), nil
 }
 
 func identityVisitOfArmType(this *TypeVisitor, at *ArmType, ctx interface{}) (Type, error) {

--- a/hack/generator/pkg/codegen/code_generator.go
+++ b/hack/generator/pkg/codegen/code_generator.go
@@ -60,6 +60,7 @@ func corePipelineStages(idFactory astmodel.IdentifierFactory, configuration *con
 		applyKubernetesResourceInterface(idFactory),
 		checkForAnyType(configuration.AnyTypePackages),
 		checkForMissingStatusInformation(),
+		simplifyDefinitions(),
 	}
 }
 

--- a/hack/generator/pkg/codegen/code_generator.go
+++ b/hack/generator/pkg/codegen/code_generator.go
@@ -58,9 +58,9 @@ func corePipelineStages(idFactory astmodel.IdentifierFactory, configuration *con
 		stripUnreferencedTypeDefinitions(),
 		createArmTypesAndCleanKubernetesTypes(idFactory),
 		applyKubernetesResourceInterface(idFactory),
+		simplifyDefinitions(),
 		checkForAnyType(configuration.AnyTypePackages),
 		checkForMissingStatusInformation(),
-		simplifyDefinitions(),
 	}
 }
 

--- a/hack/generator/pkg/codegen/pipeline_simplify_definitions.go
+++ b/hack/generator/pkg/codegen/pipeline_simplify_definitions.go
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) Microsoft Corporation.
+ * Licensed under the MIT license.
+ */
+
+package codegen
+
+import (
+	"context"
+	"github.com/Azure/k8s-infra/hack/generator/pkg/astmodel"
+	kerrors "k8s.io/apimachinery/pkg/util/errors"
+	"k8s.io/klog"
+)
+
+// simplifyDefinitions creates a pipeline stage that removes any wrapper types prior to actual code generation
+func simplifyDefinitions() PipelineStage {
+	return MakePipelineStage(
+		"simplifyDefinitions",
+		"Simplify definitions",
+		func(ctx context.Context, defs astmodel.Types) (astmodel.Types, error) {
+			visitor := createSimplifyingVisitor()
+			var errs []error
+			result := make(astmodel.Types)
+			for _, def := range defs {
+				d, err := visitor.VisitDefinition(def, nil)
+				if err != nil {
+					errs = append(errs, err)
+				} else {
+					result[d.Name()] = *d
+					if !def.Type().Equals(d.Type()) {
+						klog.V(3).Infof("Simplified %v", def.Name())
+					}
+				}
+			}
+
+			if len(errs) > 0 {
+				return nil, kerrors.NewAggregate(errs)
+			}
+
+			return result, nil
+		})
+}
+
+func createSimplifyingVisitor() astmodel.TypeVisitor {
+	result := astmodel.MakeTypeVisitor()
+
+	result.VisitArmType = func(tv *astmodel.TypeVisitor, at *astmodel.ArmType, ctx interface{}) (astmodel.Type, error) {
+		ot := at.ObjectType()
+		return tv.Visit(&ot, ctx)
+	}
+
+	return result
+}

--- a/hack/generator/pkg/codegen/pipeline_simplify_definitions.go
+++ b/hack/generator/pkg/codegen/pipeline_simplify_definitions.go
@@ -50,7 +50,7 @@ func createSimplifyingVisitor() astmodel.TypeVisitor {
 		return tv.Visit(&ot, ctx)
 	}
 
-	// Don't need to waste type iterating within complex objects
+	// Don't need to waste time iterating within complex objects
 	result.VisitObjectType = func(_ *astmodel.TypeVisitor, ot *astmodel.ObjectType, _ interface{}) (astmodel.Type, error) {
 		return ot, nil
 	}


### PR DESCRIPTION
We're introducing a number of wrapper types to distinguish different types as we process them through the pipeline; this stage flattens all of those types just prior to generating the actual code.

Prerequisite for #255 