### PR TITLE
Simplification of flagged types by removing flags in pipeline stage

### DIFF
--- a/hack/generator/pkg/astmodel/code_generation_context.go
+++ b/hack/generator/pkg/astmodel/code_generation_context.go
@@ -6,6 +6,7 @@
 package astmodel
 
 import (
+	"fmt"
 	"github.com/pkg/errors"
 )
 
@@ -121,7 +122,8 @@ func (codeGenContext *CodeGenerationContext) GetTypesInPackage(ref PackageRefere
 func (codeGenContext *CodeGenerationContext) GetTypesInCurrentPackage() Types {
 	def, ok := codeGenContext.GetTypesInPackage(codeGenContext.currentPackage)
 	if !ok {
-		panic("Should always have definitions for the current package")
+		msg := fmt.Sprintf("Should always have definitions for the current package %v", codeGenContext.currentPackage)
+		panic(msg)
 	}
 
 	return def

--- a/hack/generator/pkg/astmodel/code_generation_context.go
+++ b/hack/generator/pkg/astmodel/code_generation_context.go
@@ -108,7 +108,13 @@ func (codeGenContext *CodeGenerationContext) GetImportedDefinition(typeName Type
 }
 
 // GetTypesInPackage returns the actual definitions from a specific package
-func (codeGenContext *CodeGenerationContext) GetTypesInPackage(ref PackageReference) (Types, bool) {
+func (codeGenContext *CodeGenerationContext) GetTypesInPackage(packageRef PackageReference) (Types, bool) {
+	ref := packageRef
+	if local, ok := ref.AsLocalPackage(); ok {
+		// Resolve to a local reference if possible
+		ref = local
+	}
+
 	def, ok := codeGenContext.generatedPackages[ref]
 	if !ok {
 		// Package reference not found

--- a/hack/generator/pkg/astmodel/package_reference.go
+++ b/hack/generator/pkg/astmodel/package_reference.go
@@ -14,7 +14,7 @@ const (
 var MetaV1PackageReference = MakeExternalPackageReference("k8s.io/apimachinery/pkg/apis/meta/v1")
 
 type PackageReference interface {
-	// IsLocalPackage returns a valud indicating whether this is a local package
+	// AsLocalPackage attempts conversion to a LocalPackageReference
 	AsLocalPackage() (LocalPackageReference, bool)
 	// Package returns the package name of this reference
 	PackageName() string

--- a/hack/generator/pkg/astmodel/storage_package_reference.go
+++ b/hack/generator/pkg/astmodel/storage_package_reference.go
@@ -5,6 +5,8 @@
 
 package astmodel
 
+import "fmt"
+
 const (
 	StoragePackageSuffix = "storage"
 )
@@ -23,6 +25,11 @@ func MakeStoragePackageReference(local LocalPackageReference) StoragePackageRefe
 			version: local.version + StoragePackageSuffix,
 		},
 	}
+}
+
+// String returns the string representation of the package reference
+func (spr StoragePackageReference) String() string {
+	return fmt.Sprintf("storage:%v", spr.PackagePath())
 }
 
 // IsStoragePackageReference returns true if the reference is to a storage package

--- a/hack/generator/pkg/codegen/pipeline_simplify_definitions.go
+++ b/hack/generator/pkg/codegen/pipeline_simplify_definitions.go
@@ -51,6 +51,12 @@ func createSimplifyingVisitor() astmodel.TypeVisitor {
 		return tv.Visit(&ot, ctx)
 	}
 
+	// Unwrap flagged types, promoting the object within.
+	result.VisitFlaggedType = func(tv *astmodel.TypeVisitor, ft *astmodel.FlaggedType, ctx interface{}) (astmodel.Type, error) {
+		e := ft.Element()
+		return tv.Visit(e, ctx)
+	}
+
 	// Don't need to waste time iterating within complex objects
 	result.VisitObjectType = func(_ *astmodel.TypeVisitor, ot *astmodel.ObjectType, _ interface{}) (astmodel.Type, error) {
 		return ot, nil

--- a/hack/generator/pkg/codegen/pipeline_simplify_definitions_test.go
+++ b/hack/generator/pkg/codegen/pipeline_simplify_definitions_test.go
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) Microsoft Corporation.
+ * Licensed under the MIT license.
+ */
+
+package codegen
+
+import (
+	. "github.com/onsi/gomega"
+
+	"github.com/Azure/k8s-infra/hack/generator/pkg/astmodel"
+	"testing"
+)
+
+func Test_SimplifyDefinitionsPipelineStage_GivenTypes_FlattensToExpectedTypes(t *testing.T) {
+
+	fullName := astmodel.NewPropertyDefinition("FullName", "full-name", astmodel.StringType)
+	familyName := astmodel.NewPropertyDefinition("FamilyName", "family-name", astmodel.StringType)
+	knownAs := astmodel.NewPropertyDefinition("KnownAs", "known-as", astmodel.StringType)
+
+	obj := astmodel.NewObjectType().
+		WithProperties(fullName, familyName, knownAs)
+
+	flagged := astmodel.ArmFlag.ApplyTo(obj)
+
+	cases := []struct {
+		name     string
+		original astmodel.Type
+		expected astmodel.Type
+	}{
+		{"Object Type remains unchanged", obj, obj},
+		{"Flagged type gets simplified", flagged, obj},
+	}
+
+	for _, c := range cases {
+		c := c
+		t.Run(c.name, func(t *testing.T) {
+			g := NewGomegaWithT(t)
+
+			visitor := createSimplifyingVisitor()
+			result, err := visitor.Visit(c.original, nil)
+			g.Expect(err).To(BeNil())
+			g.Expect(result.Equals(c.expected)).To(BeTrue())
+		})
+	}
+}


### PR DESCRIPTION
The simplification stage of the pipeline needs to also remove any flags that are still pending - this should have been done when flagged types were introduced in PR #331 

Also fixes a bug where `GetTypesInPackage()` needs to resolve the provided reference to a `LocalPackageReference` for consistency with the way packages are defined.

Once this is merged, the CI build for PR #333 should pass.