### PR TITLE
Fix nolint issues

### DIFF
--- a/hack/generated/pkg/testcommon/resource_namer.go
+++ b/hack/generated/pkg/testcommon/resource_namer.go
@@ -35,7 +35,7 @@ func (rnc ResourceNameConfig) NewResourceNamer(testName string) ResourceNamer {
 	seed := hasher.Sum64()
 	return ResourceNamer{
 		ResourceNameConfig: rnc,
-		// nolint: do not want cryptographic randomness here
+		//nolint:gosec // do not want cryptographic randomness here
 		rand: rand.New(rand.NewSource(int64(seed))),
 	}
 }

--- a/hack/generator/main.go
+++ b/hack/generator/main.go
@@ -18,7 +18,7 @@ import (
 func main() {
 	flagSet := goflag.NewFlagSet(os.Args[0], goflag.ExitOnError)
 	klog.InitFlags(flagSet)
-	flagSet.Parse(os.Args[1:]) //nolint: error will never be returned due to ExitOnError
+	flagSet.Parse(os.Args[1:]) //nolint:errcheck // error will never be returned due to ExitOnError
 	flag.CommandLine.AddGoFlagSet(flagSet)
 	cmd.Execute()
 }


### PR DESCRIPTION
Looks like we were not following the rules for how `//nolint` comments work, and a recent update to the linter means these now break the build.

I think the relevant PR is [this one](https://github.com/golangci/golangci-lint/pull/1497).

For reference:

* The comment must start with `//nolint` (no space)
* To suppress a specific linter, use a colon - `//nolint:gosec`
* To provide additional information, follow it with another comment -  
`//nolint:gosec // don't need cryptographic random numbers`