### PR TITLE
Fix for removing tmp files

### DIFF
--- a/.devcontainer/install-dependencies.sh
+++ b/.devcontainer/install-dependencies.sh
@@ -39,6 +39,7 @@ echo "Installing tools to $TOOL_DEST"
 # Install Go tools
 TMPDIR=$(mktemp -d)
 clean() { 
+    chmod +w -R "$TMPDIR"
     rm -rf "$TMPDIR"
 }
 trap clean EXIT


### PR DESCRIPTION
go makes mod directories readonly so the files cannot be deleted, so make everything writable before deleting.