### PR TITLE
Improve derivation of explicit import names

### DIFF
--- a/hack/generator/pkg/astmodel/package_import_set.go
+++ b/hack/generator/pkg/astmodel/package_import_set.go
@@ -225,9 +225,10 @@ func ByNameInGroups(left PackageImport, right PackageImport) bool {
 	return left.packageReference.String() < right.packageReference.String()
 }
 
-// Extract the last part of the name of the service for use to disambiguate imports
+// Extract a name for the service for use to disambiguate imports
 // E.g. for microsoft.batch/v201700401, extract "batch"
-//      for microsoft.storage/v20200101 extract "storage" and so on
+//      for microsoft.storage/v20200101 extract "storage"
+//      for microsoft.storsimple.1200 extract "storsimple1200" and so on
 func (set *PackageImportSet) ServiceNameForImport(imp PackageImport) string {
 	pathBits := strings.Split(imp.packageReference.PackagePath(), "/")
 	index := len(pathBits) - 1
@@ -236,7 +237,8 @@ func (set *PackageImportSet) ServiceNameForImport(imp PackageImport) string {
 	}
 
 	nameBits := strings.Split(pathBits[index], ".")
-	return nameBits[len(nameBits)-1]
+	result := strings.Join(nameBits[1:], "")
+	return result
 }
 
 // Create a versioned name based on the service for use to disambiguate imports

--- a/hack/generator/pkg/astmodel/package_import_set_test.go
+++ b/hack/generator/pkg/astmodel/package_import_set_test.go
@@ -311,3 +311,43 @@ func TestPackageImportSet_ResolveConflicts_GivenImplicityNamedConflicts_AssignsE
 		})
 	}
 }
+
+/*
+ * ServiceNameForImport() tests
+ */
+
+func TestPackageImportSet_ServiceNameForImport_GivenImport_ReturnsExpectedName(t *testing.T) {
+	cases := []struct {
+		name     string
+		ref      PackageReference
+		expected string
+	}{
+		{
+			"Batch",
+			MakeExternalPackageReference("github.com/Azure/k8s-infra/hack/generated/apis/microsoft.batch/v201700401"),
+			"batch",
+		},
+		{
+			"Storage",
+			MakeExternalPackageReference("github.com/Azure/k8s-infra/hack/generated/apis/microsoft.storage/v20200101"),
+			"storage",
+		},
+		{
+			"StorSimple",
+			MakeExternalPackageReference("github.com/Azure/k8s-infra/hack/generated/apis/microsoft.storsimple.1200/v20161001"),
+			"storsimple1200",
+		},
+	}
+
+	for _, c := range cases {
+		c := c
+		t.Run(c.name, func(t *testing.T) {
+			t.Parallel()
+			g := NewGomegaWithT(t)
+			imp := NewPackageImport(c.ref)
+			set := NewPackageImportSet()
+			name := set.ServiceNameForImport(imp)
+			g.Expect(name).To(Equal(c.expected))
+		})
+	}
+}


### PR DESCRIPTION
@Porges discovered that using the last part of the service name as the explicit name for an import would sometimes give a syntax error because it was a number. 

One example was `github.com/Azure/k8s-infra/hack/generated/apis/microsoft.storsimple.1200/v20161001` becoming `1200`

This PR changes the approach to use the entire service name, without periods (`.`), and without the `microsoft.` prefix.