### PR TITLE
Handle panic when writing file

### DIFF
--- a/hack/generator/pkg/astmodel/file_definition.go
+++ b/hack/generator/pkg/astmodel/file_definition.go
@@ -286,7 +286,16 @@ func (file FileDefinition) SaveToFile(filePath string) error {
 		return err
 	}
 
-	defer f.Close()
+	defer func() {
+		f.Close()
+
+		// if we are panicking, the file will be in a broken
+		// state, so remove it
+		if r := recover(); r != nil {
+			os.Remove(filePath)
+			panic(r)
+		}
+	}()
 
 	return file.SaveToWriter(f)
 }


### PR DESCRIPTION
If we panic when writing a file we end up with an empty (or worse) file. The empty file makes `header-check` fail and then you have to manually remove it to re-run any tests you’re doing. So: let’s remove it.