### PR TITLE
Fix issues with generated test cases

### DIFF
--- a/hack/generator/pkg/astmodel/object_type_serialization_test_case.go
+++ b/hack/generator/pkg/astmodel/object_type_serialization_test_case.go
@@ -147,6 +147,7 @@ func (o ObjectSerializationTestCase) RequiredImports() *PackageImportSet {
 	result.AddImportOfReference(DiffReference)
 	result.AddImportOfReference(PrettyReference)
 
+	// Merge references required for properties
 	for _, prop := range o.objectType.Properties() {
 		for _, ref := range prop.PropertyType().RequiredPackageReferences().AsSlice() {
 			result.AddImportOfReference(ref)

--- a/hack/generator/pkg/astmodel/object_type_serialization_test_case.go
+++ b/hack/generator/pkg/astmodel/object_type_serialization_test_case.go
@@ -167,7 +167,7 @@ func (o ObjectSerializationTestCase) createTestRunner() ast.Decl {
 	const (
 		parametersLocal  = "parameters"
 		propertiesLocal  = "properties"
-		property   = "property"
+		propertyMethod   = "Property"
 		testingRun = "testingRun"
 	)
 
@@ -207,7 +207,7 @@ func (o ObjectSerializationTestCase) createTestRunner() ast.Decl {
 	// properties.Property("...", prop.ForAll(RunTestForX, XGenerator())
 	defineTestCase := astbuilder.InvokeQualifiedFunc(
 		propertiesLocal,
-		property,
+		propertyMethod,
 		testName,
 		propForAll)
 

--- a/hack/generator/pkg/astmodel/object_type_serialization_test_case.go
+++ b/hack/generator/pkg/astmodel/object_type_serialization_test_case.go
@@ -165,7 +165,7 @@ func (o ObjectSerializationTestCase) Equals(_ TestCase) bool {
 func (o ObjectSerializationTestCase) createTestRunner() ast.Decl {
 
 	const (
-		parameters = "parameters"
+		parametersLocal  = "parameters"
 		properties = "properties"
 		property   = "property"
 		testingRun = "testingRun"
@@ -175,13 +175,14 @@ func (o ObjectSerializationTestCase) createTestRunner() ast.Decl {
 
 	// parameters := gopter.DefaultTestParameters()
 	defineParameters := astbuilder.SimpleAssignment(
-		ast.NewIdent(parameters),
+		ast.NewIdent(parametersLocal),
 		token.DEFINE,
 		astbuilder.CallQualifiedFunc("gopter", "DefaultTestParameters"))
 
+	// parameters.MaxSize = 10
 	configureMaxSize := astbuilder.SimpleAssignment(
 		&ast.SelectorExpr{
-			X:   ast.NewIdent(parameters),
+			X:   ast.NewIdent(parametersLocal),
 			Sel: ast.NewIdent("MaxSize"),
 		},
 		token.ASSIGN,
@@ -191,7 +192,7 @@ func (o ObjectSerializationTestCase) createTestRunner() ast.Decl {
 	defineProperties := astbuilder.SimpleAssignment(
 		ast.NewIdent(properties),
 		token.DEFINE,
-		astbuilder.CallQualifiedFunc("gopter", "NewProperties", ast.NewIdent(parameters)))
+		astbuilder.CallQualifiedFunc("gopter", "NewProperties", ast.NewIdent(parametersLocal)))
 
 	// partial expression: name of the test
 	testName := astbuilder.StringLiteralf("Round trip of %v via JSON returns original", o.Subject())

--- a/hack/generator/pkg/astmodel/object_type_serialization_test_case.go
+++ b/hack/generator/pkg/astmodel/object_type_serialization_test_case.go
@@ -153,6 +153,9 @@ func (o ObjectSerializationTestCase) RequiredImports() *PackageImportSet {
 		}
 	}
 
+	// We're not currently creating generators for types in this package, so leave it out
+	result.Remove(NewPackageImport(GenRuntimeReference))
+
 	return result
 }
 

--- a/hack/generator/pkg/astmodel/object_type_serialization_test_case.go
+++ b/hack/generator/pkg/astmodel/object_type_serialization_test_case.go
@@ -166,7 +166,7 @@ func (o ObjectSerializationTestCase) createTestRunner() ast.Decl {
 
 	const (
 		parametersLocal  = "parameters"
-		properties = "properties"
+		propertiesLocal  = "properties"
 		property   = "property"
 		testingRun = "testingRun"
 	)
@@ -190,7 +190,7 @@ func (o ObjectSerializationTestCase) createTestRunner() ast.Decl {
 
 	// properties := gopter.NewProperties(parameters)
 	defineProperties := astbuilder.SimpleAssignment(
-		ast.NewIdent(properties),
+		ast.NewIdent(propertiesLocal),
 		token.DEFINE,
 		astbuilder.CallQualifiedFunc("gopter", "NewProperties", ast.NewIdent(parametersLocal)))
 
@@ -206,13 +206,13 @@ func (o ObjectSerializationTestCase) createTestRunner() ast.Decl {
 
 	// properties.Property("...", prop.ForAll(RunTestForX, XGenerator())
 	defineTestCase := astbuilder.InvokeQualifiedFunc(
-		properties,
+		propertiesLocal,
 		property,
 		testName,
 		propForAll)
 
 	// properties.TestingRun(t)
-	runTests := astbuilder.InvokeQualifiedFunc(properties, testingRun, t)
+	runTests := astbuilder.InvokeQualifiedFunc(propertiesLocal, testingRunMethod, t)
 
 	// Define our function
 	fn := astbuilder.NewTestFuncDetails(

--- a/hack/generator/pkg/astmodel/object_type_serialization_test_case.go
+++ b/hack/generator/pkg/astmodel/object_type_serialization_test_case.go
@@ -168,7 +168,7 @@ func (o ObjectSerializationTestCase) createTestRunner() ast.Decl {
 		parametersLocal  = "parameters"
 		propertiesLocal  = "properties"
 		propertyMethod   = "Property"
-		testingRun = "testingRun"
+		testingRunMethod = "TestingRun"
 	)
 
 	t := ast.NewIdent("t")
@@ -194,7 +194,7 @@ func (o ObjectSerializationTestCase) createTestRunner() ast.Decl {
 		token.DEFINE,
 		astbuilder.CallQualifiedFunc("gopter", "NewProperties", ast.NewIdent(parametersLocal)))
 
-	// partial expression: name of the test
+	// partial expression: description of the test
 	testName := astbuilder.StringLiteralf("Round trip of %v via JSON returns original", o.Subject())
 
 	// partial expression: prop.ForAll(RunTestForX, XGenerator())


### PR DESCRIPTION
* Renames constants to reflect their use
* Fixes the constants used to refer to the `Property()` and `TestingRun()` methods
* Removes an unused import
