### PR TITLE
Pipeline stage prerequisites

### DIFF
--- a/hack/generator/pkg/codegen/code_generator.go
+++ b/hack/generator/pkg/codegen/code_generator.go
@@ -151,7 +151,7 @@ func (generator *CodeGenerator) Generate(ctx context.Context) error {
 		// Defensive copy (in case the pipeline modifies its inputs) so that we can compare types in vs out
 		defsOut, err := stage.action(ctx, defs.Copy())
 		if err != nil {
-			return errors.Wrapf(err, "Failed during pipeline stage %d/%d: %s", i+1, len(generator.pipeline), stage.description)
+			return errors.Wrapf(err, "failed during pipeline stage %d/%d: %s", i+1, len(generator.pipeline), stage.description)
 		}
 
 		defsAdded := defsOut.Except(defs)


### PR DESCRIPTION
Allow pipeline stages to declare their prerequisites so that we can catch issues caused by changes to the pipeline early, before they generate slightly dodgy CRD code.

* Adds `RequiresPrerequisiteStages()` to `PipelineStage` to allow prerequisites to be declared
* Adds `verifyPipeline()` to `CodeGenerator` to enforce them
* Adds some prerequisites to the existing pipeline

Enforcement is very simple at present, deliberately taking the simplest possible approach. 