### PR TITLE
Derive the JSON omitempty annotation directly from the property type

### DIFF
--- a/hack/generator/pkg/codegen/testdata/EmbeddedTypes/Embedded_type_simple_resource.golden
+++ b/hack/generator/pkg/codegen/testdata/EmbeddedTypes/Embedded_type_simple_resource.golden
@@ -43,7 +43,7 @@ type FakeResource_SpecArm struct {
 	ApiVersion       FakeResourceSpecApiVersion `json:"apiVersion"`
 	Color            *FakeResourceSpecColor     `json:"color,omitempty"`
 	Foo              FooArm                     `json:"foo"`
-	Name             string                     `json:"name"`
+	Name             string                     `json:"name,omitempty"`
 	OptionalFoo      *FooArm                    `json:"optionalFoo,omitempty"`
 	Type             FakeResourceSpecType       `json:"type"`
 }
@@ -92,7 +92,7 @@ type FakeResource_Spec struct {
 
 	//AzureName: The name of the resource in Azure. This is often the same as the name
 	//of the resource in Kubernetes but it doesn't have to be.
-	AzureName string                 `json:"azureName"`
+	AzureName string                 `json:"azureName,omitempty"`
 	Color     *FakeResourceSpecColor `json:"color,omitempty"`
 
 	// +kubebuilder:validation:Required


### PR DESCRIPTION
At the moment we've tightly coupled use of the `omitempty` JSON tag with configuration of whether the property is optional or mandatory in the JSON schema. This is causing issues where sometimes we don't round-trip via JSON with sufficient fidelity.

For example, an uninitialized slice differs from an empty slice, with different serializations:
```
// Uninitialized slice
{"Items":null}

// Initialized with zero items
{"Items":[]}
```

Unfortunately, if `omitempty` is specified, these both serialize by omitting the tag completely:
```
// Uninitialized slice
{}

// Initialized with zero items
{}
```

We need to keep the separate representations so that we can submit the right things to ARM. This also has the benefit of making our round-trip tests work without needing any kludges.
