### PR TITLE
Force ordering of imports

### DIFF
--- a/hack/generator/pkg/astmodel/file_definition.go
+++ b/hack/generator/pkg/astmodel/file_definition.go
@@ -166,11 +166,27 @@ func (file *FileDefinition) generateImports() *PackageImportSet {
 
 func (file *FileDefinition) generateImportSpecs(imports *PackageImportSet) []ast.Spec {
 	var importSpecs []ast.Spec
-	for _, requiredImport := range imports.AsSlice() {
+	for _, requiredImport := range imports.AsSortedSlice(file.orderImports) {
 		importSpecs = append(importSpecs, requiredImport.AsImportSpec())
 	}
 
 	return importSpecs
+}
+
+func (file *FileDefinition) orderImports(i PackageImport, j PackageImport) bool {
+	if i.HasExplicitName() && j.HasExplicitName() {
+		return i.name < j.name
+	}
+
+	if i.HasExplicitName() {
+		return true
+	}
+
+	if j.HasExplicitName() {
+		return false
+	}
+
+	return i.packageReference.String() < j.packageReference.String()
 }
 
 // AsAst generates an AST node representing this file

--- a/hack/generator/pkg/astmodel/file_definition_test.go
+++ b/hack/generator/pkg/astmodel/file_definition_test.go
@@ -241,6 +241,55 @@ func Test_CalcRanks_GivenDiamondWithReverseBar_AssignRanksInOrder(t *testing.T) 
 }
 
 /*
+ * orderImports() tests
+ */
+
+func TestFileDefinitionOrderImports(t *testing.T) {
+
+	alphaRef := MakeExternalPackageReference("alpha")
+	betaRef := MakeExternalPackageReference("beta")
+
+	alphaImport := NewPackageImport(alphaRef)
+	betaImport := NewPackageImport(betaRef)
+
+	alphaImportWithName := alphaImport.WithName("alpha")
+	betaImportWithName := betaImport.WithName("beta")
+
+	cases := []struct {
+		name  string
+		left  PackageImport
+		right PackageImport
+		less  bool
+	}{
+		{"Anonymous imports are alphabetical (i)", alphaImport, betaImport, true},
+		{"Anonymous imports are alphabetical (ii)", betaImport, alphaImport, false},
+		{"Named imports are alphabetical (i)", alphaImportWithName, betaImportWithName, true},
+		{"Named imports are alphabetical (ii)", betaImportWithName, alphaImportWithName, false},
+		{"Named imports come before anonymous (i)", alphaImportWithName, alphaImport, true},
+		{"Named imports come before anonymous (ii)", betaImportWithName, alphaImport, true},
+		{"Named imports come before anonymous (iii)", alphaImportWithName, betaImport, true},
+		{"Named imports come before anonymous (iv)", betaImportWithName, betaImport, true},
+		{"Anonymous imports come after named (i)", alphaImport, alphaImportWithName, false},
+		{"Anonymous imports come after named (ii)", alphaImport, betaImportWithName, false},
+		{"Anonymous imports come after named (iii)", betaImport, alphaImportWithName, false},
+		{"Anonymous imports come after named (iv)", betaImport, betaImportWithName, false},
+	}
+
+	var file FileDefinition
+
+	for _, c := range cases {
+		c := c
+		t.Run(c.name, func(t *testing.T) {
+			t.Parallel()
+			g := NewGomegaWithT(t)
+
+			less := file.orderImports(c.left, c.right)
+			g.Expect(less).To(Equal(c.less))
+		})
+	}
+}
+
+/*
  * Supporting methods
  */
 


### PR DESCRIPTION
@Porges observed that import ordering was non-deterministic, so force things into a particular order.