### PR TITLE
Remove oneOf-related pruning

### DIFF
--- a/hack/generator/azure-arm.yaml
+++ b/hack/generator/azure-arm.yaml
@@ -48,17 +48,6 @@ typeFilters:
     name: AutomationAccountsRunbooksDraftChildResource
     because: Uses OneOf in a weird way that makes detecting actual resource difficult, skipping for now.
   - action: prune
-    group: microsoft.web
-    version: '*2018*'
-    because: Some types (SitesSlotsConfig) use OneOf in a way we don't currently handle.
-  - action: prune
-    group: microsoft.kusto
-    because: Some types use OneOf in a way we don't currently handle correctly.
-  - action: prune
-    group: microsoft.timeseriesinsights
-    version: v20171115
-    because: Some types use OneOf in a way we don't currently handle.
-  - action: prune
     group: microsoft.storage
     version: v20190401
     name: StorageAccountsFileServices*
@@ -116,6 +105,10 @@ anyTypePackages:
   - microsoft.containerregistry/v20171001
   - microsoft.datafactory/v20180601
   - microsoft.keyvault/v20150601
+  - microsoft.kusto/v20190515
+  - microsoft.kusto/v20191109
+  - microsoft.kusto/v20200215
+  - microsoft.kusto/v20200614
   - microsoft.logic/v20160601
   - microsoft.logic/v20161001
   - microsoft.logic/v20170701
@@ -165,6 +158,8 @@ anyTypePackages:
   - microsoft.web/v20140601
   - microsoft.web/v20150801
   - microsoft.web/v20160601
+  - microsoft.web/v20180201
+  - microsoft.web/v20181101
   # The following end up with AnyType in Status
   - microsoft.apimanagement/v20190101
   - microsoft.containerservice/v20180331


### PR DESCRIPTION
These shouldn’t fail now, but some of them generate anyTypes so the exclusions should be there instead.