### PR TITLE
Only generate imports for packages that are referenced

### DIFF
--- a/hack/generator/pkg/astbuilder/builder.go
+++ b/hack/generator/pkg/astbuilder/builder.go
@@ -243,13 +243,13 @@ func ReturnIfExpr(cond ast.Expr, returns ...ast.Expr) *ast.IfStmt {
 
 // FormatError produces a call to fmt.Errorf with the given format string and args
 //	fmt.Errorf(<formatString>, <args>)
-func FormatError(formatString string, args ...ast.Expr) ast.Expr {
+func FormatError(fmtPackage string, formatString string, args ...ast.Expr) ast.Expr {
 	var callArgs []ast.Expr
 	callArgs = append(
 		callArgs,
 		StringLiteral(formatString))
 	callArgs = append(callArgs, args...)
-	return CallQualifiedFunc("fmt", "Errorf", callArgs...)
+	return CallQualifiedFunc(fmtPackage, "Errorf", callArgs...)
 }
 
 // AddrOf returns a statement that gets the address of the provided expression.

--- a/hack/generator/pkg/astbuilder/func_details.go
+++ b/hack/generator/pkg/astbuilder/func_details.go
@@ -24,7 +24,7 @@ type FuncDetails struct {
 
 // NewTestFuncDetails returns a FuncDetails for a test method
 // Tests require a particular signature, so this makes it simpler to create test functions
-func NewTestFuncDetails(testName string, body ...ast.Stmt) *FuncDetails {
+func NewTestFuncDetails(testingPackage string, testName string, body ...ast.Stmt) *FuncDetails {
 
 	// Ensure the method name starts with `Test` as required
 	var name string
@@ -42,7 +42,7 @@ func NewTestFuncDetails(testName string, body ...ast.Stmt) *FuncDetails {
 	result.AddParameter("t",
 		&ast.StarExpr{
 			X: &ast.SelectorExpr{
-				X:   ast.NewIdent("testing"),
+				X:   ast.NewIdent(testingPackage),
 				Sel: ast.NewIdent("T"),
 			}},
 	)

--- a/hack/generator/pkg/astmodel/armconversion/convert_from_arm_function_builder.go
+++ b/hack/generator/pkg/astmodel/armconversion/convert_from_arm_function_builder.go
@@ -109,6 +109,8 @@ func (builder *convertFromArmBuilder) functionBodyStatements() []ast.Stmt {
 func (builder *convertFromArmBuilder) assertInputTypeIsArm() []ast.Stmt {
 	var result []ast.Stmt
 
+	fmtPackage := builder.codeGenerationContext.MustGetImportedPackageName(astmodel.FmtReference)
+
 	// perform a type assert
 	result = append(
 		result,
@@ -122,6 +124,7 @@ func (builder *convertFromArmBuilder) assertInputTypeIsArm() []ast.Stmt {
 		result,
 		astbuilder.ReturnIfNotOk(
 			astbuilder.FormatError(
+				fmtPackage,
 				fmt.Sprintf("unexpected type supplied for %s() function. Expected %s, got %%T",
 					builder.methodName,
 					builder.armTypeIdent),

--- a/hack/generator/pkg/astmodel/code_generation_context.go
+++ b/hack/generator/pkg/astmodel/code_generation_context.go
@@ -69,6 +69,17 @@ func (codeGenContext *CodeGenerationContext) GetImportedPackageName(reference Pa
 	return packageImport.PackageName(), nil
 }
 
+// MustGetImportedPackageName gets the imported packages name or panics if the package was not imported
+// Use this when you're absolutely positively sure the package will be there already
+func (codeGenContext *CodeGenerationContext) MustGetImportedPackageName(reference PackageReference) string {
+	result, err := codeGenContext.GetImportedPackageName(reference)
+	if err != nil {
+		panic(err)
+	}
+
+	return result
+}
+
 // GetGeneratedPackage gets a reference to the PackageDefinition referred to by the provided reference
 func (codeGenContext *CodeGenerationContext) GetGeneratedPackage(reference PackageReference) (*PackageDefinition, error) {
 	// Make sure that we're actually importing that package -- don't want to allow references to things we aren't importing

--- a/hack/generator/pkg/astmodel/code_generation_context.go
+++ b/hack/generator/pkg/astmodel/code_generation_context.go
@@ -16,6 +16,7 @@ import (
 type CodeGenerationContext struct {
 	packageImports *PackageImportSet
 	currentPackage PackageReference
+	usedImports    *PackageImportSet
 
 	generatedPackages map[PackageReference]*PackageDefinition
 }
@@ -32,7 +33,8 @@ func NewCodeGenerationContext(
 	return &CodeGenerationContext{
 		currentPackage:    currentPackage,
 		packageImports:    imports,
-		generatedPackages: generatedPackages}
+		generatedPackages: generatedPackages,
+		usedImports:       NewPackageImportSet()}
 }
 
 // CurrentPackage returns the current package being generated
@@ -40,11 +42,19 @@ func (codeGenContext *CodeGenerationContext) CurrentPackage() PackageReference {
 	return codeGenContext.currentPackage
 }
 
-// PackageImports returns the set of package references in the current context
+// PackageImports returns the set of package imports in the current context
 func (codeGenContext *CodeGenerationContext) PackageImports() *PackageImportSet {
-	// return a copy of the map to ensure immutability
+	// return a copy to ensure immutability
 	result := NewPackageImportSet()
 	result.Merge(codeGenContext.packageImports)
+	return result
+}
+
+// UsedImports returns the set of package imports that have been used by the generated code
+func (codeGenContext *CodeGenerationContext) UsedPackageImports() *PackageImportSet {
+	// return a copy to ensure immutability
+	result := NewPackageImportSet()
+	result.Merge(codeGenContext.usedImports)
 	return result
 }
 
@@ -54,6 +64,8 @@ func (codeGenContext *CodeGenerationContext) GetImportedPackageName(reference Pa
 	if !ok {
 		return "", errors.Errorf("package %s not imported", reference)
 	}
+
+	codeGenContext.usedImports.AddImport(packageImport)
 	return packageImport.PackageName(), nil
 }
 

--- a/hack/generator/pkg/astmodel/object_type_serialization_test_case.go
+++ b/hack/generator/pkg/astmodel/object_type_serialization_test_case.go
@@ -176,6 +176,8 @@ func (o ObjectSerializationTestCase) createTestRunner() ast.Decl {
 		testingRunMethod = "TestingRun"
 	)
 
+	testingPackage := codegenContext.MustGetImportedPackageName(TestingReference)
+
 	t := ast.NewIdent("t")
 
 	// parameters := gopter.DefaultTestParameters()
@@ -221,6 +223,7 @@ func (o ObjectSerializationTestCase) createTestRunner() ast.Decl {
 
 	// Define our function
 	fn := astbuilder.NewTestFuncDetails(
+		testingPackage,
 		o.testName,
 		defineParameters,
 		configureMaxSize,

--- a/hack/generator/pkg/astmodel/object_type_serialization_test_case.go
+++ b/hack/generator/pkg/astmodel/object_type_serialization_test_case.go
@@ -13,7 +13,6 @@ import (
 
 	"github.com/Azure/k8s-infra/hack/generator/pkg/astbuilder"
 	"github.com/pkg/errors"
-	kerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/klog/v2"
 )
 
@@ -28,7 +27,7 @@ type ObjectSerializationTestCase struct {
 
 var _ TestCase = &ObjectSerializationTestCase{}
 
-// NewObjectSerializationTestCase creates a new test case for the JSON serialization round tripability of the specified object type
+// NewObjectSerializationTestCase creates a new test case for the JSON serialization round-trip-ability of the specified object type
 func NewObjectSerializationTestCase(
 	name TypeName,
 	objectType *ObjectType,
@@ -62,16 +61,10 @@ func (o ObjectSerializationTestCase) AsFuncs(name TypeName, genContext *CodeGene
 	properties := o.makePropertyMap()
 
 	// Find all the simple generators (those with no external dependencies)
-	simpleGenerators, err := o.createGenerators(properties, genContext, o.createIndependentGenerator)
-	if err != nil {
-		errs = append(errs, err)
-	}
+	simpleGenerators := o.createGenerators(properties, genContext, o.createIndependentGenerator)
 
 	// Find all the complex generators (dependent on other generators we'll be generating elsewhere)
-	relatedGenerators, err := o.createGenerators(properties, genContext, o.createRelatedGenerator)
-	if err != nil {
-		errs = append(errs, err)
-	}
+	relatedGenerators := o.createGenerators(properties, genContext, o.createRelatedGenerator)
 
 	// Remove properties from our runtime
 	o.removeByPackage(properties, GenRuntimeReference)
@@ -93,26 +86,17 @@ func (o ObjectSerializationTestCase) AsFuncs(name TypeName, genContext *CodeGene
 		errs = append(errs, errors.Errorf("No property generators for %v", name))
 	} else {
 		result = append(result,
-			o.createTestRunner(),
-			o.createTestMethod())
-
-		addMethod := func(decl ast.Decl, err error) {
-			if err != nil {
-				errs = append(errs, err)
-			} else {
-				result = append(result, decl)
-			}
-		}
-
-		addMethod(o.createGeneratorDeclaration(genContext))
-		addMethod(o.createGeneratorMethod(genContext, len(simpleGenerators) > 0, len(relatedGenerators) > 0))
+			o.createTestRunner(genContext),
+			o.createTestMethod(genContext),
+			o.createGeneratorDeclaration(genContext),
+			o.createGeneratorMethod(genContext, len(simpleGenerators) > 0, len(relatedGenerators) > 0))
 
 		if len(simpleGenerators) > 0 {
-			addMethod(o.createGeneratorsFactoryMethod(o.idOfIndependentGeneratorsFactoryMethod(), simpleGenerators, genContext))
+			result = append(result, o.createGeneratorsFactoryMethod(o.idOfIndependentGeneratorsFactoryMethod(), simpleGenerators, genContext))
 		}
 
 		if len(relatedGenerators) > 0 {
-			addMethod(o.createGeneratorsFactoryMethod(o.idOfRelatedGeneratorsFactoryMethod(), relatedGenerators, genContext))
+			result = append(result, o.createGeneratorsFactoryMethod(o.idOfRelatedGeneratorsFactoryMethod(), relatedGenerators, genContext))
 		}
 	}
 
@@ -167,7 +151,7 @@ func (o ObjectSerializationTestCase) Equals(_ TestCase) bool {
 }
 
 // createTestRunner generates the AST for the test runner itself
-func (o ObjectSerializationTestCase) createTestRunner() ast.Decl {
+func (o ObjectSerializationTestCase) createTestRunner(codegenContext *CodeGenerationContext) ast.Decl {
 
 	const (
 		parametersLocal  = "parameters"
@@ -176,6 +160,8 @@ func (o ObjectSerializationTestCase) createTestRunner() ast.Decl {
 		testingRunMethod = "TestingRun"
 	)
 
+	gopterPackage := codegenContext.MustGetImportedPackageName(GopterReference)
+	propPackage := codegenContext.MustGetImportedPackageName(GopterPropReference)
 	testingPackage := codegenContext.MustGetImportedPackageName(TestingReference)
 
 	t := ast.NewIdent("t")
@@ -184,7 +170,7 @@ func (o ObjectSerializationTestCase) createTestRunner() ast.Decl {
 	defineParameters := astbuilder.SimpleAssignment(
 		ast.NewIdent(parametersLocal),
 		token.DEFINE,
-		astbuilder.CallQualifiedFunc("gopter", "DefaultTestParameters"))
+		astbuilder.CallQualifiedFunc(gopterPackage, "DefaultTestParameters"))
 
 	// parameters.MaxSize = 10
 	configureMaxSize := astbuilder.SimpleAssignment(
@@ -199,14 +185,14 @@ func (o ObjectSerializationTestCase) createTestRunner() ast.Decl {
 	defineProperties := astbuilder.SimpleAssignment(
 		ast.NewIdent(propertiesLocal),
 		token.DEFINE,
-		astbuilder.CallQualifiedFunc("gopter", "NewProperties", ast.NewIdent(parametersLocal)))
+		astbuilder.CallQualifiedFunc(gopterPackage, "NewProperties", ast.NewIdent(parametersLocal)))
 
 	// partial expression: description of the test
 	testName := astbuilder.StringLiteralf("Round trip of %v via JSON returns original", o.Subject())
 
 	// partial expression: prop.ForAll(RunTestForX, XGenerator())
 	propForAll := astbuilder.CallQualifiedFunc(
-		"prop",
+		propPackage,
 		"ForAll",
 		ast.NewIdent(o.idOfTestMethod()),
 		astbuilder.CallFunc(o.idOfGeneratorMethod(o.subject)))
@@ -235,7 +221,7 @@ func (o ObjectSerializationTestCase) createTestRunner() ast.Decl {
 }
 
 // createTestMethod generates the AST for a method to run a single test of JSON serialization
-func (o ObjectSerializationTestCase) createTestMethod() ast.Decl {
+func (o ObjectSerializationTestCase) createTestMethod(codegenContext *CodeGenerationContext) ast.Decl {
 	const (
 		binId        = "bin"
 		actualId     = "actual"
@@ -247,11 +233,17 @@ func (o ObjectSerializationTestCase) createTestMethod() ast.Decl {
 		errId        = "err"
 	)
 
+	jsonPackage := codegenContext.MustGetImportedPackageName(JsonReference)
+	cmpPackage := codegenContext.MustGetImportedPackageName(CmpReference)
+	cmpoptsPackage := codegenContext.MustGetImportedPackageName(CmpOptsReference)
+	prettyPackage := codegenContext.MustGetImportedPackageName(PrettyReference)
+	diffPackage := codegenContext.MustGetImportedPackageName(DiffReference)
+
 	// bin, err := json.Marshal(subject)
 	serialize := astbuilder.SimpleAssignmentWithErr(
 		ast.NewIdent(binId),
 		token.DEFINE,
-		astbuilder.CallQualifiedFunc("json", "Marshal", ast.NewIdent(subjectId)))
+		astbuilder.CallQualifiedFunc(jsonPackage, "Marshal", ast.NewIdent(subjectId)))
 
 	// if err != nil { return err.Error() }
 	serializeFailed := astbuilder.ReturnIfNotNil(
@@ -265,7 +257,7 @@ func (o ObjectSerializationTestCase) createTestMethod() ast.Decl {
 	deserialize := astbuilder.SimpleAssignment(
 		ast.NewIdent("err"),
 		token.ASSIGN,
-		astbuilder.CallQualifiedFunc("json", "Unmarshal",
+		astbuilder.CallQualifiedFunc(jsonPackage, "Unmarshal",
 			ast.NewIdent(binId),
 			&ast.UnaryExpr{
 				Op: token.AND,
@@ -278,11 +270,11 @@ func (o ObjectSerializationTestCase) createTestMethod() ast.Decl {
 		astbuilder.CallQualifiedFunc("err", "Error"))
 
 	// match := cmp.Equal(subject, actual, cmpopts.EquateEmpty())
-	equateEmpty := astbuilder.CallQualifiedFunc("cmpopts", "EquateEmpty")
+	equateEmpty := astbuilder.CallQualifiedFunc(cmpoptsPackage, "EquateEmpty")
 	compare := astbuilder.SimpleAssignment(
 		ast.NewIdent(matchId),
 		token.DEFINE,
-		astbuilder.CallQualifiedFunc("cmp", "Equal",
+		astbuilder.CallQualifiedFunc(cmpPackage, "Equal",
 			ast.NewIdent(subjectId),
 			ast.NewIdent(actualId),
 			equateEmpty))
@@ -298,15 +290,15 @@ func (o ObjectSerializationTestCase) createTestMethod() ast.Decl {
 				astbuilder.SimpleAssignment(
 					ast.NewIdent(actualFmtId),
 					token.DEFINE,
-					astbuilder.CallQualifiedFunc("pretty", "Sprint", ast.NewIdent(actualId))),
+					astbuilder.CallQualifiedFunc(prettyPackage, "Sprint", ast.NewIdent(actualId))),
 				astbuilder.SimpleAssignment(
 					ast.NewIdent(subjectFmtId),
 					token.DEFINE,
-					astbuilder.CallQualifiedFunc("pretty", "Sprint", ast.NewIdent(subjectId))),
+					astbuilder.CallQualifiedFunc(prettyPackage, "Sprint", ast.NewIdent(subjectId))),
 				astbuilder.SimpleAssignment(
 					ast.NewIdent(resultId),
 					token.DEFINE,
-					astbuilder.CallQualifiedFunc("diff", "Diff", ast.NewIdent(subjectFmtId), ast.NewIdent(actualFmtId))),
+					astbuilder.CallQualifiedFunc(diffPackage, "Diff", ast.NewIdent(subjectFmtId), ast.NewIdent(actualFmtId))),
 				astbuilder.Returns(ast.NewIdent(resultId)),
 			},
 		},
@@ -454,7 +446,7 @@ func (o ObjectSerializationTestCase) createGeneratorMethod(ctx *CodeGenerationCo
 	normalReturn := astbuilder.Returns(ast.NewIdent(o.idOfSubjectGeneratorGlobal()))
 	fn.AddStatements(normalReturn)
 
-	return fn.DefineFunc(), nil
+	return fn.DefineFunc()
 }
 
 // createGeneratorsFactoryMethod generates the AST for a method creating gopter generators
@@ -486,7 +478,7 @@ func (o ObjectSerializationTestCase) createGeneratorsFactoryMethod(
 func (o ObjectSerializationTestCase) createGenerators(
 	properties map[PropertyName]*PropertyDefinition,
 	genContext *CodeGenerationContext,
-	factory func(name string, propertyType Type, genContext *CodeGenerationContext) (ast.Expr, error)) ([]ast.Stmt, error) {
+	factory func(name string, propertyType Type, genContext *CodeGenerationContext) ast.Expr) []ast.Stmt {
 
 	gensIdent := ast.NewIdent("gens")
 
@@ -503,13 +495,10 @@ func (o ObjectSerializationTestCase) createGenerators(
 	})
 
 	// Iterate over all properties, creating generators where possible
-	var errs []error
 	for _, name := range toGenerate {
 		prop := properties[name]
-		g, err := factory(string(name), prop.PropertyType(), genContext)
-		if err != nil {
-			errs = append(errs, err)
-		} else if g != nil {
+		g := factory(string(name), prop.PropertyType(), genContext)
+		if g != nil {
 			insert := astbuilder.InsertMap(
 				gensIdent,
 				&ast.BasicLit{
@@ -527,27 +516,27 @@ func (o ObjectSerializationTestCase) createGenerators(
 		delete(properties, name)
 	}
 
-	return result, kerrors.NewAggregate(errs)
+	return result
 }
 
 // is directly supported by a Gopter generator, returning nil if the property type isn't supported.
 func (o ObjectSerializationTestCase) createIndependentGenerator(
 	name string,
 	propertyType Type,
-	genContext *CodeGenerationContext) (ast.Expr, error) {
+	genContext *CodeGenerationContext) ast.Expr {
 
 	genPackage := genContext.MustGetImportedPackageName(GopterGenReference)
 
 	// Handle simple primitive properties
 	switch propertyType {
 	case StringType:
-		return astbuilder.CallQualifiedFunc(genPackage, "AlphaString"), nil
+		return astbuilder.CallQualifiedFunc(genPackage, "AlphaString")
 	case IntType:
-		return astbuilder.CallQualifiedFunc(genPackage, "Int"), nil
+		return astbuilder.CallQualifiedFunc(genPackage, "Int")
 	case FloatType:
-		return astbuilder.CallQualifiedFunc(genPackage, "Float32"), nil
+		return astbuilder.CallQualifiedFunc(genPackage, "Float32")
 	case BoolType:
-		return astbuilder.CallQualifiedFunc(genPackage, "Bool"), nil
+		return astbuilder.CallQualifiedFunc(genPackage, "Bool")
 	}
 
 	switch t := propertyType.(type) {
@@ -557,52 +546,40 @@ func (o ObjectSerializationTestCase) createIndependentGenerator(
 		if ok {
 			return o.createIndependentGenerator(def.Name().name, def.theType, genContext)
 		}
-		return nil, nil
+		return nil
 
 	case *EnumType:
 		return o.createEnumGenerator(name, genPackage, t)
 
 	case *OptionalType:
-		g, err := o.createIndependentGenerator(name, t.Element(), genContext)
-		if err != nil {
-			return nil, err
-		} else if g != nil {
-			return astbuilder.CallQualifiedFunc(genPackage, "PtrOf", g), nil
+		g := o.createIndependentGenerator(name, t.Element(), genContext)
+		if g != nil {
+			return astbuilder.CallQualifiedFunc(genPackage, "PtrOf", g)
 		}
 
 	case *ArrayType:
-		g, err := o.createIndependentGenerator(name, t.Element(), genContext)
-		if err != nil {
-			return nil, err
-		} else if g != nil {
-			return astbuilder.CallQualifiedFunc(genPackage, "SliceOf", g), nil
+		g := o.createIndependentGenerator(name, t.Element(), genContext)
+		if g != nil {
+			return astbuilder.CallQualifiedFunc(genPackage, "SliceOf", g)
 		}
 
 	case *MapType:
-		keyGen, err := o.createIndependentGenerator(name, t.KeyType(), genContext)
-		if err != nil {
-			return nil, err
-		}
-
-		valueGen, err := o.createIndependentGenerator(name, t.ValueType(), genContext)
-		if err != nil {
-			return nil, err
-		}
-
+		keyGen := o.createIndependentGenerator(name, t.KeyType(), genContext)
+		valueGen := o.createIndependentGenerator(name, t.ValueType(), genContext)
 		if keyGen != nil && valueGen != nil {
-			return astbuilder.CallQualifiedFunc(genPackage, "MapOf", keyGen, valueGen), nil
+			return astbuilder.CallQualifiedFunc(genPackage, "MapOf", keyGen, valueGen)
 		}
 	}
 
 	// Not a simple property we can handle here
-	return nil, nil
+	return nil
 }
 
 // defined within the current package, returning nil if the property type isn't supported.
 func (o ObjectSerializationTestCase) createRelatedGenerator(
 	name string,
 	propertyType Type,
-	genContext *CodeGenerationContext) (ast.Expr, error) {
+	genContext *CodeGenerationContext) ast.Expr {
 
 	genPackageName := genContext.MustGetImportedPackageName(GopterGenReference)
 
@@ -622,43 +599,31 @@ func (o ObjectSerializationTestCase) createRelatedGenerator(
 
 		//TODO: Should we invoke a generator for stuff from our runtime package?
 
-		return nil, nil
+		return nil
 
 	case *OptionalType:
-		g, err := o.createRelatedGenerator(name, t.Element(), genContext)
-		if err != nil {
-			return nil, err
-		} else if g != nil {
-			return astbuilder.CallQualifiedFunc(genPackageName, "PtrOf", g), nil
+		g := o.createRelatedGenerator(name, t.Element(), genContext)
+		if g != nil {
+			return astbuilder.CallQualifiedFunc(genPackageName, "PtrOf", g)
 		}
 
 	case *ArrayType:
-		g, err := o.createRelatedGenerator(name, t.Element(), genContext)
-		if err != nil {
-			return nil, err
-		} else if g != nil {
-			return astbuilder.CallQualifiedFunc(genPackageName, "SliceOf", g), nil
+		g := o.createRelatedGenerator(name, t.Element(), genContext)
+		if g != nil {
+			return astbuilder.CallQualifiedFunc(genPackageName, "SliceOf", g)
 		}
 
 	case *MapType:
 		// We only support primitive types as keys
-		keyGen, err := o.createIndependentGenerator(name, t.KeyType(), genContext)
-		if err != nil {
-			return nil, err
-		}
-
-		valueGen, err := o.createRelatedGenerator(name, t.ValueType(), genContext)
-		if err != nil {
-			return nil, err
-		}
-
+		keyGen := o.createIndependentGenerator(name, t.KeyType(), genContext)
+		valueGen := o.createRelatedGenerator(name, t.ValueType(), genContext)
 		if keyGen != nil && valueGen != nil {
-			return astbuilder.CallQualifiedFunc(genPackageName, "MapOf", keyGen, valueGen), nil
+			return astbuilder.CallQualifiedFunc(genPackageName, "MapOf", keyGen, valueGen)
 		}
 	}
 
 	// Not a property we can handle here
-	return nil, nil
+	return nil
 }
 
 func (o *ObjectSerializationTestCase) removeByPackage(
@@ -730,12 +695,12 @@ func (o ObjectSerializationTestCase) Subject() *ast.Ident {
 	return ast.NewIdent(o.subject.name)
 }
 
-func (o ObjectSerializationTestCase) createEnumGenerator(enumName string, genPackageName string, enum *EnumType) (ast.Expr, error) {
+func (o ObjectSerializationTestCase) createEnumGenerator(enumName string, genPackageName string, enum *EnumType) ast.Expr {
 	var values []ast.Expr
 	for _, o := range enum.Options() {
 		id := GetEnumValueId(enumName, o)
 		values = append(values, ast.NewIdent(id))
 	}
 
-	return astbuilder.CallQualifiedFunc(genPackageName, "OneConstOf", values...), nil
+	return astbuilder.CallQualifiedFunc(genPackageName, "OneConstOf", values...)
 }

--- a/hack/generator/pkg/astmodel/one_of_json_marshal_function.go
+++ b/hack/generator/pkg/astmodel/one_of_json_marshal_function.go
@@ -54,6 +54,8 @@ func (f *OneOfJSONMarshalFunction) AsFunc(
 	codeGenerationContext *CodeGenerationContext,
 	receiver TypeName) *ast.FuncDecl {
 
+	jsonPackage := codeGenerationContext.MustGetImportedPackageName(JsonReference)
+
 	receiverName := f.idFactory.CreateIdentifier(receiver.name, NotExported)
 
 	var statements []ast.Stmt
@@ -75,7 +77,7 @@ func (f *OneOfJSONMarshalFunction) AsFunc(
 						Results: []ast.Expr{
 							&ast.CallExpr{
 								Fun: &ast.SelectorExpr{
-									X:   ast.NewIdent("json"),
+									X:   ast.NewIdent(jsonPackage),
 									Sel: ast.NewIdent("Marshal"),
 								},
 								Args: []ast.Expr{

--- a/hack/generator/pkg/astmodel/resource.go
+++ b/hack/generator/pkg/astmodel/resource.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/Azure/k8s-infra/hack/generator/pkg/astbuilder"
 	ast "github.com/dave/dst"
-	"github.com/pkg/errors"
 	"k8s.io/klog/v2"
 )
 
@@ -264,10 +263,7 @@ func (resource *ResourceType) RequiredPackageReferences() *PackageReferenceSet {
 // AsDeclarations converts the resource type to a set of go declarations
 func (resource *ResourceType) AsDeclarations(codeGenerationContext *CodeGenerationContext, name TypeName, description []string) []ast.Decl {
 
-	packageName, err := codeGenerationContext.GetImportedPackageName(MetaV1PackageReference)
-	if err != nil {
-		panic(errors.Wrapf(err, "resource resource for %s failed to import package", name))
-	}
+	packageName := codeGenerationContext.MustGetImportedPackageName(MetaV1PackageReference)
 
 	typeMetaField := defineField("", ast.NewIdent(fmt.Sprintf("%s.TypeMeta", packageName)), "`json:\",inline\"`")
 	objectMetaField := defineField("", ast.NewIdent(fmt.Sprintf("%s.ObjectMeta", packageName)), "`json:\"metadata,omitempty\"`")
@@ -342,10 +338,7 @@ func (resource *ResourceType) resourceListTypeDecls(
 
 	typeName := resource.makeResourceListTypeName(resourceTypeName)
 
-	packageName, err := codeGenerationContext.GetImportedPackageName(MetaV1PackageReference)
-	if err != nil {
-		panic(errors.Wrapf(err, "resource list resource for %s failed to import package", typeName))
-	}
+	packageName := codeGenerationContext.MustGetImportedPackageName(MetaV1PackageReference)
 
 	typeMetaField := defineField("", ast.NewIdent(fmt.Sprintf("%s.TypeMeta", packageName)), "`json:\",inline\"`")
 	objectMetaField := defineField("", ast.NewIdent(fmt.Sprintf("%s.ListMeta", packageName)), "`json:\"metadata,omitempty\"`")

--- a/hack/generator/pkg/astmodel/test_file_definition.go
+++ b/hack/generator/pkg/astmodel/test_file_definition.go
@@ -58,20 +58,11 @@ func (file TestFileDefinition) SaveToFile(filePath string) error {
 // AsAst generates an array of declarations for the content of the file
 func (file *TestFileDefinition) AsAst() *ast.File {
 
-	var decls []ast.Decl
-
-	// Determine imports
-	packageReferences := file.generateImports()
-
 	// Create context from imports
-	codeGenContext := NewCodeGenerationContext(file.packageReference, packageReferences, file.generatedPackages)
-
-	// Create import header if needed
-	if packageReferences.Length() > 0 {
-		decls = append(decls, &ast.GenDecl{Tok: token.IMPORT, Specs: file.generateImportSpecs(packageReferences)})
-	}
+	codeGenContext := NewCodeGenerationContext(file.packageReference, file.generateImports(), file.generatedPackages)
 
 	// Emit all test cases:
+	var testcases []ast.Decl
 	for _, s := range file.definitions {
 		definer, ok := s.Type().(TestCaseDefiner)
 		if !ok {
@@ -79,9 +70,19 @@ func (file *TestFileDefinition) AsAst() *ast.File {
 		}
 
 		for _, testcase := range definer.TestCases() {
-			decls = append(decls, testcase.AsFuncs(s.name, codeGenContext)...)
+			testcases = append(testcases, testcase.AsFuncs(s.name, codeGenContext)...)
 		}
 	}
+
+	var decls []ast.Decl
+
+	// Create import header if needed
+	usedImports := codeGenContext.UsedPackageImports()
+	if usedImports.Length() > 0 {
+		decls = append(decls, &ast.GenDecl{Tok: token.IMPORT, Specs: file.generateImportSpecs(usedImports)})
+	}
+
+	decls = append(decls, testcases...)
 
 	var header []string
 	header = append(header, CodeGenerationComments...)


### PR DESCRIPTION
Modifies the PackageImportSet so it tracks which packages are actually referenced, allowing us to only generate the relevant imports (which keeps us clean from lint errors).

Also updates (significantly!) serialization test case generation as that code was taking a few shortcuts that now don't work.

Note: Needs a rebase after #348 is merged, so there initially some duplicate changes showing here.