### PR TITLE
Mark storage version as part of pipeline

### DIFF
--- a/hack/generator/pkg/codegen/code_generator.go
+++ b/hack/generator/pkg/codegen/code_generator.go
@@ -86,6 +86,8 @@ func corePipelineStages(idFactory astmodel.IdentifierFactory, configuration *con
 		createStorageTypes(),
 		simplifyDefinitions(),
 
+		markStorageVersion(),
+
 		// Safety checks at the end:
 		ensureDefinitionsDoNotUseAnyTypes(),
 		checkForMissingStatusInformation(),

--- a/hack/generator/pkg/codegen/pipeline_mark_storage_version.go
+++ b/hack/generator/pkg/codegen/pipeline_mark_storage_version.go
@@ -1,0 +1,109 @@
+/*
+ * Copyright (c) Microsoft Corporation.
+ * Licensed under the MIT license.
+ */
+
+package codegen
+
+import (
+	"context"
+	"sort"
+
+	"github.com/pkg/errors"
+
+	"github.com/Azure/k8s-infra/hack/generator/pkg/astmodel"
+)
+
+// markStorageVersion creates a PipelineStage to mark a particular version as a storage version
+func markStorageVersion() PipelineStage {
+	return MakePipelineStage(
+		"markStorageVersion",
+		"Marking the latest version of each resource as the storage version",
+		func(ctx context.Context, types astmodel.Types) (astmodel.Types, error) {
+			updatedDefs, err := MarkLatestResourceVersionsForStorage(types)
+			if err != nil {
+				return nil, errors.Wrapf(err, "unable to mark latest resource version as storage version")
+			}
+
+			return updatedDefs, nil
+		})
+}
+
+// MarkLatestResourceVersionsForStorage marks the latest version of each resource as the storage version
+func MarkLatestResourceVersionsForStorage(types astmodel.Types) (astmodel.Types, error) {
+
+	result := make(astmodel.Types)
+	resourceLookup, err := groupResourcesByVersion(types)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, def := range types {
+		// see if it is a resource
+		if resourceType, ok := def.Type().(*astmodel.ResourceType); ok {
+
+			unversionedName, err := getUnversionedName(def.Name())
+			if err != nil {
+				// should never happen as all resources have versioned names
+				return nil, err
+			}
+
+			allVersionsOfResource := resourceLookup[unversionedName]
+			latestVersionOfResource := allVersionsOfResource[len(allVersionsOfResource)-1]
+
+			thisPackagePath := def.Name().PackageReference.PackagePath()
+			latestPackagePath := latestVersionOfResource.Name().PackageReference.PackagePath()
+
+			// mark as storage version if it's the latest version
+			isLatestVersion := thisPackagePath == latestPackagePath
+			if isLatestVersion {
+				def = astmodel.MakeTypeDefinition(def.Name(), resourceType.MarkAsStorageVersion()).
+					WithDescription(def.Description())
+			}
+		}
+		result.Add(def)
+	}
+
+	return result, nil
+}
+
+func groupResourcesByVersion(types astmodel.Types) (map[unversionedName][]astmodel.TypeDefinition, error) {
+
+	result := make(map[unversionedName][]astmodel.TypeDefinition)
+
+	for _, def := range types {
+		if astmodel.IsResourceDefinition(def) {
+			name, err := getUnversionedName(def.Name())
+			if err != nil {
+				// this should never happen as resources will all have versioned names
+				return nil, errors.Wrapf(err, "Unable to extract unversioned name in groupResources")
+			}
+
+			result[name] = append(result[name], def)
+		}
+	}
+
+	// order each set of resources by package name (== by version as these are sortable dates)
+	for _, slice := range result {
+		sort.Slice(slice, func(i, j int) bool {
+			return slice[i].Name().PackageReference.PackageName() < slice[j].Name().PackageReference.PackageName()
+		})
+	}
+
+	return result, nil
+}
+
+func getUnversionedName(name astmodel.TypeName) (unversionedName, error) {
+
+	if localRef, ok := name.PackageReference.AsLocalPackage(); ok {
+		group := localRef.Group()
+		return unversionedName{group, name.Name()}, nil
+	}
+
+	return unversionedName{}, errors.New("cannot get unversioned name from non-local package")
+}
+
+type unversionedName struct {
+	group string
+	name  string
+}

--- a/hack/generator/pkg/codegen/testdata/ArmResource/Arm_test_dependent_resource_and_ownership.golden
+++ b/hack/generator/pkg/codegen/testdata/ArmResource/Arm_test_dependent_resource_and_ownership.golden
@@ -10,6 +10,7 @@ import (
 )
 
 // +kubebuilder:object:root=true
+// +kubebuilder:storageversion
 //Generated from: https://test.test/schemas/2020-01-01/test.json#/resourceDefinitions/A
 type A struct {
 	metav1.TypeMeta   `json:",inline"`
@@ -62,6 +63,7 @@ func (aSpecArm A_SpecArm) GetType() string {
 }
 
 // +kubebuilder:object:root=true
+// +kubebuilder:storageversion
 //Generated from: https://test.test/schemas/2020-01-01/test.json#/resourceDefinitions/B
 type B struct {
 	metav1.TypeMeta   `json:",inline"`
@@ -114,6 +116,7 @@ func (bSpecArm B_SpecArm) GetType() string {
 }
 
 // +kubebuilder:object:root=true
+// +kubebuilder:storageversion
 //Generated from: https://test.test/schemas/2020-01-01/test.json#/resourceDefinitions/C
 type C struct {
 	metav1.TypeMeta   `json:",inline"`

--- a/hack/generator/pkg/codegen/testdata/ArmResource/Arm_test_simple_resource_array_properties.golden
+++ b/hack/generator/pkg/codegen/testdata/ArmResource/Arm_test_simple_resource_array_properties.golden
@@ -10,6 +10,7 @@ import (
 )
 
 // +kubebuilder:object:root=true
+// +kubebuilder:storageversion
 //Generated from: https://test.test/schemas/2020-01-01/test.json#/resourceDefinitions/FakeResource
 type FakeResource struct {
 	metav1.TypeMeta   `json:",inline"`

--- a/hack/generator/pkg/codegen/testdata/ArmResource/Arm_test_simple_resource_complex_properties.golden
+++ b/hack/generator/pkg/codegen/testdata/ArmResource/Arm_test_simple_resource_complex_properties.golden
@@ -10,6 +10,7 @@ import (
 )
 
 // +kubebuilder:object:root=true
+// +kubebuilder:storageversion
 //Generated from: https://test.test/schemas/2020-01-01/test.json#/resourceDefinitions/FakeResource
 type FakeResource struct {
 	metav1.TypeMeta   `json:",inline"`

--- a/hack/generator/pkg/codegen/testdata/ArmResource/Arm_test_simple_resource_map_properties.golden
+++ b/hack/generator/pkg/codegen/testdata/ArmResource/Arm_test_simple_resource_map_properties.golden
@@ -10,6 +10,7 @@ import (
 )
 
 // +kubebuilder:object:root=true
+// +kubebuilder:storageversion
 //Generated from: https://test.test/schemas/2020-01-01/test.json#/resourceDefinitions/FakeResource
 type FakeResource struct {
 	metav1.TypeMeta   `json:",inline"`

--- a/hack/generator/pkg/codegen/testdata/ArmResource/Arm_test_simple_resource_renders_spec.golden
+++ b/hack/generator/pkg/codegen/testdata/ArmResource/Arm_test_simple_resource_renders_spec.golden
@@ -10,6 +10,7 @@ import (
 )
 
 // +kubebuilder:object:root=true
+// +kubebuilder:storageversion
 //Generated from: https://test.test/schemas/2020-01-01/test.json#/resourceDefinitions/FakeResource
 type FakeResource struct {
 	metav1.TypeMeta   `json:",inline"`

--- a/hack/generator/pkg/codegen/testdata/EmbeddedTypes/Embedded_type_simple_resource.golden
+++ b/hack/generator/pkg/codegen/testdata/EmbeddedTypes/Embedded_type_simple_resource.golden
@@ -10,6 +10,7 @@ import (
 )
 
 // +kubebuilder:object:root=true
+// +kubebuilder:storageversion
 //Generated from: https://test.test/schemas/2020-01-01/test.json#/resourceDefinitions/FakeResource
 type FakeResource struct {
 	metav1.TypeMeta   `json:",inline"`


### PR DESCRIPTION
- This makes the golden tests more accurate as we can shim output without also losing storage versions.