### PR TITLE
Exclude certain ResourceBase properties

### DIFF
--- a/hack/generator/azure-arm.yaml
+++ b/hack/generator/azure-arm.yaml
@@ -141,6 +141,41 @@ typeTransformers:
     remove: true
     because: it has no writable properties in swagger
 
+  - name: "*"
+    property: Condition
+    ifType:
+      name: bool
+      optional: true
+    remove: true
+    because: It exists on ARMResource but doesn't make sense in the context of a CRD
+  - name: "*"
+    property: Copy
+    ifType:
+      group: deploymenttemplate
+      version: v20150101
+      name: ResourceCopy
+      optional: true
+    remove: true
+    because: It exists on ARMResource but doesn't make sense in the context of a CRD
+  - name: "*"
+    property: DependsOn
+    remove: true
+    because: It exists on ARMResource but doesn't make sense in the context of a CRD
+  - name: "*"
+    property: Scope
+    ifType:
+      name: string
+      optional: true
+    remove: true
+    because: It exists on ARMResource but doesn't make sense in the context of a CRD
+  - name: "*"
+    property: Comments
+    ifType:
+      name: string
+      optional: true
+    remove: true
+    because: It exists on ARMResource but doesn't make sense in the context of a CRD
+
 status:
   schemaRoot: "./azure-rest-api-specs/specification"
 

--- a/hack/generator/pkg/codegen/pipeline_apply_property_rewrites.go
+++ b/hack/generator/pkg/codegen/pipeline_apply_property_rewrites.go
@@ -8,9 +8,10 @@ package codegen
 import (
 	"context"
 
+	"k8s.io/klog/v2"
+
 	"github.com/Azure/k8s-infra/hack/generator/pkg/astmodel"
 	"github.com/Azure/k8s-infra/hack/generator/pkg/config"
-	"k8s.io/klog/v2"
 )
 
 // applyPropertyRewrites applies any typeTransformers for properties.
@@ -32,8 +33,8 @@ func applyPropertyRewrites(config *config.Configuration) PipelineStage {
 					continue
 				}
 
-				transformation := config.TransformTypeProperties(name, objectType)
-				if transformation != nil {
+				transformations := config.TransformTypeProperties(name, objectType)
+				for _, transformation := range transformations {
 					klog.V(2).Infof("Transforming %s", transformation)
 					objectType = transformation.NewType
 				}

--- a/hack/generator/pkg/config/configuration.go
+++ b/hack/generator/pkg/config/configuration.go
@@ -207,16 +207,20 @@ func (config *Configuration) TransformType(name astmodel.TypeName) (astmodel.Typ
 }
 
 // TransformTypeProperties applies any property transformers to the type
-func (config *Configuration) TransformTypeProperties(name astmodel.TypeName, objectType *astmodel.ObjectType) *PropertyTransformResult {
+func (config *Configuration) TransformTypeProperties(name astmodel.TypeName, objectType *astmodel.ObjectType) []*PropertyTransformResult {
+
+	var results []*PropertyTransformResult
+	toTransform := objectType
 
 	for _, transformer := range config.propertyTransformers {
-		result := transformer.TransformProperty(name, objectType)
+		result := transformer.TransformProperty(name, toTransform)
 		if result != nil {
-			return result
+			toTransform = result.NewType
+			results = append(results, result)
 		}
 	}
 
-	return nil
+	return results
 }
 
 // StatusConfiguration provides configuration options for the


### PR DESCRIPTION
  - There are some properties that don't make sense in the context
    of CRDs.
  - Fix a bug with property transformers that caused them to only
    apply the first matching transformer.