### PR TITLE
Use a buffered writer to improve performance

### DIFF
--- a/hack/generator/pkg/astmodel/file_definition.go
+++ b/hack/generator/pkg/astmodel/file_definition.go
@@ -6,6 +6,7 @@
 package astmodel
 
 import (
+	"bufio"
 	"go/token"
 	"io"
 	"os"
@@ -260,7 +261,11 @@ func (file *FileDefinition) AsAst() *ast.File {
 // SaveToWriter writes the file to the specifier io.Writer
 func (file FileDefinition) SaveToWriter(dst io.Writer) error {
 	content := file.AsAst()
-	err := decorator.Fprint(dst, content)
+
+	buf := bufio.NewWriter(dst)
+	defer buf.Flush()
+
+	err := decorator.Fprint(buf, content)
 	return err
 }
 

--- a/hack/generator/pkg/astmodel/test_file_definition.go
+++ b/hack/generator/pkg/astmodel/test_file_definition.go
@@ -6,6 +6,7 @@
 package astmodel
 
 import (
+	"bufio"
 	"go/token"
 	"io"
 	"os"
@@ -38,7 +39,11 @@ func NewTestFileDefinition(
 // SaveToWriter writes the file to the specifier io.Writer
 func (file TestFileDefinition) SaveToWriter(dst io.Writer) error {
 	content := file.AsAst()
-	err := decorator.Fprint(dst, content)
+
+	buf := bufio.NewWriter(dst)
+	defer buf.Flush()
+
+	err := decorator.Fprint(buf, content)
 	return err
 }
 

--- a/hack/generator/pkg/codegen/code_generator.go
+++ b/hack/generator/pkg/codegen/code_generator.go
@@ -122,5 +122,7 @@ func (generator *CodeGenerator) Generate(ctx context.Context) error {
 		defs = defsOut
 	}
 
+	klog.Info("Finished")
+
 	return nil
 }


### PR DESCRIPTION
Improve the performance of the export files stage by buffering file writes using `buffio`.

Rudimentary/naïve benchmark:

Unbuffered - 193.7s
Buffered - 123.1s

Saved time ~70s (~35%)

(Benchmark method: one run under each condition without isolating the effect of other processes on the machine.)