### PR TITLE
Fix issues where test generation could be different each time

### DIFF
--- a/hack/generator/pkg/astmodel/file_definition.go
+++ b/hack/generator/pkg/astmodel/file_definition.go
@@ -160,27 +160,11 @@ func (file *FileDefinition) generateImports() *PackageImportSet {
 
 func (file *FileDefinition) generateImportSpecs(imports *PackageImportSet) []ast.Spec {
 	var importSpecs []ast.Spec
-	for _, requiredImport := range imports.AsSortedSlice(file.orderImports) {
+	for _, requiredImport := range imports.AsSortedSlice() {
 		importSpecs = append(importSpecs, requiredImport.AsImportSpec())
 	}
 
 	return importSpecs
-}
-
-func (file *FileDefinition) orderImports(i PackageImport, j PackageImport) bool {
-	if i.HasExplicitName() && j.HasExplicitName() {
-		return i.name < j.name
-	}
-
-	if i.HasExplicitName() {
-		return true
-	}
-
-	if j.HasExplicitName() {
-		return false
-	}
-
-	return i.packageReference.String() < j.packageReference.String()
 }
 
 // AsAst generates an AST node representing this file

--- a/hack/generator/pkg/astmodel/file_definition_test.go
+++ b/hack/generator/pkg/astmodel/file_definition_test.go
@@ -241,55 +241,6 @@ func Test_CalcRanks_GivenDiamondWithReverseBar_AssignRanksInOrder(t *testing.T) 
 }
 
 /*
- * orderImports() tests
- */
-
-func TestFileDefinitionOrderImports(t *testing.T) {
-
-	alphaRef := MakeExternalPackageReference("alpha")
-	betaRef := MakeExternalPackageReference("beta")
-
-	alphaImport := NewPackageImport(alphaRef)
-	betaImport := NewPackageImport(betaRef)
-
-	alphaImportWithName := alphaImport.WithName("alpha")
-	betaImportWithName := betaImport.WithName("beta")
-
-	cases := []struct {
-		name  string
-		left  PackageImport
-		right PackageImport
-		less  bool
-	}{
-		{"Anonymous imports are alphabetical (i)", alphaImport, betaImport, true},
-		{"Anonymous imports are alphabetical (ii)", betaImport, alphaImport, false},
-		{"Named imports are alphabetical (i)", alphaImportWithName, betaImportWithName, true},
-		{"Named imports are alphabetical (ii)", betaImportWithName, alphaImportWithName, false},
-		{"Named imports come before anonymous (i)", alphaImportWithName, alphaImport, true},
-		{"Named imports come before anonymous (ii)", betaImportWithName, alphaImport, true},
-		{"Named imports come before anonymous (iii)", alphaImportWithName, betaImport, true},
-		{"Named imports come before anonymous (iv)", betaImportWithName, betaImport, true},
-		{"Anonymous imports come after named (i)", alphaImport, alphaImportWithName, false},
-		{"Anonymous imports come after named (ii)", alphaImport, betaImportWithName, false},
-		{"Anonymous imports come after named (iii)", betaImport, alphaImportWithName, false},
-		{"Anonymous imports come after named (iv)", betaImport, betaImportWithName, false},
-	}
-
-	var file FileDefinition
-
-	for _, c := range cases {
-		c := c
-		t.Run(c.name, func(t *testing.T) {
-			t.Parallel()
-			g := NewGomegaWithT(t)
-
-			less := file.orderImports(c.left, c.right)
-			g.Expect(less).To(Equal(c.less))
-		})
-	}
-}
-
-/*
  * Supporting methods
  */
 

--- a/hack/generator/pkg/astmodel/object_type_serialization_test_case.go
+++ b/hack/generator/pkg/astmodel/object_type_serialization_test_case.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	ast "github.com/dave/dst"
 	"go/token"
+	"sort"
 
 	"github.com/Azure/k8s-infra/hack/generator/pkg/astbuilder"
 	"github.com/pkg/errors"
@@ -507,9 +508,19 @@ func (o ObjectSerializationTestCase) createGenerators(
 	var handled []PropertyName
 	var result []ast.Stmt
 
+	// Sort Properties into alphabetical order to ensure we always generate the same code
+	var toGenerate []PropertyName
+	for name := range properties {
+		toGenerate = append(toGenerate, name)
+	}
+	sort.Slice(toGenerate, func(i, j int) bool {
+		return toGenerate[i] < toGenerate[j]
+	})
+
 	// Iterate over all properties, creating generators where possible
 	var errs []error
-	for name, prop := range properties {
+	for _, name := range toGenerate {
+		prop := properties[name]
 		g, err := factory(string(name), prop.PropertyType(), genContext)
 		if err != nil {
 			errs = append(errs, err)

--- a/hack/generator/pkg/astmodel/package_import_set.go
+++ b/hack/generator/pkg/astmodel/package_import_set.go
@@ -91,12 +91,11 @@ func (set *PackageImportSet) AsSlice() []PackageImport {
 }
 
 // AsSortedSlice() return a sorted slice containing all the imports
-// less specifies how to order the imports
-func (set *PackageImportSet) AsSortedSlice(less func(i PackageImport, j PackageImport) bool) []PackageImport {
+func (set *PackageImportSet) AsSortedSlice() []PackageImport {
 	result := set.AsSlice()
 
 	sort.Slice(result, func(i int, j int) bool {
-		return less(result[i], result[j])
+		return set.orderImports(result[i], result[j])
 	})
 
 	return result
@@ -255,4 +254,20 @@ func (set *PackageImportSet) ServiceNameForImport(imp PackageImport) string {
 func (set *PackageImportSet) versionedNameForImport(imp PackageImport) string {
 	service := set.ServiceNameForImport(imp)
 	return service + imp.packageReference.PackageName()
+}
+
+func (set *PackageImportSet) orderImports(i PackageImport, j PackageImport) bool {
+	if i.HasExplicitName() && j.HasExplicitName() {
+		return i.name < j.name
+	}
+
+	if i.HasExplicitName() {
+		return true
+	}
+
+	if j.HasExplicitName() {
+		return false
+	}
+
+	return i.packageReference.String() < j.packageReference.String()
 }

--- a/hack/generator/pkg/astmodel/package_import_set_test.go
+++ b/hack/generator/pkg/astmodel/package_import_set_test.go
@@ -372,3 +372,52 @@ func TestPackageImportSet_ServiceNameForImport_GivenImport_ReturnsExpectedName(t
 		})
 	}
 }
+
+/*
+ * orderImports() tests
+ */
+
+func Test_PackageSet_OrderImports(t *testing.T) {
+
+	alphaRef := MakeExternalPackageReference("alpha")
+	betaRef := MakeExternalPackageReference("beta")
+
+	alphaImport := NewPackageImport(alphaRef)
+	betaImport := NewPackageImport(betaRef)
+
+	alphaImportWithName := alphaImport.WithName("alpha")
+	betaImportWithName := betaImport.WithName("beta")
+
+	cases := []struct {
+		name  string
+		left  PackageImport
+		right PackageImport
+		less  bool
+	}{
+		{"Anonymous imports are alphabetical (i)", alphaImport, betaImport, true},
+		{"Anonymous imports are alphabetical (ii)", betaImport, alphaImport, false},
+		{"Named imports are alphabetical (i)", alphaImportWithName, betaImportWithName, true},
+		{"Named imports are alphabetical (ii)", betaImportWithName, alphaImportWithName, false},
+		{"Named imports come before anonymous (i)", alphaImportWithName, alphaImport, true},
+		{"Named imports come before anonymous (ii)", betaImportWithName, alphaImport, true},
+		{"Named imports come before anonymous (iii)", alphaImportWithName, betaImport, true},
+		{"Named imports come before anonymous (iv)", betaImportWithName, betaImport, true},
+		{"Anonymous imports come after named (i)", alphaImport, alphaImportWithName, false},
+		{"Anonymous imports come after named (ii)", alphaImport, betaImportWithName, false},
+		{"Anonymous imports come after named (iii)", betaImport, alphaImportWithName, false},
+		{"Anonymous imports come after named (iv)", betaImport, betaImportWithName, false},
+	}
+
+	var set PackageImportSet
+
+	for _, c := range cases {
+		c := c
+		t.Run(c.name, func(t *testing.T) {
+			t.Parallel()
+			g := NewGomegaWithT(t)
+
+			less := set.orderImports(c.left, c.right)
+			g.Expect(less).To(Equal(c.less))
+		})
+	}
+}

--- a/hack/generator/pkg/astmodel/test_file_definition.go
+++ b/hack/generator/pkg/astmodel/test_file_definition.go
@@ -143,9 +143,25 @@ func (file *TestFileDefinition) generateImports() *PackageImportSet {
 
 func (file *TestFileDefinition) generateImportSpecs(imports *PackageImportSet) []ast.Spec {
 	var importSpecs []ast.Spec
-	for _, requiredImport := range imports.AsSlice() {
+	for _, requiredImport := range imports.AsSortedSlice(file.orderImports) {
 		importSpecs = append(importSpecs, requiredImport.AsImportSpec())
 	}
 
 	return importSpecs
+}
+
+func (file *TestFileDefinition) orderImports(i PackageImport, j PackageImport) bool {
+	if i.HasExplicitName() && j.HasExplicitName() {
+		return i.name < j.name
+	}
+
+	if i.HasExplicitName() {
+		return true
+	}
+
+	if j.HasExplicitName() {
+		return false
+	}
+
+	return i.packageReference.String() < j.packageReference.String()
 }

--- a/hack/generator/pkg/astmodel/test_file_definition.go
+++ b/hack/generator/pkg/astmodel/test_file_definition.go
@@ -143,25 +143,9 @@ func (file *TestFileDefinition) generateImports() *PackageImportSet {
 
 func (file *TestFileDefinition) generateImportSpecs(imports *PackageImportSet) []ast.Spec {
 	var importSpecs []ast.Spec
-	for _, requiredImport := range imports.AsSortedSlice(file.orderImports) {
+	for _, requiredImport := range imports.AsSortedSlice() {
 		importSpecs = append(importSpecs, requiredImport.AsImportSpec())
 	}
 
 	return importSpecs
-}
-
-func (file *TestFileDefinition) orderImports(i PackageImport, j PackageImport) bool {
-	if i.HasExplicitName() && j.HasExplicitName() {
-		return i.name < j.name
-	}
-
-	if i.HasExplicitName() {
-		return true
-	}
-
-	if j.HasExplicitName() {
-		return false
-	}
-
-	return i.packageReference.String() < j.packageReference.String()
 }


### PR DESCRIPTION
Fix two issues where the code generated for a test could be different each time the generator was run.

* Gopter generators for the serialisation test are now generated in alphabetical order by property name
* Imports at the top of each test file are now sorted, same as for other files
