### PR TITLE
Introduce PackageImportSet type 

### DIFF
--- a/hack/generator/pkg/astmodel/allof_type.go
+++ b/hack/generator/pkg/astmodel/allof_type.go
@@ -116,8 +116,9 @@ func (allOf AllOfType) AsDeclarations(codeGenerationContext *CodeGenerationConte
 	panic("should have been replaced by generation time by 'convertAllOfAndOneOf' phase")
 }
 
-// RequiredImports returns the union of the required imports of all the AllOf types
-func (allOf AllOfType) RequiredImports() *PackageImportSet {
+// RequiredPackageReferences always panics; AllOf cannot be represented by the Go AST and must be
+// lowered to an object type
+func (allOf AllOfType) RequiredPackageReferences() []PackageReference {
 	panic("should have been replaced by generation time by 'convertAllOfAndOneOf' phase")
 }
 

--- a/hack/generator/pkg/astmodel/allof_type.go
+++ b/hack/generator/pkg/astmodel/allof_type.go
@@ -106,13 +106,13 @@ func (allOf AllOfType) References() TypeNameSet {
 
 // AsType always panics; AllOf cannot be represented by the Go AST and must be
 // lowered to an object type
-func (allOf AllOfType) AsType(codeGenerationContext *CodeGenerationContext) ast.Expr {
+func (allOf AllOfType) AsType(_ *CodeGenerationContext) ast.Expr {
 	panic("should have been replaced by generation time by 'convertAllOfAndOneOf' phase")
 }
 
 // AsDeclarations always panics; AllOf cannot be represented by the Go AST and must be
 // lowered to an object type
-func (allOf AllOfType) AsDeclarations(codeGenerationContext *CodeGenerationContext, name TypeName, description []string) []ast.Decl {
+func (allOf AllOfType) AsDeclarations(_ *CodeGenerationContext, _ TypeName, _ []string) []ast.Decl {
 	panic("should have been replaced by generation time by 'convertAllOfAndOneOf' phase")
 }
 

--- a/hack/generator/pkg/astmodel/allof_type.go
+++ b/hack/generator/pkg/astmodel/allof_type.go
@@ -117,7 +117,7 @@ func (allOf AllOfType) AsDeclarations(codeGenerationContext *CodeGenerationConte
 }
 
 // RequiredImports returns the union of the required imports of all the AllOf types
-func (allOf AllOfType) RequiredImports() []PackageReference {
+func (allOf AllOfType) RequiredImports() *PackageImportSet {
 	panic("should have been replaced by generation time by 'convertAllOfAndOneOf' phase")
 }
 

--- a/hack/generator/pkg/astmodel/allof_type_test.go
+++ b/hack/generator/pkg/astmodel/allof_type_test.go
@@ -106,6 +106,6 @@ func TestAllOfRequiredImportsPanics(t *testing.T) {
 
 	x := AllOfType{}
 	g.Expect(func() {
-		x.RequiredImports()
+		x.RequiredPackageReferences()
 	}).To(PanicWith("should have been replaced by generation time by 'convertAllOfAndOneOf' phase"))
 }

--- a/hack/generator/pkg/astmodel/arm_type.go
+++ b/hack/generator/pkg/astmodel/arm_type.go
@@ -25,9 +25,9 @@ func MakeArmType(object ObjectType) ArmType {
 	}
 }
 
-// RequiredImports returns a list of packages required by this type
-func (at ArmType) RequiredImports() *PackageImportSet {
-	return at.objectType.RequiredImports()
+// RequiredPackageReferences returns a list of packages required by this type
+func (at ArmType) RequiredPackageReferences() []PackageReference {
+	return at.objectType.RequiredPackageReferences()
 }
 
 // References returns the names of all types that this type references

--- a/hack/generator/pkg/astmodel/arm_type.go
+++ b/hack/generator/pkg/astmodel/arm_type.go
@@ -26,7 +26,7 @@ func MakeArmType(object ObjectType) ArmType {
 }
 
 // RequiredImports returns a list of packages required by this type
-func (at ArmType) RequiredImports() []PackageReference {
+func (at ArmType) RequiredImports() *PackageImportSet {
 	return at.objectType.RequiredImports()
 }
 

--- a/hack/generator/pkg/astmodel/armconversion/arm_conversion_function.go
+++ b/hack/generator/pkg/astmodel/armconversion/arm_conversion_function.go
@@ -36,8 +36,8 @@ func (c *ArmConversionFunction) Name() string {
 }
 
 // RequiredImports returns the imports required for this conversion function
-func (c *ArmConversionFunction) RequiredImports() []astmodel.PackageReference {
-	var result []astmodel.PackageReference
+func (c *ArmConversionFunction) RequiredImports() *astmodel.PackageImportSet {
+	result := astmodel.EmptyPackageImportSet()
 
 	// Because this interface is attached to an object, by definition that object will specify
 	// its own required imports. We don't want to call the objects required imports here
@@ -45,9 +45,9 @@ func (c *ArmConversionFunction) RequiredImports() []astmodel.PackageReference {
 
 	// We need these because we're going to be constructing/casting to the types
 	// of the properties in the ARM object, so we need to import those.
-	result = append(result, c.armType.RequiredImports()...)
-	result = append(result, astmodel.MakeGenRuntimePackageReference())
-	result = append(result, astmodel.MakeExternalPackageReference("fmt"))
+	result.Merge(c.armType.RequiredImports())
+	result.AddReference(astmodel.MakeGenRuntimePackageReference())
+	result.AddReference(astmodel.MakeExternalPackageReference("fmt"))
 
 	return result
 }

--- a/hack/generator/pkg/astmodel/armconversion/arm_conversion_function.go
+++ b/hack/generator/pkg/astmodel/armconversion/arm_conversion_function.go
@@ -36,8 +36,8 @@ func (c *ArmConversionFunction) Name() string {
 }
 
 // RequiredImports returns the imports required for this conversion function
-func (c *ArmConversionFunction) RequiredImports() *astmodel.PackageImportSet {
-	result := astmodel.EmptyPackageImportSet()
+func (c *ArmConversionFunction) RequiredPackageReferences() []astmodel.PackageReference {
+	var result []astmodel.PackageReference
 
 	// Because this interface is attached to an object, by definition that object will specify
 	// its own required imports. We don't want to call the objects required imports here
@@ -45,10 +45,9 @@ func (c *ArmConversionFunction) RequiredImports() *astmodel.PackageImportSet {
 
 	// We need these because we're going to be constructing/casting to the types
 	// of the properties in the ARM object, so we need to import those.
-	result.Merge(c.armType.RequiredImports())
-	result.AddReference(astmodel.MakeGenRuntimePackageReference())
-	result.AddReference(astmodel.MakeExternalPackageReference("fmt"))
-
+	result = append(result, c.armType.RequiredPackageReferences()...)
+	result = append(result, astmodel.MakeGenRuntimePackageReference())
+	result = append(result, astmodel.MakeExternalPackageReference("fmt"))
 	return result
 }
 

--- a/hack/generator/pkg/astmodel/array_type.go
+++ b/hack/generator/pkg/astmodel/array_type.go
@@ -39,9 +39,9 @@ func (array *ArrayType) AsType(codeGenerationContext *CodeGenerationContext) ast
 	}
 }
 
-// RequiredImports returns a list of packages required by this
-func (array *ArrayType) RequiredImports() *PackageImportSet {
-	return array.element.RequiredImports()
+// RequiredPackageReferences returns a list of packages required by this
+func (array *ArrayType) RequiredPackageReferences() []PackageReference {
+	return array.element.RequiredPackageReferences()
 }
 
 // References returns the references of the type this array contains.

--- a/hack/generator/pkg/astmodel/array_type.go
+++ b/hack/generator/pkg/astmodel/array_type.go
@@ -40,7 +40,7 @@ func (array *ArrayType) AsType(codeGenerationContext *CodeGenerationContext) ast
 }
 
 // RequiredImports returns a list of packages required by this
-func (array *ArrayType) RequiredImports() []PackageReference {
+func (array *ArrayType) RequiredImports() *PackageImportSet {
 	return array.element.RequiredImports()
 }
 

--- a/hack/generator/pkg/astmodel/code_generation_context.go
+++ b/hack/generator/pkg/astmodel/code_generation_context.go
@@ -14,7 +14,7 @@ import (
 // in which the field declaration occurs - for example in a file with two conflicting package references
 // a disambiguation must occur and field types must ensure they correctly refer to the disambiguated types
 type CodeGenerationContext struct {
-	packageImports map[PackageReference]PackageImport
+	packageImports *PackageImportSet
 	currentPackage PackageReference
 
 	generatedPackages map[PackageReference]*PackageDefinition
@@ -23,17 +23,15 @@ type CodeGenerationContext struct {
 // New CodeGenerationContext creates a new immutable code generation context
 func NewCodeGenerationContext(
 	currentPackage PackageReference,
-	packageImports map[PackageImport]struct{},
+	packageImports *PackageImportSet,
 	generatedPackages map[PackageReference]*PackageDefinition) *CodeGenerationContext {
 
-	packageImportsMap := make(map[PackageReference]PackageImport)
-	for imp := range packageImports {
-		packageImportsMap[imp.PackageReference] = imp
-	}
+	imports := EmptyPackageImportSet()
+	imports.Merge(packageImports)
 
 	return &CodeGenerationContext{
 		currentPackage:    currentPackage,
-		packageImports:    packageImportsMap,
+		packageImports:    imports,
 		generatedPackages: generatedPackages}
 }
 
@@ -43,23 +41,19 @@ func (codeGenContext *CodeGenerationContext) CurrentPackage() PackageReference {
 }
 
 // PackageImports returns the set of package references in the current context
-func (codeGenContext *CodeGenerationContext) PackageImports() map[PackageReference]PackageImport {
+func (codeGenContext *CodeGenerationContext) PackageImports() *PackageImportSet {
 	// return a copy of the map to ensure immutability
-	result := make(map[PackageReference]PackageImport)
-
-	for key, value := range codeGenContext.packageImports {
-		result[key] = value
-	}
+	result := EmptyPackageImportSet()
+	result.Merge(codeGenContext.packageImports)
 	return result
 }
 
 // GetImportedPackageName gets the imported packages name or an error if the package was not imported
 func (codeGenContext *CodeGenerationContext) GetImportedPackageName(reference PackageReference) (string, error) {
-	packageImport, ok := codeGenContext.packageImports[reference]
+	packageImport, ok := codeGenContext.packageImports.ImportFor(reference)
 	if !ok {
 		return "", errors.Errorf("package %s not imported", reference)
 	}
-
 	return packageImport.PackageName(), nil
 }
 

--- a/hack/generator/pkg/astmodel/code_generation_context.go
+++ b/hack/generator/pkg/astmodel/code_generation_context.go
@@ -26,7 +26,7 @@ func NewCodeGenerationContext(
 	packageImports *PackageImportSet,
 	generatedPackages map[PackageReference]*PackageDefinition) *CodeGenerationContext {
 
-	imports := EmptyPackageImportSet()
+	imports := NewPackageImportSet()
 	imports.Merge(packageImports)
 
 	return &CodeGenerationContext{
@@ -43,7 +43,7 @@ func (codeGenContext *CodeGenerationContext) CurrentPackage() PackageReference {
 // PackageImports returns the set of package references in the current context
 func (codeGenContext *CodeGenerationContext) PackageImports() *PackageImportSet {
 	// return a copy of the map to ensure immutability
-	result := EmptyPackageImportSet()
+	result := NewPackageImportSet()
 	result.Merge(codeGenContext.packageImports)
 	return result
 }

--- a/hack/generator/pkg/astmodel/enum_type.go
+++ b/hack/generator/pkg/astmodel/enum_type.go
@@ -148,9 +148,9 @@ func (enum *EnumType) Equals(t Type) bool {
 	return false
 }
 
-// RequiredImports indicates that Enums never need additional imports
-func (enum *EnumType) RequiredImports() *PackageImportSet {
-	return EmptyPackageImportSet()
+// RequiredPackageReferences indicates that Enums never need additional imports
+func (enum *EnumType) RequiredPackageReferences() []PackageReference {
+	return nil
 }
 
 // Options returns all the enum options

--- a/hack/generator/pkg/astmodel/enum_type.go
+++ b/hack/generator/pkg/astmodel/enum_type.go
@@ -149,8 +149,8 @@ func (enum *EnumType) Equals(t Type) bool {
 }
 
 // RequiredImports indicates that Enums never need additional imports
-func (enum *EnumType) RequiredImports() []PackageReference {
-	return nil
+func (enum *EnumType) RequiredImports() *PackageImportSet {
+	return EmptyPackageImportSet()
 }
 
 // Options returns all the enum options

--- a/hack/generator/pkg/astmodel/file_definition.go
+++ b/hack/generator/pkg/astmodel/file_definition.go
@@ -135,7 +135,9 @@ func (file *FileDefinition) generateImports() *PackageImportSet {
 	var requiredImports = EmptyPackageImportSet()
 
 	for _, s := range file.definitions {
-		requiredImports.Merge(s.RequiredImports())
+		for _, r := range s.RequiredPackageReferences() {
+			requiredImports.AddReference(r)
+		}
 	}
 
 	// Don't need to import the current package

--- a/hack/generator/pkg/astmodel/file_definition.go
+++ b/hack/generator/pkg/astmodel/file_definition.go
@@ -136,7 +136,7 @@ func (file *FileDefinition) generateImports() *PackageImportSet {
 
 	for _, s := range file.definitions {
 		for _, r := range s.RequiredPackageReferences() {
-			requiredImports.AddReference(r)
+			requiredImports.AddImportOfReference(r)
 		}
 	}
 

--- a/hack/generator/pkg/astmodel/file_definition.go
+++ b/hack/generator/pkg/astmodel/file_definition.go
@@ -144,6 +144,9 @@ func (file *FileDefinition) generateImports() *PackageImportSet {
 	selfImport := NewPackageImport(file.packageReference)
 	requiredImports.Remove(selfImport)
 
+	// TODO: Make this configurable
+	requiredImports.ApplyName(MetaV1PackageReference, "metav1")
+
 	// TODO: Do something about conflicting imports
 
 	// Determine if there are any conflicting imports -- these are imports with the same "name"

--- a/hack/generator/pkg/astmodel/file_definition.go
+++ b/hack/generator/pkg/astmodel/file_definition.go
@@ -147,8 +147,6 @@ func (file *FileDefinition) generateImports() *PackageImportSet {
 	// TODO: Make this configurable
 	requiredImports.ApplyName(MetaV1PackageReference, "metav1")
 
-	// TODO: Do something about conflicting imports
-
 	// Determine if there are any conflicting imports -- these are imports with the same "name"
 	// but a different package path
 	imports := requiredImports.AsSortedSlice(ByNameInGroups)

--- a/hack/generator/pkg/astmodel/file_definition.go
+++ b/hack/generator/pkg/astmodel/file_definition.go
@@ -132,7 +132,7 @@ func assignRanks(definers []TypeDefinition, ranks map[TypeName]int) []TypeDefini
 // generateImports products the definitive set of imports for use in this file and
 // disambiguates any conflicts
 func (file *FileDefinition) generateImports() *PackageImportSet {
-	var requiredImports = EmptyPackageImportSet()
+	var requiredImports = NewPackageImportSet()
 
 	for _, s := range file.definitions {
 		for _, r := range s.RequiredPackageReferences() {

--- a/hack/generator/pkg/astmodel/file_definition.go
+++ b/hack/generator/pkg/astmodel/file_definition.go
@@ -151,7 +151,7 @@ func (file *FileDefinition) generateImports() *PackageImportSet {
 
 	// Determine if there are any conflicting imports -- these are imports with the same "name"
 	// but a different package path
-	imports := requiredImports.AsSlice()
+	imports := requiredImports.AsSortedSlice(ByNameInGroups)
 	for _, imp := range imports {
 		for _, otherImp := range imports {
 			if !imp.Equals(otherImp) && imp.PackageName() == otherImp.PackageName() {

--- a/hack/generator/pkg/astmodel/function.go
+++ b/hack/generator/pkg/astmodel/function.go
@@ -15,7 +15,7 @@ type Function interface {
 	// (You can't have two functions with the same name on the same object or resource)
 	Name() string
 
-	RequiredImports() []PackageReference
+	RequiredImports() *PackageImportSet
 
 	// References returns the set of types to which this function refers.
 	// Should *not* include the receiver of this function

--- a/hack/generator/pkg/astmodel/function.go
+++ b/hack/generator/pkg/astmodel/function.go
@@ -15,7 +15,7 @@ type Function interface {
 	// (You can't have two functions with the same name on the same object or resource)
 	Name() string
 
-	RequiredImports() *PackageImportSet
+	RequiredPackageReferences() []PackageReference
 
 	// References returns the set of types to which this function refers.
 	// Should *not* include the receiver of this function

--- a/hack/generator/pkg/astmodel/function_test.go
+++ b/hack/generator/pkg/astmodel/function_test.go
@@ -9,14 +9,14 @@ import "go/ast"
 
 type FakeFunction struct {
 	name       string
-	Imported   *PackageImportSet
+	Imported   []PackageReference
 	Referenced TypeNameSet
 }
 
 func NewFakeFunction(name string) *FakeFunction {
 	return &FakeFunction{
 		name:     name,
-		Imported: EmptyPackageImportSet(),
+		Imported: nil,
 	}
 }
 
@@ -24,7 +24,7 @@ func (fake *FakeFunction) Name() string {
 	return fake.name
 }
 
-func (fake *FakeFunction) RequiredImports() *PackageImportSet {
+func (fake *FakeFunction) RequiredPackageReferences() []PackageReference {
 	return fake.Imported
 }
 
@@ -32,7 +32,7 @@ func (fake *FakeFunction) References() TypeNameSet {
 	return fake.Referenced
 }
 
-func (fake *FakeFunction) AsFunc(codeGenerationContext *CodeGenerationContext, receiver TypeName) *ast.FuncDecl {
+func (fake *FakeFunction) AsFunc(_ *CodeGenerationContext, _ TypeName) *ast.FuncDecl {
 	panic("implement me")
 }
 
@@ -56,12 +56,20 @@ func (fake *FakeFunction) Equals(f Function) bool {
 	}
 
 	// Check to see if they have the same imports
-	if fake.Imported.Length() != fn.Imported.Length() {
+	if len(fake.Imported) != len(fn.Imported) {
 		return false
 	}
 
-	for _, imp := range fake.Imported.AsSlice() {
-		if !fn.Imported.ContainsImport(imp) {
+	for _, imp := range fake.Imported {
+		found := false
+		for _, i := range fn.Imported {
+			if i.Equals(imp) {
+				found = true
+				break
+			}
+		}
+
+		if !found {
 			return false
 		}
 	}

--- a/hack/generator/pkg/astmodel/function_test.go
+++ b/hack/generator/pkg/astmodel/function_test.go
@@ -9,7 +9,7 @@ import "go/ast"
 
 type FakeFunction struct {
 	name       string
-	Imported   []PackageReference
+	Imported   map[PackageReference]struct{}
 	Referenced TypeNameSet
 }
 
@@ -25,7 +25,12 @@ func (fake *FakeFunction) Name() string {
 }
 
 func (fake *FakeFunction) RequiredPackageReferences() []PackageReference {
-	return fake.Imported
+	var result []PackageReference
+	for k := range fake.Imported {
+		result = append(result, k)
+	}
+
+	return result
 }
 
 func (fake *FakeFunction) References() TypeNameSet {
@@ -60,16 +65,9 @@ func (fake *FakeFunction) Equals(f Function) bool {
 		return false
 	}
 
-	for _, imp := range fake.Imported {
-		found := false
-		for _, i := range fn.Imported {
-			if i.Equals(imp) {
-				found = true
-				break
-			}
-		}
-
-		if !found {
+	for imp := range fake.Imported {
+		if _, ok := fn.Imported[imp]; !ok {
+			// Missing key, not equal
 			return false
 		}
 	}

--- a/hack/generator/pkg/astmodel/function_test.go
+++ b/hack/generator/pkg/astmodel/function_test.go
@@ -9,21 +9,23 @@ import "go/ast"
 
 type FakeFunction struct {
 	name       string
-	Imported   map[PackageReference]struct{}
+	Imported   *PackageImportSet
 	Referenced TypeNameSet
+}
+
+func NewFakeFunction(name string) *FakeFunction {
+	return &FakeFunction{
+		name:     name,
+		Imported: EmptyPackageImportSet(),
+	}
 }
 
 func (fake *FakeFunction) Name() string {
 	return fake.name
 }
 
-func (fake *FakeFunction) RequiredImports() []PackageReference {
-	var result []PackageReference
-	for k := range fake.Imported {
-		result = append(result, k)
-	}
-
-	return result
+func (fake *FakeFunction) RequiredImports() *PackageImportSet {
+	return fake.Imported
 }
 
 func (fake *FakeFunction) References() TypeNameSet {
@@ -54,13 +56,12 @@ func (fake *FakeFunction) Equals(f Function) bool {
 	}
 
 	// Check to see if they have the same imports
-	if len(fake.Imported) != len(fn.Imported) {
+	if fake.Imported.Length() != fn.Imported.Length() {
 		return false
 	}
 
-	for k := range fake.Imported {
-		if _, ok := fn.Imported[k]; !ok {
-			// Missing key, not equal
+	for _, imp := range fake.Imported.AsSlice() {
+		if !fn.Imported.ContainsImport(imp) {
 			return false
 		}
 	}

--- a/hack/generator/pkg/astmodel/interface_implementation.go
+++ b/hack/generator/pkg/astmodel/interface_implementation.go
@@ -26,11 +26,11 @@ func (iface *InterfaceImplementation) Name() TypeName {
 	return iface.name
 }
 
-// RequiredImports returns a list of packages required by this
-func (iface *InterfaceImplementation) RequiredImports() *PackageImportSet {
-	result := EmptyPackageImportSet()
+// RequiredPackageReferences returns a list of packages required by this
+func (iface *InterfaceImplementation) RequiredPackageReferences() []PackageReference {
+	var result []PackageReference
 	for _, f := range iface.functions {
-		result.Merge(f.RequiredImports())
+		result = append(result, f.RequiredPackageReferences()...)
 	}
 
 	return result

--- a/hack/generator/pkg/astmodel/interface_implementation.go
+++ b/hack/generator/pkg/astmodel/interface_implementation.go
@@ -27,11 +27,10 @@ func (iface *InterfaceImplementation) Name() TypeName {
 }
 
 // RequiredImports returns a list of packages required by this
-func (iface *InterfaceImplementation) RequiredImports() []PackageReference {
-	var result []PackageReference
-
+func (iface *InterfaceImplementation) RequiredImports() *PackageImportSet {
+	result := EmptyPackageImportSet()
 	for _, f := range iface.functions {
-		result = append(result, f.RequiredImports()...)
+		result.Merge(f.RequiredImports())
 	}
 
 	return result

--- a/hack/generator/pkg/astmodel/interface_implementer.go
+++ b/hack/generator/pkg/astmodel/interface_implementer.go
@@ -97,11 +97,10 @@ func (i InterfaceImplementer) Equals(other InterfaceImplementer) bool {
 	return true
 }
 
-func (i InterfaceImplementer) RequiredImports() []PackageReference {
-	var result []PackageReference
-
+func (i InterfaceImplementer) RequiredImports() *PackageImportSet {
+	result := EmptyPackageImportSet()
 	for _, i := range i.interfaces {
-		result = append(result, i.RequiredImports()...)
+		result.Merge(i.RequiredImports())
 	}
 
 	return result

--- a/hack/generator/pkg/astmodel/interface_implementer.go
+++ b/hack/generator/pkg/astmodel/interface_implementer.go
@@ -97,10 +97,10 @@ func (i InterfaceImplementer) Equals(other InterfaceImplementer) bool {
 	return true
 }
 
-func (i InterfaceImplementer) RequiredImports() *PackageImportSet {
-	result := EmptyPackageImportSet()
+func (i InterfaceImplementer) RequiredPackageReferences() []PackageReference {
+	var result []PackageReference
 	for _, i := range i.interfaces {
-		result.Merge(i.RequiredImports())
+		result = append(result, i.RequiredPackageReferences()...)
 	}
 
 	return result

--- a/hack/generator/pkg/astmodel/kubernetes_resource_interface.go
+++ b/hack/generator/pkg/astmodel/kubernetes_resource_interface.go
@@ -76,11 +76,9 @@ func (k *objectFunction) Name() string {
 	return k.name
 }
 
-func (k *objectFunction) RequiredImports() *PackageImportSet {
+func (k *objectFunction) RequiredPackageReferences() []PackageReference {
 	// We only require GenRuntime
-	result := EmptyPackageImportSet()
-	result.AddReference(MakeGenRuntimePackageReference())
-	return result
+	return []PackageReference{MakeGenRuntimePackageReference()}
 }
 
 func (k *objectFunction) References() TypeNameSet {

--- a/hack/generator/pkg/astmodel/kubernetes_resource_interface.go
+++ b/hack/generator/pkg/astmodel/kubernetes_resource_interface.go
@@ -76,11 +76,11 @@ func (k *objectFunction) Name() string {
 	return k.name
 }
 
-func (k *objectFunction) RequiredImports() []PackageReference {
+func (k *objectFunction) RequiredImports() *PackageImportSet {
 	// We only require GenRuntime
-	return []PackageReference{
-		MakeGenRuntimePackageReference(),
-	}
+	result := EmptyPackageImportSet()
+	result.AddReference(MakeGenRuntimePackageReference())
+	return result
 }
 
 func (k *objectFunction) References() TypeNameSet {

--- a/hack/generator/pkg/astmodel/local_package_reference.go
+++ b/hack/generator/pkg/astmodel/local_package_reference.go
@@ -65,3 +65,9 @@ func (pr LocalPackageReference) Equals(ref PackageReference) bool {
 func (pr LocalPackageReference) String() string {
 	return pr.PackagePath()
 }
+
+// IsLocalPackageReference() returns true if the supplied reference is a local one
+func IsLocalPackageReference(ref PackageReference) bool {
+	_, ok := ref.(LocalPackageReference)
+	return ok
+}

--- a/hack/generator/pkg/astmodel/map_type.go
+++ b/hack/generator/pkg/astmodel/map_type.go
@@ -53,7 +53,8 @@ func (m *MapType) AsType(codeGenerationContext *CodeGenerationContext) ast.Expr 
 
 // RequiredPackageReferences returns a list of packages required by this
 func (m *MapType) RequiredPackageReferences() []PackageReference {
-	result := m.key.RequiredPackageReferences()
+	var result []PackageReference
+	result = append(result, m.key.RequiredPackageReferences()...)
 	result = append(result, m.value.RequiredPackageReferences()...)
 	return result
 }

--- a/hack/generator/pkg/astmodel/map_type.go
+++ b/hack/generator/pkg/astmodel/map_type.go
@@ -51,11 +51,10 @@ func (m *MapType) AsType(codeGenerationContext *CodeGenerationContext) ast.Expr 
 	}
 }
 
-// RequiredImports returns a list of packages required by this
-func (m *MapType) RequiredImports() *PackageImportSet {
-	result := EmptyPackageImportSet()
-	result.Merge(m.key.RequiredImports())
-	result.Merge(m.value.RequiredImports())
+// RequiredPackageReferences returns a list of packages required by this
+func (m *MapType) RequiredPackageReferences() []PackageReference {
+	result := m.key.RequiredPackageReferences()
+	result = append(result, m.value.RequiredPackageReferences()...)
 	return result
 }
 

--- a/hack/generator/pkg/astmodel/map_type.go
+++ b/hack/generator/pkg/astmodel/map_type.go
@@ -52,10 +52,10 @@ func (m *MapType) AsType(codeGenerationContext *CodeGenerationContext) ast.Expr 
 }
 
 // RequiredImports returns a list of packages required by this
-func (m *MapType) RequiredImports() []PackageReference {
-	var result []PackageReference
-	result = append(result, m.key.RequiredImports()...)
-	result = append(result, m.value.RequiredImports()...)
+func (m *MapType) RequiredImports() *PackageImportSet {
+	result := EmptyPackageImportSet()
+	result.Merge(m.key.RequiredImports())
+	result.Merge(m.value.RequiredImports())
 	return result
 }
 

--- a/hack/generator/pkg/astmodel/object_type.go
+++ b/hack/generator/pkg/astmodel/object_type.go
@@ -132,18 +132,18 @@ func (objectType *ObjectType) AsType(codeGenerationContext *CodeGenerationContex
 	}
 }
 
-// RequiredImports returns a list of packages required by this
-func (objectType *ObjectType) RequiredImports() *PackageImportSet {
-	result := EmptyPackageImportSet()
+// RequiredPackageReferences returns a list of packages required by this
+func (objectType *ObjectType) RequiredPackageReferences() []PackageReference {
+	var result []PackageReference
 	for _, property := range objectType.properties {
-		result.Merge(property.PropertyType().RequiredImports())
+		result = append(result, property.PropertyType().RequiredPackageReferences()...)
 	}
 
 	for _, function := range objectType.functions {
-		result.Merge(function.RequiredImports())
+		result = append(result, function.RequiredPackageReferences()...)
 	}
 
-	result.Merge(objectType.InterfaceImplementer.RequiredImports())
+	result = append(result, objectType.InterfaceImplementer.RequiredPackageReferences()...)
 
 	return result
 }

--- a/hack/generator/pkg/astmodel/object_type.go
+++ b/hack/generator/pkg/astmodel/object_type.go
@@ -133,17 +133,17 @@ func (objectType *ObjectType) AsType(codeGenerationContext *CodeGenerationContex
 }
 
 // RequiredImports returns a list of packages required by this
-func (objectType *ObjectType) RequiredImports() []PackageReference {
-	var result []PackageReference
+func (objectType *ObjectType) RequiredImports() *PackageImportSet {
+	result := EmptyPackageImportSet()
 	for _, property := range objectType.properties {
-		result = append(result, property.PropertyType().RequiredImports()...)
+		result.Merge(property.PropertyType().RequiredImports())
 	}
 
 	for _, function := range objectType.functions {
-		result = append(result, function.RequiredImports()...)
+		result.Merge(function.RequiredImports())
 	}
 
-	result = append(result, objectType.InterfaceImplementer.RequiredImports()...)
+	result.Merge(objectType.InterfaceImplementer.RequiredImports())
 
 	return result
 }

--- a/hack/generator/pkg/astmodel/object_type_test.go
+++ b/hack/generator/pkg/astmodel/object_type_test.go
@@ -215,7 +215,7 @@ func Test_ObjectWithoutProperties_ReturnsExpectedObject(t *testing.T) {
 func Test_WithFunction_GivenEmptyObject_ReturnsPopulatedObject(t *testing.T) {
 	g := NewGomegaWithT(t)
 	empty := EmptyObjectType
-	fn := &FakeFunction{name: "Activate"}
+	fn := NewFakeFunction("Activate")
 	object := empty.WithFunction(fn)
 	g.Expect(empty).NotTo(Equal(object)) // Ensure the original wasn't modified
 	g.Expect(object.functions).To(HaveLen(1))

--- a/hack/generator/pkg/astmodel/one_of_json_marshal_function.go
+++ b/hack/generator/pkg/astmodel/one_of_json_marshal_function.go
@@ -122,8 +122,8 @@ func (f *OneOfJSONMarshalFunction) AsFunc(
 }
 
 // RequiredImports returns a list of packages required by this
-func (f *OneOfJSONMarshalFunction) RequiredImports() []PackageReference {
-	return []PackageReference{
-		MakeExternalPackageReference("encoding/json"),
-	}
+func (f *OneOfJSONMarshalFunction) RequiredImports() *PackageImportSet {
+	result := EmptyPackageImportSet()
+	result.AddReference(MakeExternalPackageReference("encoding/json"))
+	return result
 }

--- a/hack/generator/pkg/astmodel/one_of_json_marshal_function.go
+++ b/hack/generator/pkg/astmodel/one_of_json_marshal_function.go
@@ -122,8 +122,6 @@ func (f *OneOfJSONMarshalFunction) AsFunc(
 }
 
 // RequiredImports returns a list of packages required by this
-func (f *OneOfJSONMarshalFunction) RequiredImports() *PackageImportSet {
-	result := EmptyPackageImportSet()
-	result.AddReference(MakeExternalPackageReference("encoding/json"))
-	return result
+func (f *OneOfJSONMarshalFunction) RequiredPackageReferences() []PackageReference {
+	return []PackageReference{MakeExternalPackageReference("encoding/json")}
 }

--- a/hack/generator/pkg/astmodel/oneof_type.go
+++ b/hack/generator/pkg/astmodel/oneof_type.go
@@ -81,7 +81,7 @@ func (oneOf OneOfType) AsDeclarations(codeGenerationContext *CodeGenerationConte
 }
 
 // RequiredImports returns the union of the required imports of all the oneOf types
-func (oneOf OneOfType) RequiredImports() []PackageReference {
+func (oneOf OneOfType) RequiredImports() *PackageImportSet {
 	panic("should have been replaced by generation time by 'convertAllOfAndOneOf' phase")
 }
 

--- a/hack/generator/pkg/astmodel/oneof_type.go
+++ b/hack/generator/pkg/astmodel/oneof_type.go
@@ -80,8 +80,8 @@ func (oneOf OneOfType) AsDeclarations(codeGenerationContext *CodeGenerationConte
 	panic("should have been replaced by generation time by 'convertAllOfAndOneOf' phase")
 }
 
-// RequiredImports returns the union of the required imports of all the oneOf types
-func (oneOf OneOfType) RequiredImports() *PackageImportSet {
+// RequiredPackageReferences returns the union of the required imports of all the oneOf types
+func (oneOf OneOfType) RequiredPackageReferences() []PackageReference {
 	panic("should have been replaced by generation time by 'convertAllOfAndOneOf' phase")
 }
 

--- a/hack/generator/pkg/astmodel/oneof_type.go
+++ b/hack/generator/pkg/astmodel/oneof_type.go
@@ -70,13 +70,13 @@ func (oneOf OneOfType) References() TypeNameSet {
 
 // AsType always panics; AllOf cannot be represented by the Go AST and must be
 // lowered to an object type
-func (oneOf OneOfType) AsType(codeGenerationContext *CodeGenerationContext) ast.Expr {
+func (oneOf OneOfType) AsType(_ *CodeGenerationContext) ast.Expr {
 	panic("should have been replaced by generation time by 'convertAllOfAndOneOf' phase")
 }
 
 // AsDeclarations always panics; AllOf cannot be represented by the Go AST and must be
 // lowered to an object type
-func (oneOf OneOfType) AsDeclarations(codeGenerationContext *CodeGenerationContext, name TypeName, description []string) []ast.Decl {
+func (oneOf OneOfType) AsDeclarations(_ *CodeGenerationContext, _ TypeName, _ []string) []ast.Decl {
 	panic("should have been replaced by generation time by 'convertAllOfAndOneOf' phase")
 }
 

--- a/hack/generator/pkg/astmodel/oneof_type_test.go
+++ b/hack/generator/pkg/astmodel/oneof_type_test.go
@@ -92,6 +92,6 @@ func TestOneOfRequiredImportsPanics(t *testing.T) {
 
 	x := OneOfType{}
 	g.Expect(func() {
-		x.RequiredImports()
+		x.RequiredPackageReferences()
 	}).To(PanicWith("should have been replaced by generation time by 'convertAllOfAndOneOf' phase"))
 }

--- a/hack/generator/pkg/astmodel/optional_type.go
+++ b/hack/generator/pkg/astmodel/optional_type.go
@@ -64,7 +64,7 @@ func (optional *OptionalType) AsType(codeGenerationContext *CodeGenerationContex
 }
 
 // RequiredImports returns the imports required by the 'element' type
-func (optional *OptionalType) RequiredImports() []PackageReference {
+func (optional *OptionalType) RequiredImports() *PackageImportSet {
 	return optional.element.RequiredImports()
 }
 

--- a/hack/generator/pkg/astmodel/optional_type.go
+++ b/hack/generator/pkg/astmodel/optional_type.go
@@ -63,9 +63,9 @@ func (optional *OptionalType) AsType(codeGenerationContext *CodeGenerationContex
 	}
 }
 
-// RequiredImports returns the imports required by the 'element' type
-func (optional *OptionalType) RequiredImports() *PackageImportSet {
-	return optional.element.RequiredImports()
+// RequiredPackageReferences returns the imports required by the 'element' type
+func (optional *OptionalType) RequiredPackageReferences() []PackageReference {
+	return optional.element.RequiredPackageReferences()
 }
 
 // References returns the set of types that the underlying type refers to directly.

--- a/hack/generator/pkg/astmodel/package_import.go
+++ b/hack/generator/pkg/astmodel/package_import.go
@@ -6,6 +6,7 @@
 package astmodel
 
 import (
+	"fmt"
 	"go/ast"
 	"go/token"
 )
@@ -15,6 +16,8 @@ type PackageImport struct {
 	PackageReference PackageReference
 	name             string
 }
+
+var _ fmt.Stringer = &PackageImport{}
 
 // NewPackageImport creates a new package import from a reference
 func NewPackageImport(packageReference PackageReference) PackageImport {
@@ -59,4 +62,12 @@ func (pi PackageImport) Equals(ref PackageImport) bool {
 	namesEqual := pi.name == ref.name
 
 	return packagesEqual && namesEqual
+}
+
+func (pi PackageImport) String() string {
+	if len(pi.name) > 0 {
+		return fmt.Sprintf("%v %v", pi.name, pi.PackageReference)
+	}
+
+	return pi.PackageReference.String()
 }

--- a/hack/generator/pkg/astmodel/package_import_set.go
+++ b/hack/generator/pkg/astmodel/package_import_set.go
@@ -104,7 +104,7 @@ func (set *PackageImportSet) ApplyName(ref PackageReference, name string) {
 	}
 }
 
-// ByPackageImportName() orders PackageImport instances by name,
+// ByNameInGroups() orders PackageImport instances by name,
 // We order explicitly named packages before implicitly named ones
 func ByNameInGroups(left PackageImport, right PackageImport) bool {
 	if left.name != right.name {

--- a/hack/generator/pkg/astmodel/package_import_set.go
+++ b/hack/generator/pkg/astmodel/package_import_set.go
@@ -9,20 +9,20 @@ import "sort"
 
 // PackageImportSet represents a set of distinct PackageImport references
 type PackageImportSet struct {
-	imports map[PackageImport]bool
+	imports map[PackageImport]struct{}
 }
 
 // EmptyPackageImportSet creates a new empty set of PackageImport references
 func EmptyPackageImportSet() *PackageImportSet {
 	return &PackageImportSet{
-		imports: make(map[PackageImport]bool),
+		imports: make(map[PackageImport]struct{}),
 	}
 }
 
 // AddImport ensures the set includes the specified import
 // Adding an import already present in the set is fine.
 func (set *PackageImportSet) AddImport(packageImport PackageImport) {
-	set.imports[packageImport] = true
+	set.imports[packageImport] = struct{}{}
 }
 
 // AddReference ensures this set includes an import of the specified reference

--- a/hack/generator/pkg/astmodel/package_import_set.go
+++ b/hack/generator/pkg/astmodel/package_import_set.go
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) Microsoft Corporation.
+ * Licensed under the MIT license.
+ */
+
+package astmodel
+
+import "sort"
+
+// PackageImportSet represents a set of distinct PackageImport references
+type PackageImportSet struct {
+	imports map[PackageImport]bool
+}
+
+// EmptyPackageImportSet creates a new empty set of PackageImport references
+func EmptyPackageImportSet() *PackageImportSet {
+	return &PackageImportSet{
+		imports: make(map[PackageImport]bool),
+	}
+}
+
+// AddImport ensures the set includes the specified import
+// Adding an import already present in the set is fine.
+func (set *PackageImportSet) AddImport(packageImport PackageImport) {
+	set.imports[packageImport] = true
+}
+
+// AddReference ensures this set includes an import of the specified reference
+// Adding a reference already in the set is fine.
+func (set *PackageImportSet) AddReference(ref PackageReference) {
+	set.AddImport(NewPackageImport(ref))
+}
+
+// Merge ensures that all imports specified in other are included
+func (set *PackageImportSet) Merge(other *PackageImportSet) {
+	for i := range other.imports {
+		set.AddImport(i)
+	}
+}
+
+// Remove ensures the specified item is not present
+// Removing an item not in the set is not an error.
+func (set *PackageImportSet) Remove(packageImport PackageImport) {
+	delete(set.imports, packageImport)
+}
+
+// Contains allows checking to see if an import is included
+func (set *PackageImportSet) ContainsImport(packageImport PackageImport) bool {
+	_, found := set.imports[packageImport]
+	return found
+}
+
+// ImportFor looks up a package reference and returns its import, if any
+func (set *PackageImportSet) ImportFor(ref PackageReference) (PackageImport, bool) {
+	for imp := range set.imports {
+		if imp.PackageReference.Equals(ref) {
+			return imp, true
+		}
+	}
+
+	return PackageImport{}, false
+}
+
+// AsSlice() returns a sorted slice containing all the imports
+func (set *PackageImportSet) AsSlice() []PackageImport {
+	var result []PackageImport
+	for i := range set.imports {
+		result = append(result, i)
+	}
+
+	sort.Slice(result, func(i, j int) bool {
+		return result[i].String() < result[j].String()
+	})
+
+	return result
+}
+
+// Length returns the number of unique imports in this set
+func (set *PackageImportSet) Length() int {
+	return len(set.imports)
+}

--- a/hack/generator/pkg/astmodel/package_import_set.go
+++ b/hack/generator/pkg/astmodel/package_import_set.go
@@ -79,3 +79,20 @@ func (set *PackageImportSet) AsSlice() []PackageImport {
 func (set *PackageImportSet) Length() int {
 	return len(set.imports)
 }
+
+// ApplyName replaces any existing PackageImport for the specified reference with one using the
+// specified name
+func (set *PackageImportSet) ApplyName(ref PackageReference, name string) {
+	found := false
+	// Iterate over a slice as that freezes the list
+	for _, imp := range set.AsSlice() {
+		if imp.PackageReference.Equals(ref) {
+			set.Remove(imp)
+			found = true
+		}
+	}
+
+	if found {
+		set.AddImport(NewPackageImport(ref).WithName(name))
+	}
+}

--- a/hack/generator/pkg/astmodel/package_import_set.go
+++ b/hack/generator/pkg/astmodel/package_import_set.go
@@ -25,9 +25,9 @@ func (set *PackageImportSet) AddImport(packageImport PackageImport) {
 	set.imports[packageImport] = struct{}{}
 }
 
-// AddReference ensures this set includes an import of the specified reference
+// AddImportOfReference ensures this set includes an import of the specified reference
 // Adding a reference already in the set is fine.
-func (set *PackageImportSet) AddReference(ref PackageReference) {
+func (set *PackageImportSet) AddImportOfReference(ref PackageReference) {
 	set.AddImport(NewPackageImport(ref))
 }
 

--- a/hack/generator/pkg/astmodel/package_import_set.go
+++ b/hack/generator/pkg/astmodel/package_import_set.go
@@ -12,8 +12,8 @@ type PackageImportSet struct {
 	imports map[PackageImport]struct{}
 }
 
-// EmptyPackageImportSet creates a new empty set of PackageImport references
-func EmptyPackageImportSet() *PackageImportSet {
+// NewPackageImportSet creates a new empty set of PackageImport references
+func NewPackageImportSet() *PackageImportSet {
 	return &PackageImportSet{
 		imports: make(map[PackageImport]struct{}),
 	}

--- a/hack/generator/pkg/astmodel/package_import_set.go
+++ b/hack/generator/pkg/astmodel/package_import_set.go
@@ -74,10 +74,6 @@ func (set *PackageImportSet) AsSlice() []PackageImport {
 		result = append(result, imp)
 	}
 
-	sort.Slice(result, func(i, j int) bool {
-		return result[i].String() < result[j].String()
-	})
-
 	return result
 }
 

--- a/hack/generator/pkg/astmodel/package_import_set_test.go
+++ b/hack/generator/pkg/astmodel/package_import_set_test.go
@@ -19,12 +19,12 @@ var (
 )
 
 /*
- * EmptyPackageImportSet() tests
+ * NewPackageImportSet() tests
  */
 
 func TestEmptyPackageImportSet_ReturnsEmptySet(t *testing.T) {
 	g := NewGomegaWithT(t)
-	set := EmptyPackageImportSet()
+	set := NewPackageImportSet()
 	g.Expect(set.imports).To(HaveLen(0))
 }
 
@@ -34,14 +34,14 @@ func TestEmptyPackageImportSet_ReturnsEmptySet(t *testing.T) {
 
 func TestAddImport_WhenImportMissing_IncreasesSizeOfSet(t *testing.T) {
 	g := NewGomegaWithT(t)
-	set := EmptyPackageImportSet()
+	set := NewPackageImportSet()
 	set.AddImport(simpleTestImport)
 	g.Expect(set.imports).To(HaveLen(1))
 }
 
 func TestAddImport_WhenImportPresent_LeavesSetSameSize(t *testing.T) {
 	g := NewGomegaWithT(t)
-	set := EmptyPackageImportSet()
+	set := NewPackageImportSet()
 	set.AddImport(simpleTestImport)
 	set.AddImport(simpleTestImport)
 	g.Expect(set.imports).To(HaveLen(1))
@@ -53,14 +53,14 @@ func TestAddImport_WhenImportPresent_LeavesSetSameSize(t *testing.T) {
 
 func TestAddReference_WhenReferenceMissing_IncreasesSizeOfSet(t *testing.T) {
 	g := NewGomegaWithT(t)
-	set := EmptyPackageImportSet()
+	set := NewPackageImportSet()
 	set.AddReference(simpleTestRef)
 	g.Expect(set.imports).To(HaveLen(1))
 }
 
 func TestAddImport_WhenReferencePresent_LeavesSetSameSize(t *testing.T) {
 	g := NewGomegaWithT(t)
-	set := EmptyPackageImportSet()
+	set := NewPackageImportSet()
 	set.AddReference(simpleTestRef)
 	set.AddReference(simpleTestRef)
 	g.Expect(set.imports).To(HaveLen(1))
@@ -72,20 +72,20 @@ func TestAddImport_WhenReferencePresent_LeavesSetSameSize(t *testing.T) {
 
 func TestMerge_GivenEmptySet_LeavesSetUnchanged(t *testing.T) {
 	g := NewGomegaWithT(t)
-	setA := EmptyPackageImportSet()
+	setA := NewPackageImportSet()
 	setA.AddReference(simpleTestRef)
 	setA.AddReference(pathTestRef)
-	setB := EmptyPackageImportSet()
+	setB := NewPackageImportSet()
 	setA.Merge(setB)
 	g.Expect(setA.imports).To(HaveLen(2))
 }
 
 func TestMerge_GivenIdenticalSet_LeavesSetUnchanged(t *testing.T) {
 	g := NewGomegaWithT(t)
-	setA := EmptyPackageImportSet()
+	setA := NewPackageImportSet()
 	setA.AddReference(simpleTestRef)
 	setA.AddReference(pathTestRef)
-	setB := EmptyPackageImportSet()
+	setB := NewPackageImportSet()
 	setB.AddReference(simpleTestRef)
 	setB.AddReference(pathTestRef)
 	setA.Merge(setB)
@@ -94,9 +94,9 @@ func TestMerge_GivenIdenticalSet_LeavesSetUnchanged(t *testing.T) {
 
 func TestMerge_GivenDisjointSets_MergesSets(t *testing.T) {
 	g := NewGomegaWithT(t)
-	setA := EmptyPackageImportSet()
+	setA := NewPackageImportSet()
 	setA.AddReference(simpleTestRef)
-	setB := EmptyPackageImportSet()
+	setB := NewPackageImportSet()
 	setB.AddReference(pathTestRef)
 	setA.Merge(setB)
 	g.Expect(setA.imports).To(HaveLen(2))
@@ -108,14 +108,14 @@ func TestMerge_GivenDisjointSets_MergesSets(t *testing.T) {
 
 func TestContains_GivenMemberOfSet_ReturnsTrue(t *testing.T) {
 	g := NewGomegaWithT(t)
-	set := EmptyPackageImportSet()
+	set := NewPackageImportSet()
 	set.AddImport(simpleTestImport)
 	g.Expect(set.ContainsImport(simpleTestImport)).To(BeTrue())
 }
 
 func TestContains_GivenNonMemberOfSet_ReturnsFalse(t *testing.T) {
 	g := NewGomegaWithT(t)
-	set := EmptyPackageImportSet()
+	set := NewPackageImportSet()
 	set.AddImport(simpleTestImport)
 	g.Expect(set.ContainsImport(pathTestImport)).To(BeFalse())
 }
@@ -126,7 +126,7 @@ func TestContains_GivenNonMemberOfSet_ReturnsFalse(t *testing.T) {
 
 func TestRemove_WhenItemInSet_RemovesIt(t *testing.T) {
 	g := NewGomegaWithT(t)
-	set := EmptyPackageImportSet()
+	set := NewPackageImportSet()
 	set.AddImport(simpleTestImport)
 	set.Remove(simpleTestImport)
 	g.Expect(set.ContainsImport(simpleTestImport)).To(BeFalse())
@@ -134,7 +134,7 @@ func TestRemove_WhenItemInSet_RemovesIt(t *testing.T) {
 
 func TestRemove_WhenItemNotInSet_LeavesSetWithoutIt(t *testing.T) {
 	g := NewGomegaWithT(t)
-	set := EmptyPackageImportSet()
+	set := NewPackageImportSet()
 	set.AddImport(simpleTestImport)
 	set.Remove(pathTestImport)
 	g.Expect(set.ContainsImport(pathTestImport)).To(BeFalse())

--- a/hack/generator/pkg/astmodel/package_import_set_test.go
+++ b/hack/generator/pkg/astmodel/package_import_set_test.go
@@ -14,8 +14,9 @@ var (
 	simpleTestRef PackageReference = MakeExternalPackageReference("simple")
 	pathTestRef   PackageReference = MakeExternalPackageReference("package/path")
 
-	simpleTestImport = NewPackageImport(simpleTestRef)
-	pathTestImport   = NewPackageImport(pathTestRef)
+	simpleTestImport         = NewPackageImport(simpleTestRef)
+	pathTestImport           = NewPackageImport(pathTestRef)
+	simpleTestImportWithName = simpleTestImport.WithName("simple")
 )
 
 /*
@@ -45,6 +46,26 @@ func TestAddImport_WhenImportPresent_LeavesSetSameSize(t *testing.T) {
 	set.AddImport(simpleTestImport)
 	set.AddImport(simpleTestImport)
 	g.Expect(set.imports).To(HaveLen(1))
+}
+
+func TestAddImport_WhenAddingNamedImportAndUnnamedExists_PrefersNamedImport(t *testing.T) {
+	g := NewGomegaWithT(t)
+	set := NewPackageImportSet()
+	set.AddImport(simpleTestImport)
+	set.AddImport(simpleTestImportWithName)
+	imp, ok := set.ImportFor(simpleTestRef)
+	g.Expect(ok).To(BeTrue())
+	g.Expect(imp).To(Equal(simpleTestImportWithName))
+}
+
+func TestAddImport_WhenAddingUnnamedImportAndNamedExists_PrefersNamedImport(t *testing.T) {
+	g := NewGomegaWithT(t)
+	set := NewPackageImportSet()
+	set.AddImport(simpleTestImportWithName)
+	set.AddImport(simpleTestImport)
+	imp, ok := set.ImportFor(simpleTestRef)
+	g.Expect(ok).To(BeTrue())
+	g.Expect(imp).To(Equal(simpleTestImportWithName))
 }
 
 /*

--- a/hack/generator/pkg/astmodel/package_import_set_test.go
+++ b/hack/generator/pkg/astmodel/package_import_set_test.go
@@ -1,0 +1,141 @@
+/*
+ * Copyright (c) Microsoft Corporation.
+ * Licensed under the MIT license.
+ */
+
+package astmodel
+
+import (
+	. "github.com/onsi/gomega"
+	"testing"
+)
+
+var (
+	simpleTestRef PackageReference = MakeExternalPackageReference("simple")
+	pathTestRef   PackageReference = MakeExternalPackageReference("package/path")
+
+	simpleTestImport = NewPackageImport(simpleTestRef)
+	pathTestImport   = NewPackageImport(pathTestRef)
+)
+
+/*
+ * EmptyPackageImportSet() tests
+ */
+
+func TestEmptyPackageImportSet_ReturnsEmptySet(t *testing.T) {
+	g := NewGomegaWithT(t)
+	set := EmptyPackageImportSet()
+	g.Expect(set.imports).To(HaveLen(0))
+}
+
+/*
+ * AddImport() tests
+ */
+
+func TestAddImport_WhenImportMissing_IncreasesSizeOfSet(t *testing.T) {
+	g := NewGomegaWithT(t)
+	set := EmptyPackageImportSet()
+	set.AddImport(simpleTestImport)
+	g.Expect(set.imports).To(HaveLen(1))
+}
+
+func TestAddImport_WhenImportPresent_LeavesSetSameSize(t *testing.T) {
+	g := NewGomegaWithT(t)
+	set := EmptyPackageImportSet()
+	set.AddImport(simpleTestImport)
+	set.AddImport(simpleTestImport)
+	g.Expect(set.imports).To(HaveLen(1))
+}
+
+/*
+ * AddReference() tests
+ */
+
+func TestAddReference_WhenReferenceMissing_IncreasesSizeOfSet(t *testing.T) {
+	g := NewGomegaWithT(t)
+	set := EmptyPackageImportSet()
+	set.AddReference(simpleTestRef)
+	g.Expect(set.imports).To(HaveLen(1))
+}
+
+func TestAddImport_WhenReferencePresent_LeavesSetSameSize(t *testing.T) {
+	g := NewGomegaWithT(t)
+	set := EmptyPackageImportSet()
+	set.AddReference(simpleTestRef)
+	set.AddReference(simpleTestRef)
+	g.Expect(set.imports).To(HaveLen(1))
+}
+
+/*
+ * Merge() tests
+ */
+
+func TestMerge_GivenEmptySet_LeavesSetUnchanged(t *testing.T) {
+	g := NewGomegaWithT(t)
+	setA := EmptyPackageImportSet()
+	setA.AddReference(simpleTestRef)
+	setA.AddReference(pathTestRef)
+	setB := EmptyPackageImportSet()
+	setA.Merge(setB)
+	g.Expect(setA.imports).To(HaveLen(2))
+}
+
+func TestMerge_GivenIdenticalSet_LeavesSetUnchanged(t *testing.T) {
+	g := NewGomegaWithT(t)
+	setA := EmptyPackageImportSet()
+	setA.AddReference(simpleTestRef)
+	setA.AddReference(pathTestRef)
+	setB := EmptyPackageImportSet()
+	setB.AddReference(simpleTestRef)
+	setB.AddReference(pathTestRef)
+	setA.Merge(setB)
+	g.Expect(setA.imports).To(HaveLen(2))
+}
+
+func TestMerge_GivenDisjointSets_MergesSets(t *testing.T) {
+	g := NewGomegaWithT(t)
+	setA := EmptyPackageImportSet()
+	setA.AddReference(simpleTestRef)
+	setB := EmptyPackageImportSet()
+	setB.AddReference(pathTestRef)
+	setA.Merge(setB)
+	g.Expect(setA.imports).To(HaveLen(2))
+}
+
+/*
+ * Contains() tests
+ */
+
+func TestContains_GivenMemberOfSet_ReturnsTrue(t *testing.T) {
+	g := NewGomegaWithT(t)
+	set := EmptyPackageImportSet()
+	set.AddImport(simpleTestImport)
+	g.Expect(set.ContainsImport(simpleTestImport)).To(BeTrue())
+}
+
+func TestContains_GivenNonMemberOfSet_ReturnsFalse(t *testing.T) {
+	g := NewGomegaWithT(t)
+	set := EmptyPackageImportSet()
+	set.AddImport(simpleTestImport)
+	g.Expect(set.ContainsImport(pathTestImport)).To(BeFalse())
+}
+
+/*
+ * Remove() tests
+ */
+
+func TestRemove_WhenItemInSet_RemovesIt(t *testing.T) {
+	g := NewGomegaWithT(t)
+	set := EmptyPackageImportSet()
+	set.AddImport(simpleTestImport)
+	set.Remove(simpleTestImport)
+	g.Expect(set.ContainsImport(simpleTestImport)).To(BeFalse())
+}
+
+func TestRemove_WhenItemNotInSet_LeavesSetWithoutIt(t *testing.T) {
+	g := NewGomegaWithT(t)
+	set := EmptyPackageImportSet()
+	set.AddImport(simpleTestImport)
+	set.Remove(pathTestImport)
+	g.Expect(set.ContainsImport(pathTestImport)).To(BeFalse())
+}

--- a/hack/generator/pkg/astmodel/package_import_set_test.go
+++ b/hack/generator/pkg/astmodel/package_import_set_test.go
@@ -48,21 +48,21 @@ func TestAddImport_WhenImportPresent_LeavesSetSameSize(t *testing.T) {
 }
 
 /*
- * AddReference() tests
+ * AddImportOfReference() tests
  */
 
 func TestAddReference_WhenReferenceMissing_IncreasesSizeOfSet(t *testing.T) {
 	g := NewGomegaWithT(t)
 	set := NewPackageImportSet()
-	set.AddReference(simpleTestRef)
+	set.AddImportOfReference(simpleTestRef)
 	g.Expect(set.imports).To(HaveLen(1))
 }
 
 func TestAddImport_WhenReferencePresent_LeavesSetSameSize(t *testing.T) {
 	g := NewGomegaWithT(t)
 	set := NewPackageImportSet()
-	set.AddReference(simpleTestRef)
-	set.AddReference(simpleTestRef)
+	set.AddImportOfReference(simpleTestRef)
+	set.AddImportOfReference(simpleTestRef)
 	g.Expect(set.imports).To(HaveLen(1))
 }
 
@@ -73,8 +73,8 @@ func TestAddImport_WhenReferencePresent_LeavesSetSameSize(t *testing.T) {
 func TestMerge_GivenEmptySet_LeavesSetUnchanged(t *testing.T) {
 	g := NewGomegaWithT(t)
 	setA := NewPackageImportSet()
-	setA.AddReference(simpleTestRef)
-	setA.AddReference(pathTestRef)
+	setA.AddImportOfReference(simpleTestRef)
+	setA.AddImportOfReference(pathTestRef)
 	setB := NewPackageImportSet()
 	setA.Merge(setB)
 	g.Expect(setA.imports).To(HaveLen(2))
@@ -83,11 +83,11 @@ func TestMerge_GivenEmptySet_LeavesSetUnchanged(t *testing.T) {
 func TestMerge_GivenIdenticalSet_LeavesSetUnchanged(t *testing.T) {
 	g := NewGomegaWithT(t)
 	setA := NewPackageImportSet()
-	setA.AddReference(simpleTestRef)
-	setA.AddReference(pathTestRef)
+	setA.AddImportOfReference(simpleTestRef)
+	setA.AddImportOfReference(pathTestRef)
 	setB := NewPackageImportSet()
-	setB.AddReference(simpleTestRef)
-	setB.AddReference(pathTestRef)
+	setB.AddImportOfReference(simpleTestRef)
+	setB.AddImportOfReference(pathTestRef)
 	setA.Merge(setB)
 	g.Expect(setA.imports).To(HaveLen(2))
 }
@@ -95,9 +95,9 @@ func TestMerge_GivenIdenticalSet_LeavesSetUnchanged(t *testing.T) {
 func TestMerge_GivenDisjointSets_MergesSets(t *testing.T) {
 	g := NewGomegaWithT(t)
 	setA := NewPackageImportSet()
-	setA.AddReference(simpleTestRef)
+	setA.AddImportOfReference(simpleTestRef)
 	setB := NewPackageImportSet()
-	setB.AddReference(pathTestRef)
+	setB.AddImportOfReference(pathTestRef)
 	setA.Merge(setB)
 	g.Expect(setA.imports).To(HaveLen(2))
 }

--- a/hack/generator/pkg/astmodel/primitive_type.go
+++ b/hack/generator/pkg/astmodel/primitive_type.go
@@ -41,9 +41,9 @@ func (prim *PrimitiveType) AsDeclarations(genContext *CodeGenerationContext, nam
 	return AsSimpleDeclarations(genContext, name, description, prim)
 }
 
-// RequiredImports returns a list of package required by this
-func (prim *PrimitiveType) RequiredImports() *PackageImportSet {
-	return EmptyPackageImportSet()
+// RequiredPackageReferences returns a list of package required by this
+func (prim *PrimitiveType) RequiredPackageReferences() []PackageReference {
+	return nil
 }
 
 // References always returns nil because primitive types don't refer to

--- a/hack/generator/pkg/astmodel/primitive_type.go
+++ b/hack/generator/pkg/astmodel/primitive_type.go
@@ -42,8 +42,8 @@ func (prim *PrimitiveType) AsDeclarations(genContext *CodeGenerationContext, nam
 }
 
 // RequiredImports returns a list of package required by this
-func (prim *PrimitiveType) RequiredImports() []PackageReference {
-	return nil
+func (prim *PrimitiveType) RequiredImports() *PackageImportSet {
+	return EmptyPackageImportSet()
 }
 
 // References always returns nil because primitive types don't refer to

--- a/hack/generator/pkg/astmodel/resource.go
+++ b/hack/generator/pkg/astmodel/resource.go
@@ -226,22 +226,22 @@ func (definition *ResourceType) WithOwner(owner *TypeName) *ResourceType {
 	return &result
 }
 
-// RequiredImports returns a list of packages required by this
-func (definition *ResourceType) RequiredImports() *PackageImportSet {
-	typeImports := definition.spec.RequiredImports()
+// RequiredPackageReferences returns a list of packages required by this
+func (definition *ResourceType) RequiredPackageReferences() []PackageReference {
+	references := definition.spec.RequiredPackageReferences()
 
 	if definition.status != nil {
-		typeImports.Merge(definition.status.RequiredImports())
+		references = append(references, definition.status.RequiredPackageReferences()...)
 	}
 
-	typeImports.AddImport(NewPackageImport(MetaV1PackageReference).WithName("metav1"))
-	typeImports.AddReference(MakeGenRuntimePackageReference())
-	typeImports.AddReference(MakeExternalPackageReference("fmt"))
+	references = append(references, MetaV1PackageReference)
+	references = append(references, MakeGenRuntimePackageReference())
+	references = append(references, MakeExternalPackageReference("fmt"))
 
 	// Interface imports
-	typeImports.Merge(definition.InterfaceImplementer.RequiredImports())
+	references = append(references, definition.InterfaceImplementer.RequiredPackageReferences()...)
 
-	return typeImports
+	return references
 }
 
 // AsDeclarations converts the resource type to a set of go declarations

--- a/hack/generator/pkg/astmodel/resource.go
+++ b/hack/generator/pkg/astmodel/resource.go
@@ -227,19 +227,19 @@ func (definition *ResourceType) WithOwner(owner *TypeName) *ResourceType {
 }
 
 // RequiredImports returns a list of packages required by this
-func (definition *ResourceType) RequiredImports() []PackageReference {
+func (definition *ResourceType) RequiredImports() *PackageImportSet {
 	typeImports := definition.spec.RequiredImports()
 
 	if definition.status != nil {
-		typeImports = append(typeImports, definition.status.RequiredImports()...)
+		typeImports.Merge(definition.status.RequiredImports())
 	}
 
-	typeImports = append(typeImports, MetaV1PackageReference)
-	typeImports = append(typeImports, MakeGenRuntimePackageReference())
-	typeImports = append(typeImports, MakeExternalPackageReference("fmt"))
+	typeImports.AddImport(NewPackageImport(MetaV1PackageReference).WithName("metav1"))
+	typeImports.AddReference(MakeGenRuntimePackageReference())
+	typeImports.AddReference(MakeExternalPackageReference("fmt"))
 
 	// Interface imports
-	typeImports = append(typeImports, definition.InterfaceImplementer.RequiredImports()...)
+	typeImports.Merge(definition.InterfaceImplementer.RequiredImports())
 
 	return typeImports
 }

--- a/hack/generator/pkg/astmodel/type.go
+++ b/hack/generator/pkg/astmodel/type.go
@@ -14,8 +14,8 @@ import (
 
 // Type represents something that is a Go type
 type Type interface {
-	// RequiredImports returns a list of packages required by this type
-	RequiredImports() []PackageReference
+	// RequiredImports returns a set of packages imports required by this type
+	RequiredImports() *PackageImportSet
 
 	// References returns the names of all types that this type
 	// references. For example, an Array of Persons references a

--- a/hack/generator/pkg/astmodel/type.go
+++ b/hack/generator/pkg/astmodel/type.go
@@ -55,7 +55,7 @@ func TypeAsObjectType(t Type) (*ObjectType, error) {
 
 	ot, ok := rt.(*ObjectType)
 	if !ok {
-		return nil, fmt.Errorf("Type %v is not an object", rt)
+		return nil, fmt.Errorf("type %v is not an object", rt)
 	}
 
 	return ot, nil

--- a/hack/generator/pkg/astmodel/type.go
+++ b/hack/generator/pkg/astmodel/type.go
@@ -14,8 +14,8 @@ import (
 
 // Type represents something that is a Go type
 type Type interface {
-	// RequiredImports returns a set of packages imports required by this type
-	RequiredImports() *PackageImportSet
+	// RequiredPackageReferences returns a set of packages imports required by this type
+	RequiredPackageReferences() []PackageReference
 
 	// References returns the names of all types that this type
 	// references. For example, an Array of Persons references a

--- a/hack/generator/pkg/astmodel/type_definition.go
+++ b/hack/generator/pkg/astmodel/type_definition.go
@@ -91,7 +91,7 @@ func AsSimpleDeclarations(codeGenerationContext *CodeGenerationContext, name Typ
 }
 
 // RequiredImports returns a list of packages required by this type
-func (def TypeDefinition) RequiredImports() []PackageReference {
+func (def TypeDefinition) RequiredImports() *PackageImportSet {
 	return def.theType.RequiredImports()
 }
 

--- a/hack/generator/pkg/astmodel/type_definition.go
+++ b/hack/generator/pkg/astmodel/type_definition.go
@@ -91,8 +91,8 @@ func AsSimpleDeclarations(codeGenerationContext *CodeGenerationContext, name Typ
 }
 
 // RequiredImports returns a list of packages required by this type
-func (def TypeDefinition) RequiredImports() *PackageImportSet {
-	return def.theType.RequiredImports()
+func (def TypeDefinition) RequiredPackageReferences() []PackageReference {
+	return def.theType.RequiredPackageReferences()
 }
 
 // FileNameHint returns what a file that contains this name (if any) should be called

--- a/hack/generator/pkg/astmodel/type_name.go
+++ b/hack/generator/pkg/astmodel/type_name.go
@@ -71,8 +71,10 @@ func (typeName TypeName) References() TypeNameSet {
 }
 
 // RequiredImports returns all the imports required for this definition
-func (typeName TypeName) RequiredImports() []PackageReference {
-	return []PackageReference{typeName.PackageReference}
+func (typeName TypeName) RequiredImports() *PackageImportSet {
+	result := EmptyPackageImportSet()
+	result.AddReference(typeName.PackageReference)
+	return result
 }
 
 // Equals returns true if the passed type is the same TypeName, false otherwise

--- a/hack/generator/pkg/astmodel/type_name.go
+++ b/hack/generator/pkg/astmodel/type_name.go
@@ -70,11 +70,9 @@ func (typeName TypeName) References() TypeNameSet {
 	return NewTypeNameSet(typeName)
 }
 
-// RequiredImports returns all the imports required for this definition
-func (typeName TypeName) RequiredImports() *PackageImportSet {
-	result := EmptyPackageImportSet()
-	result.AddReference(typeName.PackageReference)
-	return result
+// RequiredPackageReferences returns all the imports required for this definition
+func (typeName TypeName) RequiredPackageReferences() []PackageReference {
+	return []PackageReference{typeName.PackageReference}
 }
 
 // Equals returns true if the passed type is the same TypeName, false otherwise

--- a/hack/generator/pkg/astmodel/type_visitor_test.go
+++ b/hack/generator/pkg/astmodel/type_visitor_test.go
@@ -121,9 +121,9 @@ func TestIdentityVisitorReturnsEqualResult(t *testing.T) {
 	familyName := NewPropertyDefinition("FamilyName", "family-name", StringType)
 	knownAs := NewPropertyDefinition("KnownAs", "known-as", StringType)
 
-	transform := &FakeFunction{name: "Transform"}
-	transmogrify := &FakeFunction{name: "Transmogrify"}
-	skew := &FakeFunction{name: "Skew"}
+	transform := NewFakeFunction("Transform")
+	transmogrify := NewFakeFunction("Transmogrify")
+	skew := NewFakeFunction("Skew")
 
 	person := NewObjectType().WithProperties(fullName, familyName, knownAs)
 	individual := NewObjectType().WithProperties(fullName).


### PR DESCRIPTION
I was writing some code for handling test case generation and it felt like someone else must have already written the same code. I was right - multiple times. Fortunately, it all looked consistent

This PR introduces a proper `PackageImportSet` abstraction (with tests), making a bunch of code more declarative and easy to read. 