### PR TITLE
Remove unnecessary references in resource.go

### DIFF
--- a/hack/generator/pkg/astmodel/resource.go
+++ b/hack/generator/pkg/astmodel/resource.go
@@ -235,8 +235,6 @@ func (definition *ResourceType) RequiredPackageReferences() []PackageReference {
 	}
 
 	references = append(references, MetaV1PackageReference)
-	references = append(references, MakeGenRuntimePackageReference())
-	references = append(references, MakeExternalPackageReference("fmt"))
 
 	// Interface imports
 	references = append(references, definition.InterfaceImplementer.RequiredPackageReferences()...)


### PR DESCRIPTION
  - genruntime can be used by interfaces, which will be automatically
    included via InterfaceImplementer. It can also be included in
    specs for properties such as Owner, but in that case it will
    already be included on the Spec as a requirement (via the property
    itself).
  - fmt can be used in functions, but those will report their need for
    it directly.