### PR TITLE
Remove gcov2lcov

### DIFF
--- a/.devcontainer/install-dependencies.sh
+++ b/.devcontainer/install-dependencies.sh
@@ -53,7 +53,6 @@ echo "Installing Go tools…"
 
 # go tools for vscode are preinstalled by base image (see first comment in Dockerfile)
 go get \
-    github.com/jandelgado/gcov2lcov@v1.0.2 \
     github.com/mikefarah/yq/v3@3.4.1 \
     github.com/mitchellh/gox@v1.0.1 \
     k8s.io/code-generator/cmd/conversion-gen@v0.18.2 \

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -82,7 +82,6 @@ tasks:
     dir: "{{.GENERATOR_ROOT}}"
     cmds:
     - go test ./... -tags=noexit -race -covermode atomic -coverprofile=cover.out -coverpkg=./...
-    - gcov2lcov -infile cover.out -outfile coverage.lcov
 
   generator:build:
     desc: Generate the {{.GENERATOR_APP}} binary.
@@ -157,7 +156,6 @@ tasks:
     deps: [generate-crds]
     cmds: 
     - go test -short -tags=noexit -race -covermode atomic -coverprofile=cover.out -coverpkg="./..." $({{.GENERATED_DIRS_TO_LINT_CMD}})
-    - gcov2lcov -infile cover.out -outfile coverage.lcov
 
   controller:build:
     desc: Generate the {{.CONTROLLER_APP}} binary.
@@ -224,8 +222,7 @@ tasks:
     deps: [controller:prep-integration-tests]
     cmds:
     # -race fails at the moment in controller-runtime
-    - ENVTEST=1 RECORD_REPLAY=1 go test -covermode atomic -coverprofile=cover-integration-envtest.out -coverpkg="./..." -v $({{.GENERATED_DIRS_TO_LINT_CMD}})
-    - gcov2lcov -infile cover-integration-envtest.out -outfile coverage-integration-envtest.lcov
+    - ENVTEST=1 RECORD_REPLAY=1 go test -covermode atomic -coverprofile=coverage-integration-envtest.out -coverpkg="./..." -v $({{.GENERATED_DIRS_TO_LINT_CMD}})
 
   controller:test-integration-envtest-live:
     desc: Run integration tests with envtest against live data and output coverage.
@@ -233,8 +230,7 @@ tasks:
     deps: [controller:prep-integration-tests, cleanup-azure-resources]
     cmds:
     # -race fails at the moment in controller-runtime
-    - ENVTEST=1 go test -covermode atomic -coverprofile=cover-integration-envtest.out -coverpkg="./..." -v $({{.GENERATED_DIRS_TO_LINT_CMD}})
-    - gcov2lcov -infile cover-integration-envtest.out -outfile coverage-integration-envtest.lcov
+    - ENVTEST=1 go test -covermode atomic -coverprofile=coverage-integration-envtest-live.out -coverpkg="./..." -v $({{.GENERATED_DIRS_TO_LINT_CMD}})
 
   generate-crds:
     desc: Run controller-gen to generate CRD files.

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -81,7 +81,7 @@ tasks:
     desc: Run {{.GENERATOR_APP}} unit tests and output coverage.
     dir: "{{.GENERATOR_ROOT}}"
     cmds:
-    - go test ./... -tags=noexit -race -covermode atomic -coverprofile=cover.out -coverpkg=./...
+    - go test ./... -tags=noexit -race -covermode atomic -coverprofile=generator-coverage.out -coverpkg=./...
 
   generator:build:
     desc: Generate the {{.GENERATOR_APP}} binary.
@@ -155,7 +155,7 @@ tasks:
     dir: "{{.CONTROLLER_ROOT}}"
     deps: [generate-crds]
     cmds: 
-    - go test -short -tags=noexit -race -covermode atomic -coverprofile=cover.out -coverpkg="./..." $({{.GENERATED_DIRS_TO_LINT_CMD}})
+    - go test -short -tags=noexit -race -covermode atomic -coverprofile=controller-coverage.out -coverpkg="./..." $({{.GENERATED_DIRS_TO_LINT_CMD}})
 
   controller:build:
     desc: Generate the {{.CONTROLLER_APP}} binary.


### PR DESCRIPTION
This is not needed with codecov.io and it is very slow when running locally.