### PR TITLE
Functions have names

### DIFF
--- a/hack/generator/pkg/astmodel/arm_spec_interface.go
+++ b/hack/generator/pkg/astmodel/arm_spec_interface.go
@@ -50,27 +50,32 @@ func NewArmSpecInterfaceImpl(
 		return nil, err
 	}
 
-	funcs := map[string]Function{
-		"GetName": &objectFunction{
-			o:         spec,
-			idFactory: idFactory,
-			asFunc:    getNameFunction,
-		},
-		"GetType": &objectFunction{
-			o:         spec,
-			idFactory: idFactory,
-			asFunc:    getTypeFunction,
-		},
-		"GetApiVersion": &objectFunction{
-			o:         spec,
-			idFactory: idFactory,
-			asFunc:    getApiVersionFunction,
-		},
+	getNameFunc := &objectFunction{
+		name:      "GetName",
+		o:         spec,
+		idFactory: idFactory,
+		asFunc:    getNameFunction,
+	}
+
+	getTypeFunc := &objectFunction{
+		name:      "GetType",
+		o:         spec,
+		idFactory: idFactory,
+		asFunc:    getTypeFunction,
+	}
+
+	getApiVersionFunc := &objectFunction{
+		name:      "GetApiVersion",
+		o:         spec,
+		idFactory: idFactory,
+		asFunc:    getApiVersionFunction,
 	}
 
 	result := NewInterfaceImplementation(
 		MakeTypeName(MakeGenRuntimePackageReference(), "ArmResourceSpec"),
-		funcs)
+		getNameFunc,
+		getTypeFunc,
+		getApiVersionFunc)
 
 	return result, nil
 }

--- a/hack/generator/pkg/astmodel/armconversion/arm_conversion_function.go
+++ b/hack/generator/pkg/astmodel/armconversion/arm_conversion_function.go
@@ -21,6 +21,7 @@ const (
 // ArmConversionFunction represents an ARM conversion function for converting between a Kubernetes resource
 // and an ARM resource.
 type ArmConversionFunction struct {
+	name        string
 	armTypeName astmodel.TypeName
 	armType     *astmodel.ObjectType
 	idFactory   astmodel.IdentifierFactory
@@ -29,6 +30,10 @@ type ArmConversionFunction struct {
 }
 
 var _ astmodel.Function = &ArmConversionFunction{}
+
+func (c *ArmConversionFunction) Name() string {
+	return c.name
+}
 
 // RequiredImports returns the imports required for this conversion function
 func (c *ArmConversionFunction) RequiredImports() []astmodel.PackageReference {
@@ -53,12 +58,12 @@ func (c *ArmConversionFunction) References() astmodel.TypeNameSet {
 }
 
 // AsFunc returns the function as a Go AST
-func (c *ArmConversionFunction) AsFunc(codeGenerationContext *astmodel.CodeGenerationContext, receiver astmodel.TypeName, methodName string) *ast.FuncDecl {
+func (c *ArmConversionFunction) AsFunc(codeGenerationContext *astmodel.CodeGenerationContext, receiver astmodel.TypeName) *ast.FuncDecl {
 	switch c.direction {
 	case ConversionDirectionToArm:
-		return c.asConvertToArmFunc(codeGenerationContext, receiver, methodName)
+		return c.asConvertToArmFunc(codeGenerationContext, receiver, c.Name())
 	case ConversionDirectionFromArm:
-		return c.asConvertFromArmFunc(codeGenerationContext, receiver, methodName)
+		return c.asConvertFromArmFunc(codeGenerationContext, receiver, c.Name())
 	default:
 		panic(fmt.Sprintf("Unknown conversion direction %s", c.direction))
 	}

--- a/hack/generator/pkg/astmodel/armconversion/shared.go
+++ b/hack/generator/pkg/astmodel/armconversion/shared.go
@@ -97,26 +97,28 @@ func NewArmTransformerImpl(
 	idFactory astmodel.IdentifierFactory,
 	isResource bool) *astmodel.InterfaceImplementation {
 
-	funcs := map[string]astmodel.Function{
-		"ConvertToArm": &ArmConversionFunction{
-			armTypeName: armTypeName,
-			armType:     armType,
-			idFactory:   idFactory,
-			direction:   ConversionDirectionToArm,
-			isResource:  isResource,
-		},
-		"PopulateFromArm": &ArmConversionFunction{
-			armTypeName: armTypeName,
-			armType:     armType,
-			idFactory:   idFactory,
-			direction:   ConversionDirectionFromArm,
-			isResource:  isResource,
-		},
+	convertToArmFunc := &ArmConversionFunction{
+		name:        "ConvertToArm",
+		armTypeName: armTypeName,
+		armType:     armType,
+		idFactory:   idFactory,
+		direction:   ConversionDirectionToArm,
+		isResource:  isResource,
+	}
+
+	populateFromArmFunc := &ArmConversionFunction{
+		name:        "PopulateFromArm",
+		armTypeName: armTypeName,
+		armType:     armType,
+		idFactory:   idFactory,
+		direction:   ConversionDirectionFromArm,
+		isResource:  isResource,
 	}
 
 	result := astmodel.NewInterfaceImplementation(
 		astmodel.MakeTypeName(astmodel.MakeGenRuntimePackageReference(), "ArmTransformer"),
-		funcs)
+		convertToArmFunc,
+		populateFromArmFunc)
 
 	return result
 }

--- a/hack/generator/pkg/astmodel/function.go
+++ b/hack/generator/pkg/astmodel/function.go
@@ -11,6 +11,9 @@ import (
 
 // Function represents something that is an (unnamed) Go function
 type Function interface {
+	// The unique name of this interface
+	Name() string
+
 	RequiredImports() []PackageReference
 
 	// References returns the set of types to which this function refers.
@@ -18,7 +21,7 @@ type Function interface {
 	References() TypeNameSet
 
 	// AsFunc renders the current instance as a Go abstract syntax tree
-	AsFunc(codeGenerationContext *CodeGenerationContext, receiver TypeName, methodName string) *ast.FuncDecl
+	AsFunc(codeGenerationContext *CodeGenerationContext, receiver TypeName) *ast.FuncDecl
 
 	// Equals determines if this Function is equal to another one
 	Equals(f Function) bool

--- a/hack/generator/pkg/astmodel/function.go
+++ b/hack/generator/pkg/astmodel/function.go
@@ -11,7 +11,8 @@ import (
 
 // Function represents something that is an (unnamed) Go function
 type Function interface {
-	// The unique name of this interface
+	// The unique name of this function
+	// (You can't have two functions with the same name on the same object or resource)
 	Name() string
 
 	RequiredImports() []PackageReference

--- a/hack/generator/pkg/astmodel/function_test.go
+++ b/hack/generator/pkg/astmodel/function_test.go
@@ -8,8 +8,13 @@ package astmodel
 import "go/ast"
 
 type FakeFunction struct {
+	name       string
 	Imported   map[PackageReference]struct{}
 	Referenced TypeNameSet
+}
+
+func (fake *FakeFunction) Name() string {
+	return fake.name
 }
 
 func (fake *FakeFunction) RequiredImports() []PackageReference {
@@ -25,7 +30,7 @@ func (fake *FakeFunction) References() TypeNameSet {
 	return fake.Referenced
 }
 
-func (fake *FakeFunction) AsFunc(codeGenerationContext *CodeGenerationContext, receiver TypeName, methodName string) *ast.FuncDecl {
+func (fake *FakeFunction) AsFunc(codeGenerationContext *CodeGenerationContext, receiver TypeName) *ast.FuncDecl {
 	panic("implement me")
 }
 

--- a/hack/generator/pkg/astmodel/interface_implementation.go
+++ b/hack/generator/pkg/astmodel/interface_implementation.go
@@ -12,8 +12,13 @@ type InterfaceImplementation struct {
 }
 
 // NewInterfaceImplementation creates a new interface implementation with the given name and set of functions
-func NewInterfaceImplementation(name TypeName, functions map[string]Function) *InterfaceImplementation {
-	return &InterfaceImplementation{name: name, functions: functions}
+func NewInterfaceImplementation(name TypeName, functions ...Function) *InterfaceImplementation {
+	result := &InterfaceImplementation{name: name, functions: make(map[string]Function)}
+	for _, f := range functions {
+		result.functions[f.Name()] = f
+	}
+
+	return result
 }
 
 // Name returns the name of the interface

--- a/hack/generator/pkg/astmodel/interface_implementer.go
+++ b/hack/generator/pkg/astmodel/interface_implementer.go
@@ -49,19 +49,19 @@ func (i InterfaceImplementer) AsDeclarations(
 	// interfaces must be ordered by name for deterministic output
 	// (We sort them directly to skip future lookups)
 	var interfaces []*InterfaceImplementation
-	for _, intf := range i.interfaces {
-		interfaces = append(interfaces, intf)
+	for _, iface := range i.interfaces {
+		interfaces = append(interfaces, iface)
 	}
 
 	sort.Slice(interfaces, func(i int, j int) bool {
-		return interfaces[i].Name().name < interfaces[j].Name().Name()
+		return interfaces[i].Name().name < interfaces[j].Name().name
 	})
 
-	for _, intf := range interfaces {
-		result = append(result, i.generateInterfaceImplAssertion(codeGenerationContext, intf, typeName))
+	for _, iface := range interfaces {
+		result = append(result, i.generateInterfaceImplAssertion(codeGenerationContext, iface, typeName))
 
 		var functions []Function
-		for _, f := range intf.functions {
+		for _, f := range iface.functions {
 			functions = append(functions, f)
 		}
 

--- a/hack/generator/pkg/astmodel/interface_implementer.go
+++ b/hack/generator/pkg/astmodel/interface_implementer.go
@@ -46,31 +46,31 @@ func (i InterfaceImplementer) AsDeclarations(
 
 	var result []ast.Decl
 
-	// First interfaces must be ordered by name for deterministic output
-	var ifaceNames []TypeName
-	for ifaceName := range i.interfaces {
-		ifaceNames = append(ifaceNames, ifaceName)
+	// interfaces must be ordered by name for deterministic output
+	// (We sort them directly to skip future lookups)
+	var interfaces []*InterfaceImplementation
+	for _, intf := range i.interfaces {
+		interfaces = append(interfaces, intf)
 	}
 
-	sort.Slice(ifaceNames, func(i int, j int) bool {
-		return ifaceNames[i].name < ifaceNames[j].name
+	sort.Slice(interfaces, func(i int, j int) bool {
+		return interfaces[i].Name().name < interfaces[j].Name().Name()
 	})
 
-	for _, ifaceName := range ifaceNames {
-		iface := i.interfaces[ifaceName]
+	for _, intf := range interfaces {
+		result = append(result, i.generateInterfaceImplAssertion(codeGenerationContext, intf, typeName))
 
-		result = append(result, i.generateInterfaceImplAssertion(codeGenerationContext, iface, typeName))
-
-		var funcNames []string
-		for funcName := range iface.functions {
-			funcNames = append(funcNames, funcName)
+		var functions []Function
+		for _, f := range intf.functions {
+			functions = append(functions, f)
 		}
 
-		sort.Strings(funcNames)
+		sort.Slice(functions, func(i int, j int) bool {
+			return functions[i].Name() < functions[j].Name()
+		})
 
-		for _, methodName := range funcNames {
-			function := iface.functions[methodName]
-			result = append(result, function.AsFunc(codeGenerationContext, typeName, methodName))
+		for _, f := range functions {
+			result = append(result, f.AsFunc(codeGenerationContext, typeName))
 		}
 	}
 

--- a/hack/generator/pkg/astmodel/interface_implementer_test.go
+++ b/hack/generator/pkg/astmodel/interface_implementer_test.go
@@ -14,7 +14,7 @@ import (
 func makeInterfaceImplForTest() *InterfaceImplementation {
 	pr := MakeLocalPackageReference("group", "package")
 
-	return NewInterfaceImplementation(MakeTypeName(pr, "foo"), nil)
+	return NewInterfaceImplementation(MakeTypeName(pr, "foo"))
 }
 
 func Test_InterfaceImplementerWithInterface_ReturnsNewInstance(t *testing.T) {

--- a/hack/generator/pkg/astmodel/kubernetes_resource_interface.go
+++ b/hack/generator/pkg/astmodel/kubernetes_resource_interface.go
@@ -71,6 +71,7 @@ type objectFunction struct {
 var _ Function = &objectFunction{}
 
 // Name returns the unique name of this function
+// (You can't have two functions with the same name on the same object or resource)
 func (k *objectFunction) Name() string {
 	return k.name
 }

--- a/hack/generator/pkg/astmodel/kubernetes_resource_interface.go
+++ b/hack/generator/pkg/astmodel/kubernetes_resource_interface.go
@@ -36,22 +36,25 @@ func NewKubernetesResourceInterfaceImpl(
 		return nil, errors.Errorf("Resource spec doesn't have %q property", azureNameProperty)
 	}
 
-	funcs := map[string]Function{
-		OwnerProperty: &objectFunction{
-			o:         spec,
-			idFactory: idFactory,
-			asFunc:    ownerFunction,
-		},
-		AzureNameProperty: &objectFunction{
-			o:         spec,
-			idFactory: idFactory,
-			asFunc:    azureNameFunction,
-		},
+	ownerFunc := &objectFunction{
+		name:      OwnerProperty,
+		o:         spec,
+		idFactory: idFactory,
+		asFunc:    ownerFunction,
+	}
+
+	azureNameFunc := &objectFunction{
+		name:      AzureNameProperty,
+		o:         spec,
+		idFactory: idFactory,
+		asFunc:    azureNameFunction,
 	}
 
 	result := NewInterfaceImplementation(
 		MakeTypeName(MakeGenRuntimePackageReference(), "KubernetesResource"),
-		funcs)
+		ownerFunc,
+		azureNameFunc)
+
 	return result, nil
 }
 

--- a/hack/generator/pkg/astmodel/kubernetes_resource_interface.go
+++ b/hack/generator/pkg/astmodel/kubernetes_resource_interface.go
@@ -58,6 +58,7 @@ func NewKubernetesResourceInterfaceImpl(
 // objectFunction is a simple helper that implements the Function interface. It is intended for use for functions
 // that only need information about the object they are operating on
 type objectFunction struct {
+	name      string
 	o         *ObjectType
 	idFactory IdentifierFactory
 
@@ -65,6 +66,11 @@ type objectFunction struct {
 }
 
 var _ Function = &objectFunction{}
+
+// Name returns the unique name of this function
+func (k *objectFunction) Name() string {
+	return k.name
+}
 
 func (k *objectFunction) RequiredImports() []PackageReference {
 	// We only require GenRuntime
@@ -77,8 +83,8 @@ func (k *objectFunction) References() TypeNameSet {
 	return k.o.References()
 }
 
-func (k *objectFunction) AsFunc(codeGenerationContext *CodeGenerationContext, receiver TypeName, methodName string) *ast.FuncDecl {
-	return k.asFunc(k, codeGenerationContext, receiver, methodName)
+func (k *objectFunction) AsFunc(codeGenerationContext *CodeGenerationContext, receiver TypeName) *ast.FuncDecl {
+	return k.asFunc(k, codeGenerationContext, receiver, k.name)
 }
 
 func (k *objectFunction) Equals(f Function) bool {

--- a/hack/generator/pkg/astmodel/object_type.go
+++ b/hack/generator/pkg/astmodel/object_type.go
@@ -67,7 +67,7 @@ func (objectType *ObjectType) generateMethodDecls(codeGenerationContext *CodeGen
 		return functions[i].Name() < functions[j].Name()
 	})
 
-	for _, f := range objectType.functions {
+	for _, f := range functions {
 		funcDef := f.AsFunc(codeGenerationContext, typeName)
 		result = append(result, funcDef)
 	}

--- a/hack/generator/pkg/astmodel/object_type.go
+++ b/hack/generator/pkg/astmodel/object_type.go
@@ -56,8 +56,19 @@ func (objectType *ObjectType) AsDeclarations(codeGenerationContext *CodeGenerati
 
 func (objectType *ObjectType) generateMethodDecls(codeGenerationContext *CodeGenerationContext, typeName TypeName) []ast.Decl {
 	var result []ast.Decl
-	for methodName, function := range objectType.functions {
-		funcDef := function.AsFunc(codeGenerationContext, typeName, methodName)
+
+	// Functions must be ordered by name for deterministic output
+	var functions []Function
+	for _, f := range objectType.functions {
+		functions = append(functions, f)
+	}
+
+	sort.Slice(functions, func(i int, j int) bool {
+		return functions[i].Name() < functions[j].Name()
+	})
+
+	for _, f := range objectType.functions {
+		funcDef := f.AsFunc(codeGenerationContext, typeName)
 		result = append(result, funcDef)
 	}
 

--- a/hack/generator/pkg/astmodel/object_type.go
+++ b/hack/generator/pkg/astmodel/object_type.go
@@ -240,10 +240,10 @@ func (objectType *ObjectType) WithoutProperty(name PropertyName) *ObjectType {
 }
 
 // WithFunction creates a new ObjectType with a function (method) attached to it
-func (objectType *ObjectType) WithFunction(name string, function Function) *ObjectType {
+func (objectType *ObjectType) WithFunction(function Function) *ObjectType {
 	// Create a copy of objectType to preserve immutability
 	result := objectType.copy()
-	result.functions[name] = function
+	result.functions[function.Name()] = function
 
 	return result
 }

--- a/hack/generator/pkg/astmodel/object_type_test.go
+++ b/hack/generator/pkg/astmodel/object_type_test.go
@@ -215,8 +215,8 @@ func Test_ObjectWithoutProperties_ReturnsExpectedObject(t *testing.T) {
 func Test_WithFunction_GivenEmptyObject_ReturnsPopulatedObject(t *testing.T) {
 	g := NewGomegaWithT(t)
 	empty := EmptyObjectType
-	fn := &FakeFunction{}
-	object := empty.WithFunction("Activate", fn)
+	fn := &FakeFunction{name: "Activate"}
+	object := empty.WithFunction(fn)
 	g.Expect(empty).NotTo(Equal(object)) // Ensure the original wasn't modified
 	g.Expect(object.functions).To(HaveLen(1))
 	g.Expect(object.functions["Activate"].Equals(fn)).To(BeTrue())
@@ -231,9 +231,7 @@ func Test_WithInterface_ReturnsExpectedObject(t *testing.T) {
 
 	// This is just a simple interface which actually has no functions
 	ifaceName := MakeTypeName(MakeLocalPackageReference("group", "2020-01-01"), "SampleInterface")
-	iface := NewInterfaceImplementation(
-		ifaceName,
-		make(map[string]Function))
+	iface := NewInterfaceImplementation(ifaceName)
 
 	object := empty.WithInterface(iface)
 

--- a/hack/generator/pkg/astmodel/one_of_json_marshal_function.go
+++ b/hack/generator/pkg/astmodel/one_of_json_marshal_function.go
@@ -29,6 +29,10 @@ func NewOneOfJSONMarshalFunction(oneOfObject *ObjectType, idFactory IdentifierFa
 // Ensure OneOfJSONMarshalFunction implements Function interface correctly
 var _ Function = (*OneOfJSONMarshalFunction)(nil)
 
+func (f *OneOfJSONMarshalFunction) Name() string {
+	return JSONMarshalFunctionName
+}
+
 // Equals determines if this function is equal to the passed in function
 func (f *OneOfJSONMarshalFunction) Equals(other Function) bool {
 	if o, ok := other.(*OneOfJSONMarshalFunction); ok {
@@ -47,8 +51,7 @@ func (f *OneOfJSONMarshalFunction) References() TypeNameSet {
 // AsFunc returns the function as a go ast
 func (f *OneOfJSONMarshalFunction) AsFunc(
 	codeGenerationContext *CodeGenerationContext,
-	receiver TypeName,
-	methodName string) *ast.FuncDecl {
+	receiver TypeName) *ast.FuncDecl {
 
 	receiverName := f.idFactory.CreateIdentifier(receiver.name, NotExported)
 
@@ -98,7 +101,7 @@ func (f *OneOfJSONMarshalFunction) AsFunc(
 
 	result := astbuilder.DefineFunc(
 		astbuilder.FuncDetails{
-			Name: ast.NewIdent(methodName),
+			Name: ast.NewIdent(f.Name()),
 			Comment: fmt.Sprintf(
 				"defers JSON marshaling to the first non-nil property, because %s represents a discriminated union (JSON OneOf)",
 				receiver.name),

--- a/hack/generator/pkg/astmodel/type_visitor_test.go
+++ b/hack/generator/pkg/astmodel/type_visitor_test.go
@@ -121,15 +121,15 @@ func TestIdentityVisitorReturnsEqualResult(t *testing.T) {
 	familyName := NewPropertyDefinition("FamilyName", "family-name", StringType)
 	knownAs := NewPropertyDefinition("KnownAs", "known-as", StringType)
 
-	transform := &FakeFunction{}
-	transmogrify := &FakeFunction{}
-	skew := &FakeFunction{}
+	transform := &FakeFunction{name: "Transform"}
+	transmogrify := &FakeFunction{name: "Transmogrify"}
+	skew := &FakeFunction{name: "Skew"}
 
 	person := NewObjectType().WithProperties(fullName, familyName, knownAs)
 	individual := NewObjectType().WithProperties(fullName).
-		WithFunction("Transform", transform).
-		WithFunction("Transmogrify", transmogrify).
-		WithFunction("Skew", skew)
+		WithFunction(transform).
+		WithFunction(transmogrify).
+		WithFunction(skew)
 
 	resource := NewResourceType(person, individual)
 

--- a/hack/generator/pkg/codegen/pipeline_convert_allof_and_oneof_to_objects.go
+++ b/hack/generator/pkg/codegen/pipeline_convert_allof_and_oneof_to_objects.go
@@ -143,7 +143,7 @@ func (s synthesizer) oneOfObject(oneOf astmodel.OneOfType) (astmodel.Type, error
 	}
 
 	objectType := astmodel.NewObjectType().WithProperties(properties...)
-	objectType = objectType.WithFunction(astmodel.JSONMarshalFunctionName, astmodel.NewOneOfJSONMarshalFunction(objectType, s.idFactory))
+	objectType = objectType.WithFunction(astmodel.NewOneOfJSONMarshalFunction(objectType, s.idFactory))
 
 	return objectType, nil
 }


### PR DESCRIPTION
Tidy up our object model by ensuring that Functions know their own names, consistent with the way properties and interface implementations also know their own names.

Interface `Function` now includes `Name()`, allowing simplification of calls to `ObjectType.WithFunction()`.

Also simplified `NewInterfaceImplementation()` to accept a variadic slice of functions instead of a map.

We now directly sort functions where needed, instead of sorting their names and then looking them up from a map later on.

Added sorting to `ObjectType.generateMethodDecls()` to ensure output order is consistent; I suspect we were only getting away with this because most methods were added via interface implementations.