### PR TITLE
Deepcopy maps, arrays and optional fields when converting to/from ARM types

### DIFF
--- a/hack/generator/pkg/astmodel/armconversion/convert_to_arm_function_builder.go
+++ b/hack/generator/pkg/astmodel/armconversion/convert_to_arm_function_builder.go
@@ -184,6 +184,32 @@ func (builder *convertToArmBuilder) propertiesWithSameNameAndTypeHandler(
 	if !ok || !toProp.PropertyType().Equals(fromProp.PropertyType()) {
 		return nil
 	}
+
+	if typeRequiresCopying(fromProp.PropertyType()) {
+		// We can't get away with just assigning this field, since
+		// it's a reference type. Use the conversion code to copy the
+		// elements.
+		source := &ast.SelectorExpr{
+			X:   builder.receiverIdent,
+			Sel: ast.NewIdent(string(toProp.PropertyName())),
+		}
+		destination := &ast.SelectorExpr{
+			X:   builder.resultIdent,
+			Sel: ast.NewIdent(string(toProp.PropertyName())),
+		}
+		return builder.toArmComplexPropertyConversion(
+			complexPropertyConversionParameters{
+				source:            source,
+				destination:       destination,
+				destinationType:   toProp.PropertyType(),
+				nameHint:          string(toProp.PropertyName()),
+				conversionContext: nil,
+				assignmentHandler: assignmentHandlerAssign,
+				sameTypes:         true,
+			},
+		)
+	}
+
 	result := astbuilder.SimpleAssignment(
 		&ast.SelectorExpr{
 			X:   builder.resultIdent,
@@ -242,7 +268,15 @@ func (builder *convertToArmBuilder) toArmComplexPropertyConversion(
 	case *astmodel.MapType:
 		return builder.convertComplexMapProperty(params)
 	case astmodel.TypeName:
+		if params.sameTypes {
+			// The only type names we leave alone are enums, which
+			// don't need conversion.
+			return builder.assignPrimitiveType(params)
+		}
 		return builder.convertComplexTypeNameProperty(params)
+	case *astmodel.PrimitiveType:
+		// No conversion needed in this case.
+		return builder.assignPrimitiveType(params)
 	default:
 		panic(fmt.Sprintf("don't know how to perform toArm conversion for type: %T", params.destinationType))
 	}
@@ -254,6 +288,15 @@ func assignmentHandlerDefine(lhs ast.Expr, rhs ast.Expr) ast.Stmt {
 
 func assignmentHandlerAssign(lhs ast.Expr, rhs ast.Expr) ast.Stmt {
 	return astbuilder.SimpleAssignment(lhs, token.ASSIGN, rhs)
+}
+
+// assignPrimitiveType just assigns source to destination directly,
+// no conversion needed.
+func (builder *convertToArmBuilder) assignPrimitiveType(
+	params complexPropertyConversionParameters) []ast.Stmt {
+	return []ast.Stmt{
+		params.assignmentHandler(params.destination, params.source),
+	}
 }
 
 // convertComplexOptionalProperty handles conversion for optional properties with complex elements
@@ -270,11 +313,17 @@ func (builder *convertToArmBuilder) convertComplexOptionalProperty(
 	tempVarIdent := ast.NewIdent(builder.idFactory.CreateIdentifier(params.nameHint+"Typed", astmodel.NotExported))
 	tempVarType := destinationType.Element()
 
+	newSource := &ast.UnaryExpr{
+		X:  params.source,
+		Op: token.MUL,
+	}
+
 	innerStatements := builder.toArmComplexPropertyConversion(
 		params.withDestination(tempVarIdent).
 			withDestinationType(tempVarType).
 			withAdditionalConversionContext(destinationType).
-			withAssignmentHandler(assignmentHandlerDefine))
+			withAssignmentHandler(assignmentHandlerDefine).
+			withSource(newSource))
 
 	// Tack on the final assignment
 	innerStatements = append(
@@ -334,6 +383,7 @@ func (builder *convertToArmBuilder) convertComplexArrayProperty(
 			nameHint:          elemIdent.Name,
 			conversionContext: append(params.conversionContext, destinationType),
 			assignmentHandler: assignmentHandlerDefine,
+			sameTypes:         params.sameTypes,
 		})
 
 	// Append the final statement
@@ -392,6 +442,7 @@ func (builder *convertToArmBuilder) convertComplexMapProperty(
 			nameHint:          elemIdent.Name,
 			conversionContext: append(params.conversionContext, destinationType),
 			assignmentHandler: assignmentHandlerDefine,
+			sameTypes:         params.sameTypes,
 		})
 
 	// Append the final statement
@@ -497,4 +548,12 @@ func callToArmFunction(source ast.Expr, destination ast.Expr, methodName string)
 	results = append(results, astbuilder.CheckErrorAndReturn(ast.NewIdent("nil")))
 
 	return results
+}
+
+func typeRequiresCopying(theType astmodel.Type) bool {
+	switch theType.(type) {
+	case *astmodel.OptionalType, *astmodel.MapType, *astmodel.ArrayType:
+		return true
+	}
+	return false
 }

--- a/hack/generator/pkg/astmodel/armconversion/convert_to_arm_function_builder.go
+++ b/hack/generator/pkg/astmodel/armconversion/convert_to_arm_function_builder.go
@@ -465,19 +465,7 @@ func (builder *convertToArmBuilder) convertComplexMapProperty(
 		},
 	}
 
-	result := &ast.IfStmt{
-		Cond: &ast.BinaryExpr{
-			X:  params.source,
-			Op: token.NEQ,
-			Y:  ast.NewIdent("nil"),
-		},
-		Body: &ast.BlockStmt{
-			List: []ast.Stmt{
-				rangeStatement,
-			},
-		},
-	}
-	return []ast.Stmt{makeMapStatement, result}
+	return []ast.Stmt{makeMapStatement, rangeStatement}
 }
 
 // convertComplexTypeNameProperty handles conversion of complex TypeName properties.

--- a/hack/generator/pkg/astmodel/armconversion/shared.go
+++ b/hack/generator/pkg/astmodel/armconversion/shared.go
@@ -129,7 +129,12 @@ type complexPropertyConversionParameters struct {
 	destinationType   astmodel.Type
 	nameHint          string
 	conversionContext []astmodel.Type
-	assignmentHandler func(result ast.Expr, destination ast.Expr) ast.Stmt
+	assignmentHandler func(destination, source ast.Expr) ast.Stmt
+
+	// sameTypes indicates that the source and destination types are
+	// the same, so no conversion between Arm and non-Arm types is
+	// required (although structure copying is).
+	sameTypes bool
 }
 
 func (params complexPropertyConversionParameters) copy() complexPropertyConversionParameters {

--- a/hack/generator/pkg/codegen/testdata/ArmResource/Arm_test_simple_resource_array_properties.golden
+++ b/hack/generator/pkg/codegen/testdata/ArmResource/Arm_test_simple_resource_array_properties.golden
@@ -133,18 +133,19 @@ func (fakeResourceSpec *FakeResource_Spec) ConvertToArm(name string) (interface{
 		}
 		result.ArrayOfArrays = append(result.ArrayOfArrays, elemTyped)
 	}
-	result.ArrayOfEnums = fakeResourceSpec.ArrayOfEnums
+	for _, item := range fakeResourceSpec.ArrayOfEnums {
+		elemTyped := item
+		result.ArrayOfEnums = append(result.ArrayOfEnums, elemTyped)
+	}
 	for _, item := range fakeResourceSpec.ArrayOfMaps {
 		elemTyped := make(map[string]FooArm)
-		if item != nil {
-			for key, value := range item {
-				elem, err := value.ConvertToArm(name)
-				if err != nil {
-					return nil, err
-				}
-				elemTyped1 := elem.(FooArm)
-				elemTyped[key] = elemTyped1
+		for key, value := range item {
+			elem, err := value.ConvertToArm(name)
+			if err != nil {
+				return nil, err
 			}
+			elemTyped1 := elem.(FooArm)
+			elemTyped[key] = elemTyped1
 		}
 		result.ArrayOfMaps = append(result.ArrayOfMaps, elemTyped)
 	}
@@ -181,7 +182,9 @@ func (fakeResourceSpec *FakeResource_Spec) PopulateFromArm(owner genruntime.Know
 		}
 		fakeResourceSpec.ArrayOfArrays = append(fakeResourceSpec.ArrayOfArrays, elem)
 	}
-	fakeResourceSpec.ArrayOfEnums = typedInput.ArrayOfEnums
+	for _, item := range typedInput.ArrayOfEnums {
+		fakeResourceSpec.ArrayOfEnums = append(fakeResourceSpec.ArrayOfEnums, item)
+	}
 	for _, item := range typedInput.ArrayOfMaps {
 		if item != nil {
 			elem := make(map[string]Foo)
@@ -219,7 +222,10 @@ func (foo *Foo) ConvertToArm(name string) (interface{}, error) {
 		return nil, nil
 	}
 	result := FooArm{}
-	result.Name = foo.Name
+	if foo.Name != nil {
+		nameTyped := *foo.Name
+		result.Name = &nameTyped
+	}
 	return result, nil
 }
 
@@ -229,7 +235,10 @@ func (foo *Foo) PopulateFromArm(owner genruntime.KnownResourceReference, armInpu
 	if !ok {
 		return fmt.Errorf("unexpected type supplied for PopulateFromArm() function. Expected FooArm, got %T", armInput)
 	}
-	foo.Name = typedInput.Name
+	if typedInput.Name != nil {
+		nameTyped := *typedInput.Name
+		foo.Name = &nameTyped
+	}
 	return nil
 }
 func init() {

--- a/hack/generator/pkg/codegen/testdata/ArmResource/Arm_test_simple_resource_complex_properties.golden
+++ b/hack/generator/pkg/codegen/testdata/ArmResource/Arm_test_simple_resource_complex_properties.golden
@@ -110,7 +110,10 @@ func (fakeResourceSpec *FakeResource_Spec) ConvertToArm(name string) (interface{
 	}
 	result := FakeResource_SpecArm{}
 	result.ApiVersion = fakeResourceSpec.ApiVersion
-	result.Color = fakeResourceSpec.Color
+	if fakeResourceSpec.Color != nil {
+		colorTyped := *fakeResourceSpec.Color
+		result.Color = &colorTyped
+	}
 	foo, err := fakeResourceSpec.Foo.ConvertToArm(name)
 	if err != nil {
 		return nil, err
@@ -118,7 +121,7 @@ func (fakeResourceSpec *FakeResource_Spec) ConvertToArm(name string) (interface{
 	result.Foo = foo.(FooArm)
 	result.Name = name
 	if fakeResourceSpec.OptionalFoo != nil {
-		optionalFoo, err := fakeResourceSpec.OptionalFoo.ConvertToArm(name)
+		optionalFoo, err := (*fakeResourceSpec.OptionalFoo).ConvertToArm(name)
 		if err != nil {
 			return nil, err
 		}
@@ -137,7 +140,10 @@ func (fakeResourceSpec *FakeResource_Spec) PopulateFromArm(owner genruntime.Know
 	}
 	fakeResourceSpec.ApiVersion = typedInput.ApiVersion
 	fakeResourceSpec.AzureName = genruntime.ExtractKubernetesResourceNameFromArmName(typedInput.Name)
-	fakeResourceSpec.Color = typedInput.Color
+	if typedInput.Color != nil {
+		colorTyped := *typedInput.Color
+		fakeResourceSpec.Color = &colorTyped
+	}
 	var err error
 	foo := Foo{}
 	err = foo.PopulateFromArm(owner, typedInput.Foo)
@@ -151,7 +157,8 @@ func (fakeResourceSpec *FakeResource_Spec) PopulateFromArm(owner genruntime.Know
 		if err != nil {
 			return err
 		}
-		fakeResourceSpec.OptionalFoo = &optionalFoo
+		optionalFooTyped := optionalFoo
+		fakeResourceSpec.OptionalFoo = &optionalFooTyped
 	}
 	fakeResourceSpec.Owner = owner
 	return nil
@@ -175,7 +182,10 @@ func (foo *Foo) ConvertToArm(name string) (interface{}, error) {
 		return nil, nil
 	}
 	result := FooArm{}
-	result.Name = foo.Name
+	if foo.Name != nil {
+		nameTyped := *foo.Name
+		result.Name = &nameTyped
+	}
 	return result, nil
 }
 
@@ -185,7 +195,10 @@ func (foo *Foo) PopulateFromArm(owner genruntime.KnownResourceReference, armInpu
 	if !ok {
 		return fmt.Errorf("unexpected type supplied for PopulateFromArm() function. Expected FooArm, got %T", armInput)
 	}
-	foo.Name = typedInput.Name
+	if typedInput.Name != nil {
+		nameTyped := *typedInput.Name
+		foo.Name = &nameTyped
+	}
 	return nil
 }
 func init() {

--- a/hack/generator/pkg/codegen/testdata/ArmResource/Arm_test_simple_resource_map_properties.golden
+++ b/hack/generator/pkg/codegen/testdata/ArmResource/Arm_test_simple_resource_map_properties.golden
@@ -39,13 +39,14 @@ type FakeResourceList struct {
 }
 
 type FakeResource_SpecArm struct {
-	ApiVersion  FakeResourceSpecApiVersion   `json:"apiVersion"`
-	MapFoo      map[string]FooArm            `json:"mapFoo"`
-	MapOfArrays map[string][]FooArm          `json:"mapOfArrays,omitempty"`
-	MapOfEnums  map[string]Color             `json:"mapOfEnums,omitempty"`
-	MapOfMaps   map[string]map[string]FooArm `json:"mapOfMaps,omitempty"`
-	Name        string                       `json:"name"`
-	Type        FakeResourceSpecType         `json:"type"`
+	ApiVersion   FakeResourceSpecApiVersion   `json:"apiVersion"`
+	MapFoo       map[string]FooArm            `json:"mapFoo"`
+	MapOfArrays  map[string][]FooArm          `json:"mapOfArrays,omitempty"`
+	MapOfEnums   map[string]Color             `json:"mapOfEnums,omitempty"`
+	MapOfMaps    map[string]map[string]FooArm `json:"mapOfMaps,omitempty"`
+	MapOfStrings map[string]string            `json:"mapOfStrings,omitempty"`
+	Name         string                       `json:"name"`
+	Type         FakeResourceSpecType         `json:"type"`
 }
 
 var _ genruntime.ArmResourceSpec = &FakeResource_SpecArm{}
@@ -95,10 +96,11 @@ type FakeResource_Spec struct {
 	AzureName string `json:"azureName"`
 
 	// +kubebuilder:validation:Required
-	MapFoo      map[string]Foo            `json:"mapFoo"`
-	MapOfArrays map[string][]Foo          `json:"mapOfArrays,omitempty"`
-	MapOfEnums  map[string]Color          `json:"mapOfEnums,omitempty"`
-	MapOfMaps   map[string]map[string]Foo `json:"mapOfMaps,omitempty"`
+	MapFoo       map[string]Foo            `json:"mapFoo"`
+	MapOfArrays  map[string][]Foo          `json:"mapOfArrays,omitempty"`
+	MapOfEnums   map[string]Color          `json:"mapOfEnums,omitempty"`
+	MapOfMaps    map[string]map[string]Foo `json:"mapOfMaps,omitempty"`
+	MapOfStrings map[string]string         `json:"mapOfStrings,omitempty"`
 
 	// +kubebuilder:validation:Required
 	Owner genruntime.KnownResourceReference `group:"microsoft.resources.infra.azure.com" json:"owner" kind:"ResourceGroup"`
@@ -139,7 +141,13 @@ func (fakeResourceSpec *FakeResource_Spec) ConvertToArm(name string) (interface{
 			result.MapOfArrays[key] = elemTyped
 		}
 	}
-	result.MapOfEnums = fakeResourceSpec.MapOfEnums
+	result.MapOfEnums = make(map[string]Color)
+	if fakeResourceSpec.MapOfEnums != nil {
+		for key, value := range fakeResourceSpec.MapOfEnums {
+			elemTyped := value
+			result.MapOfEnums[key] = elemTyped
+		}
+	}
 	result.MapOfMaps = make(map[string]map[string]FooArm)
 	if fakeResourceSpec.MapOfMaps != nil {
 		for key, value := range fakeResourceSpec.MapOfMaps {
@@ -155,6 +163,13 @@ func (fakeResourceSpec *FakeResource_Spec) ConvertToArm(name string) (interface{
 				}
 			}
 			result.MapOfMaps[key] = elemTyped
+		}
+	}
+	result.MapOfStrings = make(map[string]string)
+	if fakeResourceSpec.MapOfStrings != nil {
+		for key, value := range fakeResourceSpec.MapOfStrings {
+			elemTyped := value
+			result.MapOfStrings[key] = elemTyped
 		}
 	}
 	result.Name = name
@@ -197,7 +212,12 @@ func (fakeResourceSpec *FakeResource_Spec) PopulateFromArm(owner genruntime.Know
 			fakeResourceSpec.MapOfArrays[key] = elem
 		}
 	}
-	fakeResourceSpec.MapOfEnums = typedInput.MapOfEnums
+	if typedInput.MapOfEnums != nil {
+		fakeResourceSpec.MapOfEnums = make(map[string]Color)
+		for key, value := range typedInput.MapOfEnums {
+			fakeResourceSpec.MapOfEnums[key] = value
+		}
+	}
 	if typedInput.MapOfMaps != nil {
 		fakeResourceSpec.MapOfMaps = make(map[string]map[string]Foo)
 		for key, value := range typedInput.MapOfMaps {
@@ -213,6 +233,12 @@ func (fakeResourceSpec *FakeResource_Spec) PopulateFromArm(owner genruntime.Know
 				}
 				fakeResourceSpec.MapOfMaps[key] = elem
 			}
+		}
+	}
+	if typedInput.MapOfStrings != nil {
+		fakeResourceSpec.MapOfStrings = make(map[string]string)
+		for key, value := range typedInput.MapOfStrings {
+			fakeResourceSpec.MapOfStrings[key] = value
 		}
 	}
 	fakeResourceSpec.Owner = owner
@@ -237,7 +263,10 @@ func (foo *Foo) ConvertToArm(name string) (interface{}, error) {
 		return nil, nil
 	}
 	result := FooArm{}
-	result.FooName = foo.FooName
+	if foo.FooName != nil {
+		fooNameTyped := *foo.FooName
+		result.FooName = &fooNameTyped
+	}
 	return result, nil
 }
 
@@ -247,7 +276,10 @@ func (foo *Foo) PopulateFromArm(owner genruntime.KnownResourceReference, armInpu
 	if !ok {
 		return fmt.Errorf("unexpected type supplied for PopulateFromArm() function. Expected FooArm, got %T", armInput)
 	}
-	foo.FooName = typedInput.FooName
+	if typedInput.FooName != nil {
+		fooNameTyped := *typedInput.FooName
+		foo.FooName = &fooNameTyped
+	}
 	return nil
 }
 func init() {

--- a/hack/generator/pkg/codegen/testdata/ArmResource/Arm_test_simple_resource_map_properties.golden
+++ b/hack/generator/pkg/codegen/testdata/ArmResource/Arm_test_simple_resource_map_properties.golden
@@ -116,61 +116,49 @@ func (fakeResourceSpec *FakeResource_Spec) ConvertToArm(name string) (interface{
 	result := FakeResource_SpecArm{}
 	result.ApiVersion = fakeResourceSpec.ApiVersion
 	result.MapFoo = make(map[string]FooArm)
-	if fakeResourceSpec.MapFoo != nil {
-		for key, value := range fakeResourceSpec.MapFoo {
+	for key, value := range fakeResourceSpec.MapFoo {
+		elem, err := value.ConvertToArm(name)
+		if err != nil {
+			return nil, err
+		}
+		elemTyped := elem.(FooArm)
+		result.MapFoo[key] = elemTyped
+	}
+	result.MapOfArrays = make(map[string][]FooArm)
+	for key, value := range fakeResourceSpec.MapOfArrays {
+		var elemTyped []FooArm
+		for _, item := range value {
+			elem, err := item.ConvertToArm(name)
+			if err != nil {
+				return nil, err
+			}
+			elemTyped1 := elem.(FooArm)
+			elemTyped = append(elemTyped, elemTyped1)
+		}
+		result.MapOfArrays[key] = elemTyped
+	}
+	result.MapOfEnums = make(map[string]Color)
+	for key, value := range fakeResourceSpec.MapOfEnums {
+		elemTyped := value
+		result.MapOfEnums[key] = elemTyped
+	}
+	result.MapOfMaps = make(map[string]map[string]FooArm)
+	for key, value := range fakeResourceSpec.MapOfMaps {
+		elemTyped := make(map[string]FooArm)
+		for key, value := range value {
 			elem, err := value.ConvertToArm(name)
 			if err != nil {
 				return nil, err
 			}
-			elemTyped := elem.(FooArm)
-			result.MapFoo[key] = elemTyped
+			elemTyped1 := elem.(FooArm)
+			elemTyped[key] = elemTyped1
 		}
-	}
-	result.MapOfArrays = make(map[string][]FooArm)
-	if fakeResourceSpec.MapOfArrays != nil {
-		for key, value := range fakeResourceSpec.MapOfArrays {
-			var elemTyped []FooArm
-			for _, item := range value {
-				elem, err := item.ConvertToArm(name)
-				if err != nil {
-					return nil, err
-				}
-				elemTyped1 := elem.(FooArm)
-				elemTyped = append(elemTyped, elemTyped1)
-			}
-			result.MapOfArrays[key] = elemTyped
-		}
-	}
-	result.MapOfEnums = make(map[string]Color)
-	if fakeResourceSpec.MapOfEnums != nil {
-		for key, value := range fakeResourceSpec.MapOfEnums {
-			elemTyped := value
-			result.MapOfEnums[key] = elemTyped
-		}
-	}
-	result.MapOfMaps = make(map[string]map[string]FooArm)
-	if fakeResourceSpec.MapOfMaps != nil {
-		for key, value := range fakeResourceSpec.MapOfMaps {
-			elemTyped := make(map[string]FooArm)
-			if value != nil {
-				for key, value := range value {
-					elem, err := value.ConvertToArm(name)
-					if err != nil {
-						return nil, err
-					}
-					elemTyped1 := elem.(FooArm)
-					elemTyped[key] = elemTyped1
-				}
-			}
-			result.MapOfMaps[key] = elemTyped
-		}
+		result.MapOfMaps[key] = elemTyped
 	}
 	result.MapOfStrings = make(map[string]string)
-	if fakeResourceSpec.MapOfStrings != nil {
-		for key, value := range fakeResourceSpec.MapOfStrings {
-			elemTyped := value
-			result.MapOfStrings[key] = elemTyped
-		}
+	for key, value := range fakeResourceSpec.MapOfStrings {
+		elemTyped := value
+		result.MapOfStrings[key] = elemTyped
 	}
 	result.Name = name
 	result.Type = FakeResourceSpecTypeMicrosoftAzureFakeResource

--- a/hack/generator/pkg/codegen/testdata/ArmResource/Arm_test_simple_resource_map_properties.golden
+++ b/hack/generator/pkg/codegen/testdata/ArmResource/Arm_test_simple_resource_map_properties.golden
@@ -221,12 +221,12 @@ func (fakeResourceSpec *FakeResource_Spec) PopulateFromArm(owner genruntime.Know
 
 //Generated from: https://test.test/schemas/2020-01-01/test.json#/definitions/Foo
 type FooArm struct {
-	Name *string `json:"name,omitempty"`
+	FooName *string `json:"fooName,omitempty"`
 }
 
 //Generated from: https://test.test/schemas/2020-01-01/test.json#/definitions/Foo
 type Foo struct {
-	Name *string `json:"name,omitempty"`
+	FooName *string `json:"fooName,omitempty"`
 }
 
 var _ genruntime.ArmTransformer = &Foo{}
@@ -237,7 +237,7 @@ func (foo *Foo) ConvertToArm(name string) (interface{}, error) {
 		return nil, nil
 	}
 	result := FooArm{}
-	result.Name = foo.Name
+	result.FooName = foo.FooName
 	return result, nil
 }
 
@@ -247,7 +247,7 @@ func (foo *Foo) PopulateFromArm(owner genruntime.KnownResourceReference, armInpu
 	if !ok {
 		return fmt.Errorf("unexpected type supplied for PopulateFromArm() function. Expected FooArm, got %T", armInput)
 	}
-	foo.Name = typedInput.Name
+	foo.FooName = typedInput.FooName
 	return nil
 }
 func init() {

--- a/hack/generator/pkg/codegen/testdata/ArmResource/Arm_test_simple_resource_map_properties.json
+++ b/hack/generator/pkg/codegen/testdata/ArmResource/Arm_test_simple_resource_map_properties.json
@@ -72,7 +72,7 @@
         "Foo": {
             "type": "object",
             "properties": {
-                "name": {
+                "fooName": {
                     "type": "string"
                 }
             }

--- a/hack/generator/pkg/codegen/testdata/ArmResource/Arm_test_simple_resource_map_properties.json
+++ b/hack/generator/pkg/codegen/testdata/ArmResource/Arm_test_simple_resource_map_properties.json
@@ -58,6 +58,12 @@
                     "additionalProperties": {
                         "$ref":  "#/definitions/Color"
                     }
+                },
+                "mapOfStrings": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "string"
+                    }
                 }
             },
             "required": [


### PR DESCRIPTION
Before this some of the fields in a converted object were deepcopied in the process of converting the generated types to their ARM equivalents but other reference-type fields (maps/arrays/optionals of enums or primitive types) would be shared between the ARM object and the kubernetes one. That seems a lot more error-prone - it would be easy to inadvertently update some shared data because we'd been lulled into a false sense of security by the other fields that weren't shared.

Fixes #286.