### PR TITLE
Further improvements to PackageReference

### DIFF
--- a/hack/generator/pkg/astmodel/armconversion/arm_conversion_function.go
+++ b/hack/generator/pkg/astmodel/armconversion/arm_conversion_function.go
@@ -42,7 +42,7 @@ func (c *ArmConversionFunction) RequiredImports() []astmodel.PackageReference {
 	// of the properties in the ARM object, so we need to import those.
 	result = append(result, c.armType.RequiredImports()...)
 	result = append(result, astmodel.MakeGenRuntimePackageReference())
-	result = append(result, astmodel.MakeLibraryPackageReference("fmt"))
+	result = append(result, astmodel.MakeExternalPackageReference("fmt"))
 
 	return result
 }

--- a/hack/generator/pkg/astmodel/external_package_reference.go
+++ b/hack/generator/pkg/astmodel/external_package_reference.go
@@ -11,43 +11,43 @@ import (
 	"strings"
 )
 
-// LibraryPackageReference indicates a library package that needs to be imported
-type LibraryPackageReference struct {
+// ExternalPackageReference indicates a library package that needs to be imported
+type ExternalPackageReference struct {
 	packagePath string
 }
 
-var _ PackageReference = LibraryPackageReference{}
-var _ fmt.Stringer = LibraryPackageReference{}
+var _ PackageReference = ExternalPackageReference{}
+var _ fmt.Stringer = ExternalPackageReference{}
 
-// MakeLibraryPackageReference creates a new package reference from a path
-func MakeLibraryPackageReference(packagePath string) LibraryPackageReference {
-	return LibraryPackageReference{packagePath: packagePath}
+// MakeExternalPackageReference creates a new package reference from a path
+func MakeExternalPackageReference(packagePath string) ExternalPackageReference {
+	return ExternalPackageReference{packagePath: packagePath}
 }
 
 // IsLocalPackage returns false to indicate that library packages are not local
-func (pr LibraryPackageReference) IsLocalPackage() bool {
+func (pr ExternalPackageReference) IsLocalPackage() bool {
 	return false
 }
 
 // Group returns an error because it's invalid for library packages
-func (pr LibraryPackageReference) Group() (string, error) {
+func (pr ExternalPackageReference) Group() (string, error) {
 	return "", errors.New("Cannot return Group() for a library package")
 }
 
 // Package returns the package name of this reference
-func (pr LibraryPackageReference) Package() string {
+func (pr ExternalPackageReference) Package() string {
 	l := strings.Split(pr.packagePath, "/")
 	return l[len(l)-1]
 }
 
 // PackagePath returns the fully qualified package path
-func (pr LibraryPackageReference) PackagePath() string {
+func (pr ExternalPackageReference) PackagePath() string {
 	return pr.packagePath
 }
 
 // Equals returns true if the passed package reference references the same package, false otherwise
-func (pr LibraryPackageReference) Equals(ref PackageReference) bool {
-	if other, ok := ref.(LibraryPackageReference); ok {
+func (pr ExternalPackageReference) Equals(ref PackageReference) bool {
+	if other, ok := ref.(ExternalPackageReference); ok {
 		return pr.packagePath == other.packagePath
 	}
 
@@ -55,6 +55,6 @@ func (pr LibraryPackageReference) Equals(ref PackageReference) bool {
 }
 
 // String returns the string representation of the package reference
-func (pr LibraryPackageReference) String() string {
+func (pr ExternalPackageReference) String() string {
 	return pr.packagePath
 }

--- a/hack/generator/pkg/astmodel/external_package_reference.go
+++ b/hack/generator/pkg/astmodel/external_package_reference.go
@@ -6,7 +6,6 @@
 package astmodel
 
 import (
-	"errors"
 	"fmt"
 	"strings"
 )
@@ -25,17 +24,12 @@ func MakeExternalPackageReference(packagePath string) ExternalPackageReference {
 }
 
 // IsLocalPackage returns false to indicate that library packages are not local
-func (pr ExternalPackageReference) IsLocalPackage() bool {
-	return false
-}
-
-// Group returns an error because it's invalid for library packages
-func (pr ExternalPackageReference) Group() (string, error) {
-	return "", errors.New("Cannot return Group() for a library package")
+func (pr ExternalPackageReference) AsLocalPackage() (LocalPackageReference, bool) {
+	return LocalPackageReference{}, false
 }
 
 // Package returns the package name of this reference
-func (pr ExternalPackageReference) Package() string {
+func (pr ExternalPackageReference) PackageName() string {
 	l := strings.Split(pr.packagePath, "/")
 	return l[len(l)-1]
 }

--- a/hack/generator/pkg/astmodel/external_package_reference.go
+++ b/hack/generator/pkg/astmodel/external_package_reference.go
@@ -10,7 +10,7 @@ import (
 	"strings"
 )
 
-// ExternalPackageReference indicates a library package that needs to be imported
+// ExternalPackageReference indicates a package to be imported from an external source, such as github or the go standard library.
 type ExternalPackageReference struct {
 	packagePath string
 }

--- a/hack/generator/pkg/astmodel/external_package_reference_test.go
+++ b/hack/generator/pkg/astmodel/external_package_reference_test.go
@@ -48,9 +48,9 @@ func TestExternalPackageReferences_ReturnExpectedProperties(t *testing.T) {
 
 			ref := MakeExternalPackageReference(c.path)
 			_, err := ref.Group()
+			_, ok := ref.AsLocalPackage()
 
-			g.Expect(ref.IsLocalPackage()).To(BeFalse())
-			g.Expect(ref.Package()).To(Equal(c.packageName))
+			g.Expect(ok).To(BeFalse())
 			g.Expect(ref.PackagePath()).To(Equal(c.path))
 			g.Expect(ref.String()).To(Equal(c.path))
 			g.Expect(err).NotTo(BeNil())

--- a/hack/generator/pkg/astmodel/external_package_reference_test.go
+++ b/hack/generator/pkg/astmodel/external_package_reference_test.go
@@ -10,7 +10,7 @@ import (
 	"testing"
 )
 
-func TestMakeLibraryPackageReference_GivenPath_ReturnsInstanceWithPath(t *testing.T) {
+func TestMakeExternalPackageReference_GivenPath_ReturnsInstanceWithPath(t *testing.T) {
 	cases := []struct {
 		name string
 		path string
@@ -24,13 +24,13 @@ func TestMakeLibraryPackageReference_GivenPath_ReturnsInstanceWithPath(t *testin
 		t.Run(c.name, func(t *testing.T) {
 			t.Parallel()
 			g := NewGomegaWithT(t)
-			ref := MakeLibraryPackageReference(c.path)
+			ref := MakeExternalPackageReference(c.path)
 			g.Expect(ref.PackagePath()).To(Equal(c.path))
 		})
 	}
 }
 
-func TestLibraryPackageReferences_ReturnExpectedProperties(t *testing.T) {
+func TestExternalPackageReferences_ReturnExpectedProperties(t *testing.T) {
 	cases := []struct {
 		name        string
 		path        string
@@ -46,7 +46,7 @@ func TestLibraryPackageReferences_ReturnExpectedProperties(t *testing.T) {
 			t.Parallel()
 			g := NewGomegaWithT(t)
 
-			ref := MakeLibraryPackageReference(c.path)
+			ref := MakeExternalPackageReference(c.path)
 			_, err := ref.Group()
 
 			g.Expect(ref.IsLocalPackage()).To(BeFalse())
@@ -58,22 +58,22 @@ func TestLibraryPackageReferences_ReturnExpectedProperties(t *testing.T) {
 	}
 }
 
-func TestLibraryPackageReferences_Equals_GivesExpectedResults(t *testing.T) {
+func TestExternalPackageReferences_Equals_GivesExpectedResults(t *testing.T) {
 
-	fmtRef := MakeLibraryPackageReference("fmt")
-	astRef := MakeLibraryPackageReference("go/ast")
+	fmtRef := MakeExternalPackageReference("fmt")
+	astRef := MakeExternalPackageReference("go/ast")
 	otherRef := MakeLocalPackageReference("group", "package")
 
 	cases := []struct {
 		name     string
-		this     LibraryPackageReference
+		this     ExternalPackageReference
 		other    PackageReference
 		areEqual bool
 	}{
 		{"Equal self", fmtRef, fmtRef, true},
 		{"Equal self", astRef, astRef, true},
-		{"Not equal other library", fmtRef, astRef, false},
-		{"Not equal other library", astRef, fmtRef, false},
+		{"Not equal other external reference", fmtRef, astRef, false},
+		{"Not equal other external reference", astRef, fmtRef, false},
 		{"Not equal other kind", fmtRef, otherRef, false},
 		{"Not equal other kind", astRef, otherRef, false},
 	}

--- a/hack/generator/pkg/astmodel/external_package_reference_test.go
+++ b/hack/generator/pkg/astmodel/external_package_reference_test.go
@@ -47,13 +47,11 @@ func TestExternalPackageReferences_ReturnExpectedProperties(t *testing.T) {
 			g := NewGomegaWithT(t)
 
 			ref := MakeExternalPackageReference(c.path)
-			_, err := ref.Group()
 			_, ok := ref.AsLocalPackage()
 
 			g.Expect(ok).To(BeFalse())
 			g.Expect(ref.PackagePath()).To(Equal(c.path))
 			g.Expect(ref.String()).To(Equal(c.path))
-			g.Expect(err).NotTo(BeNil())
 		})
 	}
 }

--- a/hack/generator/pkg/astmodel/file_definition.go
+++ b/hack/generator/pkg/astmodel/file_definition.go
@@ -32,7 +32,10 @@ type FileDefinition struct {
 }
 
 // NewFileDefinition creates a file definition containing specified definitions
-func NewFileDefinition(packageRef PackageReference, definitions []TypeDefinition, generatedPackages map[PackageReference]*PackageDefinition) *FileDefinition {
+func NewFileDefinition(
+	packageRef PackageReference,
+	definitions []TypeDefinition,
+	generatedPackages map[PackageReference]*PackageDefinition) *FileDefinition {
 
 	// Topological sort of the definitions, putting them in order of reference
 	ranks := calcRanks(definitions)
@@ -234,14 +237,12 @@ func (file *FileDefinition) AsAst() ast.Node {
 		"Licensed under the MIT license.",
 		CodeGenerationComment)
 
-	packageName := file.packageReference.Package()
-
 	// We set Package (the offset of the package keyword) so that it follows the header comments
 	result := &ast.File{
 		Doc: &ast.CommentGroup{
 			List: header,
 		},
-		Name:    ast.NewIdent(packageName),
+		Name:    ast.NewIdent(file.packageReference.PackageName()),
 		Decls:   decls,
 		Package: token.Pos(headerLen),
 	}

--- a/hack/generator/pkg/astmodel/local_package_reference.go
+++ b/hack/generator/pkg/astmodel/local_package_reference.go
@@ -13,44 +13,49 @@ const (
 
 // LocalPackageReference specifies a local package name or reference
 type LocalPackageReference struct {
-	groupName   string
-	packageName string
+	group   string
+	version string
 }
 
 var _ PackageReference = LocalPackageReference{}
 var _ fmt.Stringer = LocalPackageReference{}
 
-// MakeLocalPackageReference Creates a new local package reference from a group and package name
-func MakeLocalPackageReference(groupName string, packageName string) LocalPackageReference {
-	return LocalPackageReference{groupName: groupName, packageName: packageName}
+// MakeLocalPackageReference Creates a new local package reference from a group and version
+func MakeLocalPackageReference(group string, version string) LocalPackageReference {
+	return LocalPackageReference{group: group, version: version}
 }
 
 // IsLocalPackage returns true
-func (pr LocalPackageReference) IsLocalPackage() bool {
-	return true
+func (pr LocalPackageReference) AsLocalPackage() (LocalPackageReference, bool) {
+	return pr, true
 }
 
-// Group returns the group of this reference
-func (pr LocalPackageReference) Group() (string, error) {
-	return pr.groupName, nil
+// Group returns the group of this local reference
+func (pr LocalPackageReference) Group() string {
+	return pr.group
+}
+
+// Version returns the version of this local reference
+func (pr LocalPackageReference) Version() string {
+	return pr.version
 }
 
 // Package returns the package name of this reference
-func (pr LocalPackageReference) Package() string {
-	return pr.packageName
+func (pr LocalPackageReference) PackageName() string {
+	return pr.version
 }
 
 // PackagePath returns the fully qualified package path
 func (pr LocalPackageReference) PackagePath() string {
-	url := LocalPathPrefix + pr.groupName + "/" + pr.packageName
+	url := LocalPathPrefix + pr.group + "/" + pr.version
 	return url
 }
 
 // Equals returns true if the passed package reference references the same package, false otherwise
 func (pr LocalPackageReference) Equals(ref PackageReference) bool {
 	if other, ok := ref.(LocalPackageReference); ok {
-		return pr.packageName == other.packageName &&
-			pr.groupName == other.groupName
+		return pr.version == other.version &&
+			pr.group == other.group
 	}
 
 	return false

--- a/hack/generator/pkg/astmodel/local_package_reference_test.go
+++ b/hack/generator/pkg/astmodel/local_package_reference_test.go
@@ -27,10 +27,9 @@ func TestMakeLocalPackageReference_GivenGroupAndPackage_ReturnsInstanceWithPrope
 			g := NewGomegaWithT(t)
 
 			ref := MakeLocalPackageReference(c.group, c.pkg)
-			grp, err := ref.Group()
-			pkg := ref.Package()
+			grp := ref.Group()
+			pkg := ref.PackageName()
 
-			g.Expect(err).To(BeNil())
 			g.Expect(grp).To(Equal(c.group))
 			g.Expect(pkg).To(Equal(c.pkg))
 		})
@@ -70,14 +69,14 @@ func TestLocalPackageReferences_ReturnExpectedProperties(t *testing.T) {
 			g := NewGomegaWithT(t)
 
 			ref := MakeLocalPackageReference(c.group, c.pkg)
-			grp, err := ref.Group()
+			grp := ref.Group()
+			_, ok := ref.AsLocalPackage()
 
-			g.Expect(ref.IsLocalPackage()).To(BeTrue())
-			g.Expect(ref.Package()).To(Equal(c.pkg))
+			g.Expect(ok).To(BeTrue())
+			g.Expect(ref.PackageName()).To(Equal(c.pkg))
 			g.Expect(ref.PackagePath()).To(Equal(c.expectedPath))
 			g.Expect(ref.String()).To(Equal(c.expectedPath))
 			g.Expect(grp).To(Equal(c.group))
-			g.Expect(err).To(BeNil())
 		})
 	}
 }

--- a/hack/generator/pkg/astmodel/local_package_reference_test.go
+++ b/hack/generator/pkg/astmodel/local_package_reference_test.go
@@ -87,7 +87,7 @@ func TestLocalPackageReferences_Equals_GivesExpectedResults(t *testing.T) {
 	batchRef := MakeLocalPackageReference("microsoft.batch", "v20200901")
 	olderRef := MakeLocalPackageReference("microsoft.batch", "v20150101")
 	networkingRef := MakeLocalPackageReference("microsoft.networking", "v20200901")
-	fmtRef := MakeLibraryPackageReference("fmt")
+	fmtRef := MakeExternalPackageReference("fmt")
 
 	cases := []struct {
 		name     string

--- a/hack/generator/pkg/astmodel/one_of_json_marshal_function.go
+++ b/hack/generator/pkg/astmodel/one_of_json_marshal_function.go
@@ -121,6 +121,6 @@ func (f *OneOfJSONMarshalFunction) AsFunc(
 // RequiredImports returns a list of packages required by this
 func (f *OneOfJSONMarshalFunction) RequiredImports() []PackageReference {
 	return []PackageReference{
-		MakeLibraryPackageReference("encoding/json"),
+		MakeExternalPackageReference("encoding/json"),
 	}
 }

--- a/hack/generator/pkg/astmodel/package_definition.go
+++ b/hack/generator/pkg/astmodel/package_definition.go
@@ -74,7 +74,9 @@ func (pkgDef *PackageDefinition) DefinitionCount() int {
 func emitFiles(filesToGenerate map[string][]TypeDefinition, outputDir string, generatedPackages map[PackageReference]*PackageDefinition) error {
 	for fileName, defs := range filesToGenerate {
 		fullFileName := fileName + "_types" + CodeGeneratedFileSuffix
-		genFile := NewFileDefinition(defs[0].Name().PackageReference, defs, generatedPackages)
+
+		ref := defs[0].Name().PackageReference
+		genFile := NewFileDefinition(ref, defs, generatedPackages)
 		outputFile := filepath.Join(outputDir, fullFileName)
 
 		klog.V(5).Infof("Writing %q\n", outputFile)

--- a/hack/generator/pkg/astmodel/package_import.go
+++ b/hack/generator/pkg/astmodel/package_import.go
@@ -50,7 +50,7 @@ func (pi PackageImport) PackageName() string {
 		return pi.name
 	}
 
-	return pi.PackageReference.Package()
+	return pi.PackageReference.PackageName()
 }
 
 // Equals returns true if the passed package reference references the same package, false otherwise

--- a/hack/generator/pkg/astmodel/package_reference.go
+++ b/hack/generator/pkg/astmodel/package_reference.go
@@ -15,11 +15,9 @@ var MetaV1PackageReference = MakeExternalPackageReference("k8s.io/apimachinery/p
 
 type PackageReference interface {
 	// IsLocalPackage returns a valud indicating whether this is a local package
-	IsLocalPackage() bool
-	// Group returns the group of this reference (but only if it is local)
-	Group() (string, error)
+	AsLocalPackage() (LocalPackageReference, bool)
 	// Package returns the package name of this reference
-	Package() string
+	PackageName() string
 	// PackagePath returns the fully qualified package path
 	PackagePath() string
 	// Equals returns true if the passed package reference references the same package, false otherwise

--- a/hack/generator/pkg/astmodel/package_reference.go
+++ b/hack/generator/pkg/astmodel/package_reference.go
@@ -11,7 +11,7 @@ const (
 	GroupSuffix           = ".infra.azure.com"
 )
 
-var MetaV1PackageReference = MakeLibraryPackageReference("k8s.io/apimachinery/pkg/apis/meta/v1")
+var MetaV1PackageReference = MakeExternalPackageReference("k8s.io/apimachinery/pkg/apis/meta/v1")
 
 type PackageReference interface {
 	// IsLocalPackage returns a valud indicating whether this is a local package
@@ -30,5 +30,5 @@ type PackageReference interface {
 
 // MakeGenRuntimePackageReference creates a new package reference for the genruntime package
 func MakeGenRuntimePackageReference() PackageReference {
-	return MakeLibraryPackageReference(genRuntimePathPrefix)
+	return MakeExternalPackageReference(genRuntimePathPrefix)
 }

--- a/hack/generator/pkg/astmodel/resource.go
+++ b/hack/generator/pkg/astmodel/resource.go
@@ -225,7 +225,7 @@ func (definition *ResourceType) RequiredImports() []PackageReference {
 
 	typeImports = append(typeImports, MetaV1PackageReference)
 	typeImports = append(typeImports, MakeGenRuntimePackageReference())
-	typeImports = append(typeImports, MakeLibraryPackageReference("fmt"))
+	typeImports = append(typeImports, MakeExternalPackageReference("fmt"))
 
 	// Interface imports
 	typeImports = append(typeImports, definition.InterfaceImplementer.RequiredImports()...)

--- a/hack/generator/pkg/astmodel/type_definition_test.go
+++ b/hack/generator/pkg/astmodel/type_definition_test.go
@@ -29,13 +29,11 @@ func Test_MakeTypeDefinition_GivenValues_InitializesProperties(t *testing.T) {
 	g.Expect(objectDefinition.Name().name).To(Equal(name))
 	g.Expect(objectDefinition.Type()).To(Equal(objectType))
 
-	definitionGroup, err := objectDefinition.Name().PackageReference.Group()
-	g.Expect(err).To(BeNil())
+	localRef, ok := objectDefinition.Name().PackageReference.AsLocalPackage()
+	g.Expect(ok).To(BeTrue())
 
-	definitionPackage := objectDefinition.Name().PackageReference.Package()
-
-	g.Expect(definitionGroup).To(Equal(group))
-	g.Expect(definitionPackage).To(Equal(version))
+	g.Expect(localRef.Group()).To(Equal(group))
+	g.Expect(localRef.Version()).To(Equal(version))
 	g.Expect(objectDefinition.Type().(*ObjectType).properties).To(HaveLen(3))
 }
 

--- a/hack/generator/pkg/astmodel/types_test.go
+++ b/hack/generator/pkg/astmodel/types_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 var (
-	pkg             = MakeLibraryPackageReference("foo")
+	pkg             = MakeExternalPackageReference("foo")
 	alphaDefinition = createTestDefinition("alpha")
 	betaDefinition  = createTestDefinition("beta")
 	gammaDefinition = createTestDefinition("gamma")

--- a/hack/generator/pkg/codegen/pipeline_check_for_anytype.go
+++ b/hack/generator/pkg/codegen/pipeline_check_for_anytype.go
@@ -51,10 +51,8 @@ func checkForAnyType(description string, packages []string) PipelineStage {
 					badNames = append(badNames, name)
 				}
 
-				packageName, err := packageName(name)
-				if err != nil {
-					return nil, err
-				}
+				packageName := packageName(name)
+
 				// We only want to include this type in the output if
 				// it's not in a package that we know contains
 				// AnyTypes.
@@ -92,14 +90,15 @@ func containsAnyType(theType astmodel.Type) bool {
 	return found
 }
 
-func packageName(name astmodel.TypeName) (string, error) {
-	group, err := name.PackageReference.Group()
-	if err != nil {
-		return "", err
+func packageName(name astmodel.TypeName) string {
+	if localRef, ok := name.PackageReference.AsLocalPackage(); ok {
+		group := localRef.Group()
+		version := localRef.Version()
+
+		return group + "/" + version
 	}
 
-	version := name.PackageReference.Package()
-	return group + "/" + version, nil
+	return name.PackageReference.PackageName()
 }
 
 func collectBadPackages(
@@ -108,10 +107,7 @@ func collectBadPackages(
 ) ([]string, error) {
 	grouped := make(map[string][]string)
 	for _, name := range names {
-		groupVersion, err := packageName(name)
-		if err != nil {
-			return nil, err
-		}
+		groupVersion := packageName(name)
 		grouped[groupVersion] = append(grouped[groupVersion], name.Name())
 	}
 

--- a/hack/generator/pkg/codegen/pipeline_create_arm_types.go
+++ b/hack/generator/pkg/codegen/pipeline_create_arm_types.go
@@ -432,14 +432,13 @@ func createOwnerProperty(idFactory astmodel.IdentifierFactory, ownerTypeName *as
 		idFactory.CreateIdentifier(astmodel.OwnerProperty, astmodel.NotExported),
 		knownResourceReferenceType)
 
-	group, err := ownerTypeName.PackageReference.Group()
-	if err != nil {
-		return nil, err
+	if localRef, ok := ownerTypeName.PackageReference.AsLocalPackage(); ok {
+		group := localRef.Group() + astmodel.GroupSuffix
+		prop = prop.WithTag("group", group).WithTag("kind", ownerTypeName.Name())
+		prop = prop.WithValidation(astmodel.ValidateRequired()) // Owner is already required
+	} else {
+		panic("owners from external packages not currently supported")
 	}
-	group = group + astmodel.GroupSuffix
-
-	prop = prop.WithTag("group", group).WithTag("kind", ownerTypeName.Name())
-	prop = prop.WithValidation(astmodel.ValidateRequired()) // Owner is already required
 
 	return prop, nil
 }

--- a/hack/generator/pkg/codegen/pipeline_create_arm_types.go
+++ b/hack/generator/pkg/codegen/pipeline_create_arm_types.go
@@ -437,7 +437,7 @@ func createOwnerProperty(idFactory astmodel.IdentifierFactory, ownerTypeName *as
 		prop = prop.WithTag("group", group).WithTag("kind", ownerTypeName.Name())
 		prop = prop.WithValidation(astmodel.ValidateRequired()) // Owner is already required
 	} else {
-		panic("owners from external packages not currently supported")
+		return nil, errors.New("owners from external packages not currently supported")
 	}
 
 	return prop, nil

--- a/hack/generator/pkg/codegen/pipeline_strip_unused_types_test.go
+++ b/hack/generator/pkg/codegen/pipeline_strip_unused_types_test.go
@@ -18,7 +18,7 @@ const packagePath = "test.package/v1"
 func TestConnectionChecker_Avoids_Cycles(t *testing.T) {
 	g := NewGomegaWithT(t)
 	makeName := func(name string) astmodel.TypeName {
-		return astmodel.MakeTypeName(astmodel.MakeLibraryPackageReference(packagePath), name)
+		return astmodel.MakeTypeName(astmodel.MakeExternalPackageReference(packagePath), name)
 	}
 
 	makeSet := func(names ...string) astmodel.TypeNameSet {

--- a/hack/generator/pkg/config/type_matcher.go
+++ b/hack/generator/pkg/config/type_matcher.go
@@ -6,7 +6,6 @@
 package config
 
 import (
-	"fmt"
 	"regexp"
 	"strings"
 
@@ -63,19 +62,19 @@ func (typeMatcher *TypeMatcher) matches(glob string, regex **regexp.Regexp, name
 
 // AppliesToType indicates whether this filter should be applied to the supplied type definition
 func (typeMatcher *TypeMatcher) AppliesToType(typeName astmodel.TypeName) bool {
-	groupName, err := typeName.PackageReference.Group()
-	if err != nil {
-		// TODO: Should this func return an error rather than panic?
-		panic(fmt.Sprintf("%v", err))
+	if localRef, ok := typeName.PackageReference.AsLocalPackage(); ok {
+		group := localRef.Group()
+		version := localRef.Version()
+
+		result := typeMatcher.groupMatches(group) &&
+			typeMatcher.versionMatches(version) &&
+			typeMatcher.nameMatches(typeName.Name())
+
+		return result
 	}
 
-	packageName := typeName.PackageReference.Package()
-
-	result := typeMatcher.groupMatches(groupName) &&
-		typeMatcher.versionMatches(packageName) &&
-		typeMatcher.nameMatches(typeName.Name())
-
-	return result
+	// Never match external references
+	return false
 }
 
 // create a regex that does globbing of names

--- a/hack/generator/pkg/config/type_transformer.go
+++ b/hack/generator/pkg/config/type_transformer.go
@@ -58,7 +58,7 @@ func produceTargetType(target TransformTarget, descriptor string) (astmodel.Type
 	if target.Name != "" {
 		if target.LibraryPath != "" {
 			return astmodel.MakeTypeName(
-				astmodel.MakeLibraryPackageReference(target.LibraryPath),
+				astmodel.MakeExternalPackageReference(target.LibraryPath),
 				target.Name), nil
 		}
 

--- a/hack/generator/pkg/config/type_transformer.go
+++ b/hack/generator/pkg/config/type_transformer.go
@@ -16,11 +16,10 @@ import (
 
 // A transformation target
 type TransformTarget struct {
-	LibraryPath string `yaml:",omitempty"`
-	Group       string `yaml:",omitempty"`
-	PackageName string `yaml:"package,omitempty"`
-	Name        string `yaml:",omitempty"`
-	Map         *MapType
+	Group   string `yaml:",omitempty"`
+	Version string `yaml:"package,omitempty"`
+	Name    string `yaml:",omitempty"`
+	Map     *MapType
 }
 
 type MapType struct {
@@ -56,15 +55,9 @@ func produceTargetType(target TransformTarget, descriptor string) (astmodel.Type
 	}
 
 	if target.Name != "" {
-		if target.LibraryPath != "" {
+		if target.Group != "" && target.Version != "" {
 			return astmodel.MakeTypeName(
-				astmodel.MakeExternalPackageReference(target.LibraryPath),
-				target.Name), nil
-		}
-
-		if target.Group != "" && target.PackageName != "" {
-			return astmodel.MakeTypeName(
-				astmodel.MakeLocalPackageReference(target.Group, target.PackageName),
+				astmodel.MakeLocalPackageReference(target.Group, target.Version),
 				target.Name), nil
 		}
 
@@ -161,23 +154,14 @@ func (transformer *TypeTransformer) propertyNameMatches(propName astmodel.Proper
 // TransformTypeName transforms the type with the specified name into the TypeTransformer target type if
 // the provided type name matches the pattern(s) specified in the TypeTransformer
 func (transformer *TypeTransformer) TransformTypeName(typeName astmodel.TypeName) astmodel.Type {
-	name := typeName.Name()
+	if localRef, ok := typeName.PackageReference.AsLocalPackage(); ok {
+		group := localRef.Group()
+		version := localRef.Version()
+		name := typeName.Name()
 
-	if typeName.PackageReference.IsLocalPackage() {
-		group, err := typeName.PackageReference.Group()
-		if err != nil {
-			// This shouldn't ever happen because IsLocalPackage is true -- checking just to be safe
-			panic(fmt.Sprintf("%s was flagged as a local package but has no group and package", typeName.PackageReference))
-		}
-
-		version := typeName.PackageReference.Package()
-
-		if transformer.groupMatches(group) && transformer.versionMatches(version) && transformer.nameMatches(name) {
-			return transformer.targetType
-		}
-	} else {
-		// TODO: Support external types better rather than doing everything in terms of GVK?
-		if transformer.nameMatches(name) {
+		if transformer.groupMatches(group) &&
+			transformer.versionMatches(version) &&
+			transformer.nameMatches(name) {
 			return transformer.targetType
 		}
 	}

--- a/hack/generator/pkg/config/type_transformer_test.go
+++ b/hack/generator/pkg/config/type_transformer_test.go
@@ -83,9 +83,9 @@ func Test_TransformCanTransform_ToComplexType(t *testing.T) {
 	transformer := config.TypeTransformer{
 		TypeMatcher: config.TypeMatcher{Name: "tutor"},
 		Target: &config.TransformTarget{
-			Group:       "role",
-			PackageName: "2019-01-01",
-			Name:        "student",
+			Group:   "role",
+			Version: "2019-01-01",
+			Name:    "student",
 		},
 	}
 	err := transformer.Initialize()


### PR DESCRIPTION
Based on feedback provided on PR #260 that arrived after I merged the branch.

* Renamed `LibraryPackageReference` to `ExternalPackageReference`
* Rename properties of `LocalPackageReference` to Group and Version
* Rewrite method `IsLocalReference()` of `PackageReference` to `AsLocalReference()`
* Remove `LibraryPath` from `TransformTarget` as only local types are transformable