### PR TITLE
Improve pluralization of type names

### DIFF
--- a/hack/generator/pkg/astmodel/property_definition.go
+++ b/hack/generator/pkg/astmodel/property_definition.go
@@ -26,6 +26,8 @@ type PropertyDefinition struct {
 	tags         map[string][]string
 }
 
+var _ fmt.Stringer = &PropertyDefinition{}
+
 // NewPropertyDefinition is a factory method for creating a new PropertyDefinition
 // name is the name for the new property (mandatory)
 // propertyType is the type for the new property (mandatory)
@@ -324,4 +326,8 @@ func (property *PropertyDefinition) copy() *PropertyDefinition {
 	}
 
 	return &result
+}
+
+func (property *PropertyDefinition) String() string {
+	return fmt.Sprintf("%s: %s %s", property.propertyName, property.propertyType, property.renderedTags())
 }

--- a/hack/generator/pkg/astmodel/type_name.go
+++ b/hack/generator/pkg/astmodel/type_name.go
@@ -90,11 +90,23 @@ func (typeName TypeName) String() string {
 	return fmt.Sprintf("%s/%s", typeName.PackageReference, typeName.name)
 }
 
+var typeNameSingulars map[string]string = map[string]string{
+	"Services": "Service",
+	"services": "service",
+	"Redis":    "Redis",
+	"redis":    "redis",
+}
+
 // Singular returns a typename with the name singularized
 func (typeName TypeName) Singular() TypeName {
 	// work around bug in flect: https://github.com/Azure/k8s-infra/issues/319
-	if strings.HasSuffix(strings.ToLower(typeName.name), "services") {
-		return MakeTypeName(typeName.PackageReference, typeName.name[0:len(typeName.name)-1])
+	name := typeName.name
+	for plural, single := range typeNameSingulars {
+
+		if strings.HasSuffix(name, plural) {
+			n := name[0:len(name)-len(plural)] + single
+			return MakeTypeName(typeName.PackageReference, n)
+		}
 	}
 
 	return MakeTypeName(typeName.PackageReference, flect.Singularize(typeName.name))

--- a/hack/generator/pkg/astmodel/type_name_test.go
+++ b/hack/generator/pkg/astmodel/type_name_test.go
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) Microsoft Corporation.
+ * Licensed under the MIT license.
+ */
+
+package astmodel
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+)
+
+func TestSingular_GivesExpectedResults(t *testing.T) {
+	cases := []struct {
+		name     string
+		expected string
+	}{
+		{"Account", "Account"},
+		{"Accounts", "Account"},
+		{"Batch", "Batch"},
+		{"Batches", "Batch"},
+		{"ImportServices", "ImportService"},
+		{"Exportservices", "Exportservice"},
+		{"AzureRedis", "AzureRedis"},
+	}
+
+	ref := MakeLocalPackageReference("Demo", "v2010")
+
+	for _, c := range cases {
+		c := c
+		t.Run(c.name, func(t *testing.T) {
+			t.Parallel()
+			g := NewGomegaWithT(t)
+
+			name := MakeTypeName(ref, c.name)
+			result := name.Singular()
+			g.Expect(result.name).To(Equal(c.expected))
+		})
+	}
+}


### PR DESCRIPTION
Also makes it easier to add further special cases in future - now we've got two of them, chances of others is high.