### PR TITLE
Rename imports of the dave/dst library to use ast

### DIFF
--- a/hack/generator/pkg/astbuilder/assignments.go
+++ b/hack/generator/pkg/astbuilder/assignments.go
@@ -8,19 +8,19 @@ package astbuilder
 import (
 	"go/token"
 
-	ast "github.com/dave/dst"
+	"github.com/dave/dst"
 )
 
 // SimpleAssignment performs a simple assignment like:
 //     <lhs> := <rhs>       // tok = token.DEFINE
 // or  <lhs> = <rhs>        // tok = token.ASSIGN
-func SimpleAssignment(lhs ast.Expr, tok token.Token, rhs ast.Expr) *ast.AssignStmt {
-	return &ast.AssignStmt{
-		Lhs: []ast.Expr{
+func SimpleAssignment(lhs dst.Expr, tok token.Token, rhs dst.Expr) *dst.AssignStmt {
+	return &dst.AssignStmt{
+		Lhs: []dst.Expr{
 			lhs,
 		},
 		Tok: tok,
-		Rhs: []ast.Expr{
+		Rhs: []dst.Expr{
 			rhs,
 		},
 	}
@@ -29,15 +29,15 @@ func SimpleAssignment(lhs ast.Expr, tok token.Token, rhs ast.Expr) *ast.AssignSt
 // SimpleAssignmentWithErr performs a simple assignment like:
 // 	    <lhs>, err := <rhs>       // tok = token.DEFINE
 // 	or  <lhs>, err = <rhs>        // tok = token.ASSIGN
-func SimpleAssignmentWithErr(lhs ast.Expr, tok token.Token, rhs ast.Expr) *ast.AssignStmt {
-	errId := ast.NewIdent("err")
-	return &ast.AssignStmt{
-		Lhs: []ast.Expr{
+func SimpleAssignmentWithErr(lhs dst.Expr, tok token.Token, rhs dst.Expr) *dst.AssignStmt {
+	errId := dst.NewIdent("err")
+	return &dst.AssignStmt{
+		Lhs: []dst.Expr{
 			lhs,
 			errId,
 		},
 		Tok: tok,
-		Rhs: []ast.Expr{
+		Rhs: []dst.Expr{
 			rhs,
 		},
 	}

--- a/hack/generator/pkg/astbuilder/builder.go
+++ b/hack/generator/pkg/astbuilder/builder.go
@@ -8,27 +8,27 @@ package astbuilder
 import (
 	"go/token"
 
-	ast "github.com/dave/dst"
+	"github.com/dave/dst"
 )
 
 // CheckErrorAndReturn checks if the err is non-nil, and if it is returns. For example:
 // 	if err != nil {
 // 		return <otherReturns...>, err
 //	}
-func CheckErrorAndReturn(otherReturns ...ast.Expr) ast.Stmt {
+func CheckErrorAndReturn(otherReturns ...dst.Expr) dst.Stmt {
 
-	returnValues := append([]ast.Expr{}, otherReturns...)
-	returnValues = append(returnValues, ast.NewIdent("err"))
+	returnValues := append([]dst.Expr{}, otherReturns...)
+	returnValues = append(returnValues, dst.NewIdent("err"))
 
-	return &ast.IfStmt{
-		Cond: &ast.BinaryExpr{
-			X:  ast.NewIdent("err"),
+	return &dst.IfStmt{
+		Cond: &dst.BinaryExpr{
+			X:  dst.NewIdent("err"),
 			Op: token.NEQ,
-			Y:  ast.NewIdent("nil"),
+			Y:  dst.NewIdent("nil"),
 		},
-		Body: &ast.BlockStmt{
-			List: []ast.Stmt{
-				&ast.ReturnStmt{
+		Body: &dst.BlockStmt{
+			List: []dst.Stmt{
+				&dst.ReturnStmt{
 					Results: returnValues,
 				},
 			},
@@ -46,16 +46,16 @@ func CheckErrorAndReturn(otherReturns ...ast.Expr) ast.Stmt {
 //     <varName> := <packageRef>.<structName>{}
 //
 // …as that does not work for enum types.
-func NewVariableQualified(varName string, qualifier string, structName string) ast.Stmt {
-	return &ast.DeclStmt{
-		Decl: &ast.GenDecl{
+func NewVariableQualified(varName string, qualifier string, structName string) dst.Stmt {
+	return &dst.DeclStmt{
+		Decl: &dst.GenDecl{
 			Tok: token.VAR,
-			Specs: []ast.Spec{
-				&ast.TypeSpec{
-					Name: ast.NewIdent(varName),
-					Type: &ast.SelectorExpr{
-						X:   ast.NewIdent(qualifier),
-						Sel: ast.NewIdent(structName),
+			Specs: []dst.Spec{
+				&dst.TypeSpec{
+					Name: dst.NewIdent(varName),
+					Type: &dst.SelectorExpr{
+						X:   dst.NewIdent(qualifier),
+						Sel: dst.NewIdent(structName),
 					},
 				},
 			},
@@ -73,14 +73,14 @@ func NewVariableQualified(varName string, qualifier string, structName string) a
 //     <varName> := <structName>{}
 //
 // …as that does not work for enum types.
-func NewVariable(varName string, structName string) ast.Stmt {
-	return &ast.DeclStmt{
-		Decl: &ast.GenDecl{
+func NewVariable(varName string, structName string) dst.Stmt {
+	return &dst.DeclStmt{
+		Decl: &dst.GenDecl{
 			Tok: token.VAR,
-			Specs: []ast.Spec{
-				&ast.TypeSpec{
-					Name: ast.NewIdent(varName),
-					Type: ast.NewIdent(structName),
+			Specs: []dst.Spec{
+				&dst.TypeSpec{
+					Name: dst.NewIdent(varName),
+					Type: dst.NewIdent(structName),
 				},
 			},
 		},
@@ -89,8 +89,8 @@ func NewVariable(varName string, structName string) ast.Stmt {
 
 // LocalVariableDeclaration performs a local variable declaration for use within a method like:
 // 	var <ident> <typ>
-func LocalVariableDeclaration(ident string, typ ast.Expr, comment string) ast.Stmt {
-	return &ast.DeclStmt{
+func LocalVariableDeclaration(ident string, typ dst.Expr, comment string) dst.Stmt {
+	return &dst.DeclStmt{
 		Decl: VariableDeclaration(ident, typ, comment),
 	}
 }
@@ -99,13 +99,13 @@ func LocalVariableDeclaration(ident string, typ ast.Expr, comment string) ast.St
 //  // <comment>
 // 	var <ident> <typ>
 // For a LocalVariable within a method, use LocalVariableDeclaration() to create an ast.Stmt instead
-func VariableDeclaration(ident string, typ ast.Expr, comment string) *ast.GenDecl {
-	decl := &ast.GenDecl{
+func VariableDeclaration(ident string, typ dst.Expr, comment string) *dst.GenDecl {
+	decl := &dst.GenDecl{
 		Tok: token.VAR,
-		Specs: []ast.Spec{
-			&ast.ValueSpec{
-				Names: []*ast.Ident{
-					ast.NewIdent(ident),
+		Specs: []dst.Spec{
+			&dst.ValueSpec{
+				Names: []*dst.Ident{
+					dst.NewIdent(ident),
 				},
 				Type: typ,
 			},
@@ -119,34 +119,34 @@ func VariableDeclaration(ident string, typ ast.Expr, comment string) *ast.GenDec
 
 // AppendList returns a statement for a list append, like:
 //     <lhs> = append(<lhs>, <rhs>)
-func AppendList(lhs ast.Expr, rhs ast.Expr) ast.Stmt {
+func AppendList(lhs dst.Expr, rhs dst.Expr) dst.Stmt {
 	return SimpleAssignment(
-		ast.Clone(lhs).(ast.Expr),
+		dst.Clone(lhs).(dst.Expr),
 		token.ASSIGN,
-		CallFunc("append", ast.Clone(lhs).(ast.Expr), ast.Clone(rhs).(ast.Expr)))
+		CallFunc("append", dst.Clone(lhs).(dst.Expr), dst.Clone(rhs).(dst.Expr)))
 }
 
 // InsertMap returns an assignment statement for inserting an item into a map, like:
 // 	<m>[<key>] = <rhs>
-func InsertMap(m ast.Expr, key ast.Expr, rhs ast.Expr) *ast.AssignStmt {
+func InsertMap(m dst.Expr, key dst.Expr, rhs dst.Expr) *dst.AssignStmt {
 	return SimpleAssignment(
-		&ast.IndexExpr{
-			X:     ast.Clone(m).(ast.Expr),
-			Index: ast.Clone(key).(ast.Expr),
+		&dst.IndexExpr{
+			X:     dst.Clone(m).(dst.Expr),
+			Index: dst.Clone(key).(dst.Expr),
 		},
 		token.ASSIGN,
-		ast.Clone(rhs).(ast.Expr))
+		dst.Clone(rhs).(dst.Expr))
 }
 
 // MakeMap returns the call expression for making a map, like:
 // 	make(map[<key>]<value>)
-func MakeMap(key ast.Expr, value ast.Expr) *ast.CallExpr {
-	return &ast.CallExpr{
-		Fun: ast.NewIdent("make"),
-		Args: []ast.Expr{
-			&ast.MapType{
-				Key:   ast.Clone(key).(ast.Expr),
-				Value: ast.Clone(value).(ast.Expr),
+func MakeMap(key dst.Expr, value dst.Expr) *dst.CallExpr {
+	return &dst.CallExpr{
+		Fun: dst.NewIdent("make"),
+		Args: []dst.Expr{
+			&dst.MapType{
+				Key:   dst.Clone(key).(dst.Expr),
+				Value: dst.Clone(value).(dst.Expr),
 			},
 		},
 	}
@@ -154,16 +154,16 @@ func MakeMap(key ast.Expr, value ast.Expr) *ast.CallExpr {
 
 // TypeAssert returns an assignment statement with a type assertion
 // 	<lhs>, ok := <rhs>.(<type>)
-func TypeAssert(lhs ast.Expr, rhs ast.Expr, typ ast.Expr) *ast.AssignStmt {
+func TypeAssert(lhs dst.Expr, rhs dst.Expr, typ dst.Expr) *dst.AssignStmt {
 
-	return &ast.AssignStmt{
-		Lhs: []ast.Expr{
+	return &dst.AssignStmt{
+		Lhs: []dst.Expr{
 			lhs,
-			ast.NewIdent("ok"),
+			dst.NewIdent("ok"),
 		},
 		Tok: token.DEFINE,
-		Rhs: []ast.Expr{
-			&ast.TypeAssertExpr{
+		Rhs: []dst.Expr{
+			&dst.TypeAssertExpr{
 				X:    rhs,
 				Type: typ,
 			},
@@ -175,19 +175,19 @@ func TypeAssert(lhs ast.Expr, rhs ast.Expr, typ ast.Expr) *ast.AssignStmt {
 //	if ok {
 //		return <returns>
 //	}
-func ReturnIfOk(returns ...ast.Expr) *ast.IfStmt {
-	return ReturnIfExpr(ast.NewIdent("ok"), returns...)
+func ReturnIfOk(returns ...dst.Expr) *dst.IfStmt {
+	return ReturnIfExpr(dst.NewIdent("ok"), returns...)
 }
 
 // ReturnIfNotOk checks a boolean ok variable and if it is not ok returns the specified values
 //	if !ok {
 //		return <returns>
 //	}
-func ReturnIfNotOk(returns ...ast.Expr) *ast.IfStmt {
+func ReturnIfNotOk(returns ...dst.Expr) *dst.IfStmt {
 	return ReturnIfExpr(
-		&ast.UnaryExpr{
+		&dst.UnaryExpr{
 			Op: token.NOT,
-			X:  ast.NewIdent("ok"),
+			X:  dst.NewIdent("ok"),
 		},
 		returns...)
 }
@@ -196,12 +196,12 @@ func ReturnIfNotOk(returns ...ast.Expr) *ast.IfStmt {
 // 	if <toCheck> == nil {
 // 		return <returns...>
 //	}
-func ReturnIfNil(toCheck ast.Expr, returns ...ast.Expr) ast.Stmt {
+func ReturnIfNil(toCheck dst.Expr, returns ...dst.Expr) dst.Stmt {
 	return ReturnIfExpr(
-		&ast.BinaryExpr{
+		&dst.BinaryExpr{
 			X:  toCheck,
 			Op: token.EQL,
-			Y:  ast.NewIdent("nil"),
+			Y:  dst.NewIdent("nil"),
 		},
 		returns...)
 }
@@ -210,12 +210,12 @@ func ReturnIfNil(toCheck ast.Expr, returns ...ast.Expr) ast.Stmt {
 // 	if <toCheck> != nil {
 // 		return <returns...>
 //	}
-func ReturnIfNotNil(toCheck ast.Expr, returns ...ast.Expr) ast.Stmt {
+func ReturnIfNotNil(toCheck dst.Expr, returns ...dst.Expr) dst.Stmt {
 	return ReturnIfExpr(
-		&ast.BinaryExpr{
+		&dst.BinaryExpr{
 			X:  toCheck,
 			Op: token.NEQ,
-			Y:  ast.NewIdent("nil"),
+			Y:  dst.NewIdent("nil"),
 		},
 		returns...)
 }
@@ -224,16 +224,16 @@ func ReturnIfNotNil(toCheck ast.Expr, returns ...ast.Expr) ast.Stmt {
 //	if <cond> {
 // 		return <returns...>
 //	}
-func ReturnIfExpr(cond ast.Expr, returns ...ast.Expr) *ast.IfStmt {
+func ReturnIfExpr(cond dst.Expr, returns ...dst.Expr) *dst.IfStmt {
 	if len(returns) == 0 {
 		panic("Expected at least 1 return for ReturnIfOk")
 	}
 
-	return &ast.IfStmt{
+	return &dst.IfStmt{
 		Cond: cond,
-		Body: &ast.BlockStmt{
-			List: []ast.Stmt{
-				&ast.ReturnStmt{
+		Body: &dst.BlockStmt{
+			List: []dst.Stmt{
+				&dst.ReturnStmt{
 					Results: returns,
 				},
 			},
@@ -243,8 +243,8 @@ func ReturnIfExpr(cond ast.Expr, returns ...ast.Expr) *ast.IfStmt {
 
 // FormatError produces a call to fmt.Errorf with the given format string and args
 //	fmt.Errorf(<formatString>, <args>)
-func FormatError(fmtPackage string, formatString string, args ...ast.Expr) ast.Expr {
-	var callArgs []ast.Expr
+func FormatError(fmtPackage string, formatString string, args ...dst.Expr) dst.Expr {
+	var callArgs []dst.Expr
 	callArgs = append(
 		callArgs,
 		StringLiteral(formatString))
@@ -254,8 +254,8 @@ func FormatError(fmtPackage string, formatString string, args ...ast.Expr) ast.E
 
 // AddrOf returns a statement that gets the address of the provided expression.
 //	&<expr>
-func AddrOf(exp ast.Expr) *ast.UnaryExpr {
-	return &ast.UnaryExpr{
+func AddrOf(exp dst.Expr) *dst.UnaryExpr {
+	return &dst.UnaryExpr{
 		Op: token.AND,
 		X:  exp,
 	}
@@ -264,11 +264,11 @@ func AddrOf(exp ast.Expr) *ast.UnaryExpr {
 // Returns creates a return statement with one or more expressions, of the form
 //    return <expr>
 // or return <expr>, <expr>, ...
-func Returns(returns ...ast.Expr) ast.Stmt {
-	return &ast.ReturnStmt{
-		Decs: ast.ReturnStmtDecorations{
-			NodeDecs: ast.NodeDecs{
-				Before: ast.NewLine,
+func Returns(returns ...dst.Expr) dst.Stmt {
+	return &dst.ReturnStmt{
+		Decs: dst.ReturnStmtDecorations{
+			NodeDecs: dst.NodeDecs{
+				Before: dst.NewLine,
 			},
 		},
 		Results: returns,
@@ -277,9 +277,9 @@ func Returns(returns ...ast.Expr) ast.Stmt {
 
 // QualifiedTypeName generates a reference to a type within an imported package
 // of the form <pkg>.<name>
-func QualifiedTypeName(pkg string, name string) *ast.SelectorExpr {
-	return &ast.SelectorExpr{
-		X:   ast.NewIdent(pkg),
-		Sel: ast.NewIdent(name),
+func QualifiedTypeName(pkg string, name string) *dst.SelectorExpr {
+	return &dst.SelectorExpr{
+		X:   dst.NewIdent(pkg),
+		Sel: dst.NewIdent(name),
 	}
 }

--- a/hack/generator/pkg/astbuilder/calls.go
+++ b/hack/generator/pkg/astbuilder/calls.go
@@ -6,15 +6,15 @@
 package astbuilder
 
 import (
-	ast "github.com/dave/dst"
+	"github.com/dave/dst"
 )
 
 // CallFunc creates an expression to call a function with specified arguments, generating code
 // like:
 // <funcName>(<arguments>...)
-func CallFunc(funcName string, arguments ...ast.Expr) ast.Expr {
-	return &ast.CallExpr{
-		Fun:  ast.NewIdent(funcName),
+func CallFunc(funcName string, arguments ...dst.Expr) dst.Expr {
+	return &dst.CallExpr{
+		Fun:  dst.NewIdent(funcName),
 		Args: arguments,
 	}
 }
@@ -22,11 +22,11 @@ func CallFunc(funcName string, arguments ...ast.Expr) ast.Expr {
 // CallQualifiedFunc creates an expression to call a qualified function with the specified
 // arguments, generating code like:
 // <qualifier>.<funcName>(arguments...)
-func CallQualifiedFunc(qualifier string, funcName string, arguments ...ast.Expr) ast.Expr {
-	return &ast.CallExpr{
-		Fun: &ast.SelectorExpr{
-			X:   ast.NewIdent(qualifier),
-			Sel: ast.NewIdent(funcName),
+func CallQualifiedFunc(qualifier string, funcName string, arguments ...dst.Expr) dst.Expr {
+	return &dst.CallExpr{
+		Fun: &dst.SelectorExpr{
+			X:   dst.NewIdent(qualifier),
+			Sel: dst.NewIdent(funcName),
 		},
 		Args: arguments,
 	}
@@ -36,8 +36,8 @@ func CallQualifiedFunc(qualifier string, funcName string, arguments ...ast.Expr)
 // like
 // <funcName>(arguments...)
 // If you want to use the result of the function call as a value, use CallFunc() instead
-func InvokeFunc(funcName string, arguments ...ast.Expr) ast.Stmt {
-	return &ast.ExprStmt{
+func InvokeFunc(funcName string, arguments ...dst.Expr) dst.Stmt {
+	return &dst.ExprStmt{
 		X: CallFunc(funcName, arguments...),
 	}
 }
@@ -46,8 +46,8 @@ func InvokeFunc(funcName string, arguments ...ast.Expr) ast.Stmt {
 // arguments, generating code like:
 // <qualifier>.<funcName>(arguments...)
 // If you want to use the result of the function call as a value, use CallQualifiedFunc() instead
-func InvokeQualifiedFunc(qualifier string, funcName string, arguments ...ast.Expr) ast.Stmt {
-	return &ast.ExprStmt{
+func InvokeQualifiedFunc(qualifier string, funcName string, arguments ...dst.Expr) dst.Stmt {
+	return &dst.ExprStmt{
 		X: CallQualifiedFunc(qualifier, funcName, arguments...),
 	}
 }

--- a/hack/generator/pkg/astbuilder/comments.go
+++ b/hack/generator/pkg/astbuilder/comments.go
@@ -9,12 +9,12 @@ import (
 	"regexp"
 	"strings"
 
-	ast "github.com/dave/dst"
+	"github.com/dave/dst"
 )
 
 // AddWrappedComments adds comments to the specified list, wrapping text to the specified width as
 // it goes. Respects any existing line breaks specified by \n or <br>
-func AddWrappedComments(commentList *ast.Decorations, comments []string, width int) {
+func AddWrappedComments(commentList *dst.Decorations, comments []string, width int) {
 	for _, comment := range comments {
 		// Skip empty comments
 		if comment == "" {
@@ -27,14 +27,14 @@ func AddWrappedComments(commentList *ast.Decorations, comments []string, width i
 
 // AddWrappedComment adds a single comment to the specified list, wrapping text to the specified
 // width as it goes. Respects any existing line breaks specified by \n or <br>
-func AddWrappedComment(commentList *ast.Decorations, comment string, width int) {
+func AddWrappedComment(commentList *dst.Decorations, comment string, width int) {
 	for _, c := range formatComment(comment, width) {
 		AddComment(commentList, c)
 	}
 }
 
 // AddComments adds preformatted comments to the specified list
-func AddComments(commentList *ast.Decorations, comments []string) {
+func AddComments(commentList *dst.Decorations, comments []string) {
 	for _, comment := range comments {
 		// Skip empty comments
 		if comment == "" {
@@ -46,7 +46,7 @@ func AddComments(commentList *ast.Decorations, comments []string) {
 }
 
 // AddComment adds a single comment line to the specified list
-func AddComment(commentList *ast.Decorations, comment string) {
+func AddComment(commentList *dst.Decorations, comment string) {
 	line := comment
 
 	if !strings.HasPrefix(line, "//") {
@@ -129,7 +129,7 @@ func findBreakPoint(line string, start int, width int) int {
 }
 
 // CommentLength returns the text length of the comments, including EoLN characters
-func CommentLength(comments ast.Decorations) int {
+func CommentLength(comments dst.Decorations) int {
 	length := 0
 	for _, l := range comments {
 		length += len(l) + 1 // length including EoLN

--- a/hack/generator/pkg/astbuilder/literals.go
+++ b/hack/generator/pkg/astbuilder/literals.go
@@ -10,26 +10,26 @@ import (
 	"go/token"
 	"strings"
 
-	ast "github.com/dave/dst"
+	"github.com/dave/dst"
 )
 
 // TextLiteral creates the AST node for a literal text value
 // No additional text is included
-func TextLiteral(content string) *ast.BasicLit {
-	return &ast.BasicLit{
+func TextLiteral(content string) *dst.BasicLit {
+	return &dst.BasicLit{
 		Value: content,
 		Kind:  token.STRING,
 	}
 }
 
 // TextLiteralf creates the AST node for literal text based on a format string
-func TextLiteralf(format string, a ...interface{}) *ast.BasicLit {
+func TextLiteralf(format string, a ...interface{}) *dst.BasicLit {
 	return TextLiteral(fmt.Sprintf(format, a...))
 }
 
 // StringLiteral creates the AST node for a literal string value
 // Leading and trailing quotes are added as required and any existing quotes are escaped
-func StringLiteral(content string) *ast.BasicLit {
+func StringLiteral(content string) *dst.BasicLit {
 	// Pay attention to the string escaping here!
 	escaped := content
 	escaped = strings.ReplaceAll(escaped, "\\", "\\\\")
@@ -41,13 +41,13 @@ func StringLiteral(content string) *ast.BasicLit {
 
 // StringLiteralf creates the AST node for a literal string value based on a format string
 // Leading and trailing quotes are added as required and any existing quotes are escaped
-func StringLiteralf(format string, a ...interface{}) *ast.BasicLit {
+func StringLiteralf(format string, a ...interface{}) *dst.BasicLit {
 	return StringLiteral(fmt.Sprintf(format, a...))
 }
 
 // IntLiteral() create the AST node for a literal integer value
-func IntLiteral(value int) *ast.BasicLit {
-	return &ast.BasicLit{
+func IntLiteral(value int) *dst.BasicLit {
+	return &dst.BasicLit{
 		Value: fmt.Sprint(value),
 		Kind:  token.INT,
 	}

--- a/hack/generator/pkg/astmodel/allof_type.go
+++ b/hack/generator/pkg/astmodel/allof_type.go
@@ -10,7 +10,7 @@ import (
 	"sort"
 	"strings"
 
-	ast "github.com/dave/dst"
+	"github.com/dave/dst"
 	"github.com/pkg/errors"
 	"k8s.io/klog/v2"
 )
@@ -109,13 +109,13 @@ var allOfPanicMsg = "AllOfType should have been replaced by generation time by '
 
 // AsType always panics; AllOf cannot be represented by the Go AST and must be
 // lowered to an object type
-func (allOf AllOfType) AsType(_ *CodeGenerationContext) ast.Expr {
+func (allOf AllOfType) AsType(_ *CodeGenerationContext) dst.Expr {
 	panic(errors.New(allOfPanicMsg))
 }
 
 // AsDeclarations always panics; AllOf cannot be represented by the Go AST and must be
 // lowered to an object type
-func (allOf AllOfType) AsDeclarations(_ *CodeGenerationContext, _ DeclarationContext) []ast.Decl {
+func (allOf AllOfType) AsDeclarations(_ *CodeGenerationContext, _ DeclarationContext) []dst.Decl {
 	panic(errors.New(allOfPanicMsg))
 }
 

--- a/hack/generator/pkg/astmodel/arm_spec_interface.go
+++ b/hack/generator/pkg/astmodel/arm_spec_interface.go
@@ -9,7 +9,7 @@ import (
 	"fmt"
 
 	"github.com/Azure/k8s-infra/hack/generator/pkg/astbuilder"
-	ast "github.com/dave/dst"
+	"github.com/dave/dst"
 	"github.com/pkg/errors"
 )
 
@@ -81,7 +81,7 @@ func NewArmSpecInterfaceImpl(
 	return result, nil
 }
 
-func getNameFunction(k *objectFunction, codeGenerationContext *CodeGenerationContext, receiver TypeName, methodName string) *ast.FuncDecl {
+func getNameFunction(k *objectFunction, codeGenerationContext *CodeGenerationContext, receiver TypeName, methodName string) *dst.FuncDecl {
 	return armSpecInterfaceSimpleGetFunction(
 		k,
 		codeGenerationContext,
@@ -91,7 +91,7 @@ func getNameFunction(k *objectFunction, codeGenerationContext *CodeGenerationCon
 		false)
 }
 
-func getTypeFunction(k *objectFunction, codeGenerationContext *CodeGenerationContext, receiver TypeName, methodName string) *ast.FuncDecl {
+func getTypeFunction(k *objectFunction, codeGenerationContext *CodeGenerationContext, receiver TypeName, methodName string) *dst.FuncDecl {
 	return armSpecInterfaceSimpleGetFunction(
 		k,
 		codeGenerationContext,
@@ -101,7 +101,7 @@ func getTypeFunction(k *objectFunction, codeGenerationContext *CodeGenerationCon
 		true)
 }
 
-func getApiVersionFunction(k *objectFunction, codeGenerationContext *CodeGenerationContext, receiver TypeName, methodName string) *ast.FuncDecl {
+func getApiVersionFunction(k *objectFunction, codeGenerationContext *CodeGenerationContext, receiver TypeName, methodName string) *dst.FuncDecl {
 	return armSpecInterfaceSimpleGetFunction(
 		k,
 		codeGenerationContext,
@@ -117,22 +117,22 @@ func armSpecInterfaceSimpleGetFunction(
 	receiver TypeName,
 	methodName string,
 	propertyName string,
-	castToString bool) *ast.FuncDecl {
+	castToString bool) *dst.FuncDecl {
 
 	receiverIdent := k.idFactory.CreateIdentifier(receiver.Name(), NotExported)
 	receiverType := receiver.AsType(codeGenerationContext)
 
-	var result ast.Expr
-	result = &ast.SelectorExpr{
-		X:   ast.NewIdent(receiverIdent),
-		Sel: ast.NewIdent(propertyName),
+	var result dst.Expr
+	result = &dst.SelectorExpr{
+		X:   dst.NewIdent(receiverIdent),
+		Sel: dst.NewIdent(propertyName),
 	}
 
 	// This is not the most beautiful thing but it saves some code.
 	if castToString {
-		result = &ast.CallExpr{
-			Fun: ast.NewIdent("string"),
-			Args: []ast.Expr{
+		result = &dst.CallExpr{
+			Fun: dst.NewIdent("string"),
+			Args: []dst.Expr{
 				result,
 			},
 		}
@@ -147,15 +147,15 @@ func armSpecInterfaceSimpleGetFunction(
 		// TODO: for example on resource we use ptr receiver... the inconsistency is
 		// TODO: awkward...
 		ReceiverType: receiverType,
-		Body: []ast.Stmt{
-			&ast.ReturnStmt{
-				Decs: ast.ReturnStmtDecorations{
-					NodeDecs: ast.NodeDecs{
-						Before: ast.NewLine,
-						After:  ast.NewLine,
+		Body: []dst.Stmt{
+			&dst.ReturnStmt{
+				Decs: dst.ReturnStmtDecorations{
+					NodeDecs: dst.NodeDecs{
+						Before: dst.NewLine,
+						After:  dst.NewLine,
 					},
 				},
-				Results: []ast.Expr{
+				Results: []dst.Expr{
 					result,
 				},
 			},

--- a/hack/generator/pkg/astmodel/armconversion/arm_conversion_function.go
+++ b/hack/generator/pkg/astmodel/armconversion/arm_conversion_function.go
@@ -9,7 +9,7 @@ import (
 	"fmt"
 
 	"github.com/Azure/k8s-infra/hack/generator/pkg/astmodel"
-	ast "github.com/dave/dst"
+	"github.com/dave/dst"
 )
 
 type ConversionDirection string
@@ -57,7 +57,7 @@ func (c *ArmConversionFunction) References() astmodel.TypeNameSet {
 }
 
 // AsFunc returns the function as a Go AST
-func (c *ArmConversionFunction) AsFunc(codeGenerationContext *astmodel.CodeGenerationContext, receiver astmodel.TypeName) *ast.FuncDecl {
+func (c *ArmConversionFunction) AsFunc(codeGenerationContext *astmodel.CodeGenerationContext, receiver astmodel.TypeName) *dst.FuncDecl {
 	switch c.direction {
 	case ConversionDirectionToArm:
 		return c.asConvertToArmFunc(codeGenerationContext, receiver, c.Name())
@@ -71,7 +71,7 @@ func (c *ArmConversionFunction) AsFunc(codeGenerationContext *astmodel.CodeGener
 func (c *ArmConversionFunction) asConvertToArmFunc(
 	codeGenerationContext *astmodel.CodeGenerationContext,
 	receiver astmodel.TypeName,
-	methodName string) *ast.FuncDecl {
+	methodName string) *dst.FuncDecl {
 
 	builder := newConvertToArmFunctionBuilder(
 		c,
@@ -85,7 +85,7 @@ func (c *ArmConversionFunction) asConvertToArmFunc(
 func (c *ArmConversionFunction) asConvertFromArmFunc(
 	codeGenerationContext *astmodel.CodeGenerationContext,
 	receiver astmodel.TypeName,
-	methodName string) *ast.FuncDecl {
+	methodName string) *dst.FuncDecl {
 
 	builder := newConvertFromArmFunctionBuilder(
 		c,

--- a/hack/generator/pkg/astmodel/armconversion/create_empty_arm_value_function.go
+++ b/hack/generator/pkg/astmodel/armconversion/create_empty_arm_value_function.go
@@ -8,7 +8,7 @@ package armconversion
 import (
 	"github.com/Azure/k8s-infra/hack/generator/pkg/astbuilder"
 	"github.com/Azure/k8s-infra/hack/generator/pkg/astmodel"
-	ast "github.com/dave/dst"
+	"github.com/dave/dst"
 )
 
 // CreateEmptyArmValueFunc represents a function that creates
@@ -21,16 +21,16 @@ type CreateEmptyArmValueFunc struct {
 
 var _ astmodel.Function = &CreateEmptyArmValueFunc{}
 
-func (f CreateEmptyArmValueFunc) AsFunc(c *astmodel.CodeGenerationContext, receiver astmodel.TypeName) *ast.FuncDecl {
+func (f CreateEmptyArmValueFunc) AsFunc(c *astmodel.CodeGenerationContext, receiver astmodel.TypeName) *dst.FuncDecl {
 	fn := &astbuilder.FuncDetails{
 		Name:          "CreateEmptyArmValue",
 		ReceiverIdent: f.idFactory.CreateIdentifier(receiver.Name(), astmodel.NotExported),
-		ReceiverType: &ast.StarExpr{
-			X: ast.NewIdent(receiver.Name()),
+		ReceiverType: &dst.StarExpr{
+			X: dst.NewIdent(receiver.Name()),
 		},
-		Body: []ast.Stmt{
-			astbuilder.Returns(&ast.CompositeLit{
-				Type: ast.NewIdent(f.armTypeName.Name()),
+		Body: []dst.Stmt{
+			astbuilder.Returns(&dst.CompositeLit{
+				Type: dst.NewIdent(f.armTypeName.Name()),
 			}),
 		},
 	}

--- a/hack/generator/pkg/astmodel/array_type.go
+++ b/hack/generator/pkg/astmodel/array_type.go
@@ -8,7 +8,7 @@ package astmodel
 import (
 	"fmt"
 
-	ast "github.com/dave/dst"
+	"github.com/dave/dst"
 )
 
 // ArrayType is used for properties that contain an array of values
@@ -29,13 +29,13 @@ func (array *ArrayType) Element() Type {
 // assert we implemented Type correctly
 var _ Type = (*ArrayType)(nil)
 
-func (array *ArrayType) AsDeclarations(codeGenerationContext *CodeGenerationContext, declContext DeclarationContext) []ast.Decl {
+func (array *ArrayType) AsDeclarations(codeGenerationContext *CodeGenerationContext, declContext DeclarationContext) []dst.Decl {
 	return AsSimpleDeclarations(codeGenerationContext, declContext, array)
 }
 
 // AsType renders the Go abstract syntax tree for an array type
-func (array *ArrayType) AsType(codeGenerationContext *CodeGenerationContext) ast.Expr {
-	return &ast.ArrayType{
+func (array *ArrayType) AsType(codeGenerationContext *CodeGenerationContext) dst.Expr {
+	return &dst.ArrayType{
 		Elt: array.element.AsType(codeGenerationContext),
 	}
 }

--- a/hack/generator/pkg/astmodel/enum_type.go
+++ b/hack/generator/pkg/astmodel/enum_type.go
@@ -11,7 +11,7 @@ import (
 	"sort"
 
 	"github.com/Azure/k8s-infra/hack/generator/pkg/astbuilder"
-	ast "github.com/dave/dst"
+	"github.com/dave/dst"
 	"k8s.io/klog/v2"
 )
 
@@ -40,17 +40,17 @@ func NewEnumType(baseType *PrimitiveType, options []EnumValue) *EnumType {
 }
 
 // AsDeclarations converts the EnumType to a series of Go AST Decls
-func (enum *EnumType) AsDeclarations(codeGenerationContext *CodeGenerationContext, declContext DeclarationContext) []ast.Decl {
-	result := []ast.Decl{enum.createBaseDeclaration(codeGenerationContext, declContext.Name, declContext.Description, declContext.Validations)}
+func (enum *EnumType) AsDeclarations(codeGenerationContext *CodeGenerationContext, declContext DeclarationContext) []dst.Decl {
+	result := []dst.Decl{enum.createBaseDeclaration(codeGenerationContext, declContext.Name, declContext.Description, declContext.Validations)}
 
-	var specs []ast.Spec
+	var specs []dst.Spec
 	for _, v := range enum.options {
 		s := enum.createValueDeclaration(declContext.Name, v)
 		specs = append(specs, s)
 	}
 
 	if len(specs) > 0 {
-		declaration := &ast.GenDecl{
+		declaration := &dst.GenDecl{
 			Tok:   token.CONST,
 			Specs: specs,
 		}
@@ -65,21 +65,21 @@ func (enum *EnumType) createBaseDeclaration(
 	codeGenerationContext *CodeGenerationContext,
 	name TypeName,
 	description []string,
-	validations []KubeBuilderValidation) ast.Decl {
+	validations []KubeBuilderValidation) dst.Decl {
 
-	typeSpecification := &ast.TypeSpec{
-		Name: ast.NewIdent(name.Name()),
+	typeSpecification := &dst.TypeSpec{
+		Name: dst.NewIdent(name.Name()),
 		Type: enum.baseType.AsType(codeGenerationContext),
 	}
 
-	declaration := &ast.GenDecl{
-		Decs: ast.GenDeclDecorations{
-			NodeDecs: ast.NodeDecs{
-				Before: ast.EmptyLine,
+	declaration := &dst.GenDecl{
+		Decs: dst.GenDeclDecorations{
+			NodeDecs: dst.NodeDecs{
+				Before: dst.EmptyLine,
 			},
 		},
 		Tok: token.TYPE,
-		Specs: []ast.Spec{
+		Specs: []dst.Spec{
 			typeSpecification,
 		},
 	}
@@ -93,11 +93,11 @@ func (enum *EnumType) createBaseDeclaration(
 	return declaration
 }
 
-func (enum *EnumType) createValueDeclaration(name TypeName, value EnumValue) ast.Spec {
+func (enum *EnumType) createValueDeclaration(name TypeName, value EnumValue) dst.Spec {
 
-	valueSpec := &ast.ValueSpec{
-		Names: []*ast.Ident{ast.NewIdent(GetEnumValueId(name.name, value))},
-		Values: []ast.Expr{
+	valueSpec := &dst.ValueSpec{
+		Names: []*dst.Ident{dst.NewIdent(GetEnumValueId(name.name, value))},
+		Values: []dst.Expr{
 			astbuilder.CallFunc(name.Name(), astbuilder.TextLiteral(value.Value)),
 		},
 	}
@@ -106,7 +106,7 @@ func (enum *EnumType) createValueDeclaration(name TypeName, value EnumValue) ast
 }
 
 // AsType implements Type for EnumType
-func (enum *EnumType) AsType(codeGenerationContext *CodeGenerationContext) ast.Expr {
+func (enum *EnumType) AsType(codeGenerationContext *CodeGenerationContext) dst.Expr {
 	// this should "never" happen as we name all enums; warn about it if it does
 	klog.Warning("Emitting unnamed enum, something’s awry")
 	return enum.baseType.AsType(codeGenerationContext)

--- a/hack/generator/pkg/astmodel/errored_type.go
+++ b/hack/generator/pkg/astmodel/errored_type.go
@@ -8,7 +8,7 @@ package astmodel
 import (
 	"fmt"
 
-	ast "github.com/dave/dst"
+	"github.com/dave/dst"
 	"github.com/pkg/errors"
 	kerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/klog/v2"
@@ -107,7 +107,7 @@ func (errored ErroredType) handleWarningsAndErrors() {
 	}
 }
 
-func (errored ErroredType) AsDeclarations(cgc *CodeGenerationContext, dc DeclarationContext) []ast.Decl {
+func (errored ErroredType) AsDeclarations(cgc *CodeGenerationContext, dc DeclarationContext) []dst.Decl {
 	errored.handleWarningsAndErrors()
 	if errored.inner == nil {
 		return nil
@@ -116,7 +116,7 @@ func (errored ErroredType) AsDeclarations(cgc *CodeGenerationContext, dc Declara
 	return errored.inner.AsDeclarations(cgc, dc)
 }
 
-func (errored ErroredType) AsType(cgc *CodeGenerationContext) ast.Expr {
+func (errored ErroredType) AsType(cgc *CodeGenerationContext) dst.Expr {
 	errored.handleWarningsAndErrors()
 	if errored.inner == nil {
 		return nil

--- a/hack/generator/pkg/astmodel/flagged_type.go
+++ b/hack/generator/pkg/astmodel/flagged_type.go
@@ -9,7 +9,7 @@ import (
 	"sort"
 	"strings"
 
-	ast "github.com/dave/dst"
+	"github.com/dave/dst"
 	"github.com/pkg/errors"
 )
 
@@ -105,13 +105,13 @@ func (ft *FlaggedType) References() TypeNameSet {
 }
 
 // AsType renders as a Go abstract syntax tree for a type
-// (yes this says ast.Expr but that is what the Go 'ast' package uses for types)
-func (ft *FlaggedType) AsType(ctx *CodeGenerationContext) ast.Expr {
+// (yes this says ast.Expr but that is what the Go 'dst' package uses for types)
+func (ft *FlaggedType) AsType(ctx *CodeGenerationContext) dst.Expr {
 	return ft.element.AsType(ctx)
 }
 
 // AsDeclarations renders as a Go abstract syntax tree for a declaration
-func (ft *FlaggedType) AsDeclarations(ctx *CodeGenerationContext, declContext DeclarationContext) []ast.Decl {
+func (ft *FlaggedType) AsDeclarations(ctx *CodeGenerationContext, declContext DeclarationContext) []dst.Decl {
 	return ft.element.AsDeclarations(ctx, declContext)
 }
 

--- a/hack/generator/pkg/astmodel/function.go
+++ b/hack/generator/pkg/astmodel/function.go
@@ -6,7 +6,7 @@
 package astmodel
 
 import (
-	ast "github.com/dave/dst"
+	"github.com/dave/dst"
 )
 
 // Function represents something that is an (unnamed) Go function
@@ -22,7 +22,7 @@ type Function interface {
 	References() TypeNameSet
 
 	// AsFunc renders the current instance as a Go abstract syntax tree
-	AsFunc(codeGenerationContext *CodeGenerationContext, receiver TypeName) *ast.FuncDecl
+	AsFunc(codeGenerationContext *CodeGenerationContext, receiver TypeName) *dst.FuncDecl
 
 	// Equals determines if this Function is equal to another one
 	Equals(f Function) bool

--- a/hack/generator/pkg/astmodel/function_test.go
+++ b/hack/generator/pkg/astmodel/function_test.go
@@ -6,7 +6,7 @@
 package astmodel
 
 import (
-	ast "github.com/dave/dst"
+	"github.com/dave/dst"
 )
 
 type FakeFunction struct {
@@ -36,7 +36,7 @@ func (fake *FakeFunction) References() TypeNameSet {
 	return fake.Referenced
 }
 
-func (fake *FakeFunction) AsFunc(_ *CodeGenerationContext, _ TypeName) *ast.FuncDecl {
+func (fake *FakeFunction) AsFunc(_ *CodeGenerationContext, _ TypeName) *dst.FuncDecl {
 	panic("implement me")
 }
 

--- a/hack/generator/pkg/astmodel/interface_implementer.go
+++ b/hack/generator/pkg/astmodel/interface_implementer.go
@@ -9,7 +9,7 @@ import (
 	"go/token"
 	"sort"
 
-	ast "github.com/dave/dst"
+	"github.com/dave/dst"
 )
 
 type InterfaceImplementer struct {
@@ -54,9 +54,9 @@ func (i InterfaceImplementer) References() TypeNameSet {
 func (i InterfaceImplementer) AsDeclarations(
 	codeGenerationContext *CodeGenerationContext,
 	typeName TypeName,
-	_ []string) []ast.Decl {
+	_ []string) []dst.Decl {
 
-	var result []ast.Decl
+	var result []dst.Decl
 
 	// interfaces must be ordered by name for deterministic output
 	// (We sort them directly to skip future lookups)
@@ -121,41 +121,41 @@ func (i InterfaceImplementer) RequiredPackageReferences() *PackageReferenceSet {
 func (i InterfaceImplementer) generateInterfaceImplAssertion(
 	codeGenerationContext *CodeGenerationContext,
 	iface *InterfaceImplementation,
-	typeName TypeName) ast.Decl {
+	typeName TypeName) dst.Decl {
 
 	ifacePackageName, err := codeGenerationContext.GetImportedPackageName(iface.name.PackageReference)
 	if err != nil {
 		panic(err)
 	}
 
-	var doc ast.Decorations
+	var doc dst.Decorations
 	if iface.annotation != "" {
 		doc.Append("// " + iface.annotation)
 		doc.Append("\n")
 	}
 
-	typeAssertion := &ast.GenDecl{
+	typeAssertion := &dst.GenDecl{
 		Tok: token.VAR,
-		Decs: ast.GenDeclDecorations{
-			NodeDecs: ast.NodeDecs{
-				Before: ast.EmptyLine,
+		Decs: dst.GenDeclDecorations{
+			NodeDecs: dst.NodeDecs{
+				Before: dst.EmptyLine,
 				Start:  doc,
 			},
 		},
-		Specs: []ast.Spec{
-			&ast.ValueSpec{
-				Type: &ast.SelectorExpr{
-					X:   ast.NewIdent(ifacePackageName),
-					Sel: ast.NewIdent(iface.name.name),
+		Specs: []dst.Spec{
+			&dst.ValueSpec{
+				Type: &dst.SelectorExpr{
+					X:   dst.NewIdent(ifacePackageName),
+					Sel: dst.NewIdent(iface.name.name),
 				},
-				Names: []*ast.Ident{
-					ast.NewIdent("_"),
+				Names: []*dst.Ident{
+					dst.NewIdent("_"),
 				},
-				Values: []ast.Expr{
-					&ast.UnaryExpr{
+				Values: []dst.Expr{
+					&dst.UnaryExpr{
 						Op: token.AND,
-						X: &ast.CompositeLit{
-							Type: ast.NewIdent(typeName.name),
+						X: &dst.CompositeLit{
+							Type: dst.NewIdent(typeName.name),
 						},
 					},
 				},

--- a/hack/generator/pkg/astmodel/kubebuilder_validations.go
+++ b/hack/generator/pkg/astmodel/kubebuilder_validations.go
@@ -13,7 +13,7 @@ import (
 	"strings"
 
 	"github.com/Azure/k8s-infra/hack/generator/pkg/astbuilder"
-	ast "github.com/dave/dst"
+	"github.com/dave/dst"
 	"k8s.io/klog/v2"
 )
 
@@ -51,7 +51,7 @@ func GenerateKubebuilderComment(validation KubeBuilderValidation) string {
 	return fmt.Sprintf("%s%s", prefix, validation.name)
 }
 
-func AddValidationComments(commentList *ast.Decorations, validations []KubeBuilderValidation) {
+func AddValidationComments(commentList *dst.Decorations, validations []KubeBuilderValidation) {
 	// generate validation comments:
 	for _, validation := range validations {
 		// these are not doc comments but they must go here to be emitted before the property

--- a/hack/generator/pkg/astmodel/kubernetes_resource_interface.go
+++ b/hack/generator/pkg/astmodel/kubernetes_resource_interface.go
@@ -11,7 +11,7 @@ import (
 	"strings"
 
 	"github.com/Azure/k8s-infra/hack/generator/pkg/astbuilder"
-	ast "github.com/dave/dst"
+	"github.com/dave/dst"
 	"github.com/pkg/errors"
 )
 
@@ -222,37 +222,37 @@ type objectFunction struct {
 	asFunc    asFuncType
 }
 
-type asFuncType func(f *objectFunction, codeGenerationContext *CodeGenerationContext, receiver TypeName, methodName string) *ast.FuncDecl
+type asFuncType func(f *objectFunction, codeGenerationContext *CodeGenerationContext, receiver TypeName, methodName string) *dst.FuncDecl
 
 // getEnumAzureNameFunction adds an AzureName() function that casts the AzureName property
 // with an enum value to a string
 func getEnumAzureNameFunction(enumType TypeName) asFuncType {
-	return func(f *objectFunction, codeGenerationContext *CodeGenerationContext, receiver TypeName, methodName string) *ast.FuncDecl {
+	return func(f *objectFunction, codeGenerationContext *CodeGenerationContext, receiver TypeName, methodName string) *dst.FuncDecl {
 		receiverIdent := f.idFactory.CreateIdentifier(receiver.Name(), NotExported)
 		receiverType := receiver.AsType(codeGenerationContext)
 
 		fn := &astbuilder.FuncDetails{
 			Name:          methodName,
 			ReceiverIdent: receiverIdent,
-			ReceiverType:  &ast.StarExpr{X: receiverType},
-			Body: []ast.Stmt{
-				&ast.ReturnStmt{
-					Decs: ast.ReturnStmtDecorations{
-						NodeDecs: ast.NodeDecs{
-							Before: ast.NewLine,
+			ReceiverType:  &dst.StarExpr{X: receiverType},
+			Body: []dst.Stmt{
+				&dst.ReturnStmt{
+					Decs: dst.ReturnStmtDecorations{
+						NodeDecs: dst.NodeDecs{
+							Before: dst.NewLine,
 						},
 					},
-					Results: []ast.Expr{
-						&ast.CallExpr{
+					Results: []dst.Expr{
+						&dst.CallExpr{
 							// cast from the enum value to string
-							Fun: ast.NewIdent("string"),
-							Args: []ast.Expr{
-								&ast.SelectorExpr{
-									X: &ast.SelectorExpr{
-										X:   ast.NewIdent(receiverIdent),
-										Sel: ast.NewIdent("Spec"),
+							Fun: dst.NewIdent("string"),
+							Args: []dst.Expr{
+								&dst.SelectorExpr{
+									X: &dst.SelectorExpr{
+										X:   dst.NewIdent(receiverIdent),
+										Sel: dst.NewIdent("Spec"),
 									},
-									Sel: ast.NewIdent(AzureNameProperty),
+									Sel: dst.NewIdent(AzureNameProperty),
 								},
 							},
 						},
@@ -270,36 +270,36 @@ func getEnumAzureNameFunction(enumType TypeName) asFuncType {
 // setEnumAzureNameFunction returns a function that sets the AzureName property to the result of casting
 // the argument string to the given enum type
 func setEnumAzureNameFunction(enumType TypeName) asFuncType {
-	return func(f *objectFunction, codeGenerationContext *CodeGenerationContext, receiver TypeName, methodName string) *ast.FuncDecl {
+	return func(f *objectFunction, codeGenerationContext *CodeGenerationContext, receiver TypeName, methodName string) *dst.FuncDecl {
 		receiverIdent := f.idFactory.CreateIdentifier(receiver.Name(), NotExported)
 		receiverType := receiver.AsType(codeGenerationContext)
 
-		azureNameProp := &ast.SelectorExpr{
-			X:   ast.NewIdent(receiverIdent),
-			Sel: ast.NewIdent(AzureNameProperty),
+		azureNameProp := &dst.SelectorExpr{
+			X:   dst.NewIdent(receiverIdent),
+			Sel: dst.NewIdent(AzureNameProperty),
 		}
 
-		enumTypeAST := ast.NewIdent(enumType.Name())
+		enumTypeAST := dst.NewIdent(enumType.Name())
 
 		fn := &astbuilder.FuncDetails{
 			Name:          methodName,
 			ReceiverIdent: receiverIdent,
-			ReceiverType:  &ast.StarExpr{X: receiverType},
-			Body: []ast.Stmt{
+			ReceiverType:  &dst.StarExpr{X: receiverType},
+			Body: []dst.Stmt{
 				astbuilder.SimpleAssignment(
 					azureNameProp,
 					token.ASSIGN,
-					&ast.CallExpr{
+					&dst.CallExpr{
 						// cast from the string value to the enum
 						Fun:  enumTypeAST,
-						Args: []ast.Expr{ast.NewIdent("azureName")},
+						Args: []dst.Expr{dst.NewIdent("azureName")},
 					},
 				),
 			},
 		}
 
 		fn.AddComments(fmt.Sprintf("sets the Azure name from the given %s value", enumType.String()))
-		fn.AddParameter("azureName", ast.NewIdent("string"))
+		fn.AddParameter("azureName", dst.NewIdent("string"))
 		return fn.DefineFunc()
 	}
 }
@@ -317,23 +317,23 @@ func fixedValueGetAzureNameFunction(fixedValue string) asFuncType {
 		fixedValue = fmt.Sprintf("%q", fixedValue)
 	}
 
-	return func(f *objectFunction, codeGenerationContext *CodeGenerationContext, receiver TypeName, methodName string) *ast.FuncDecl {
+	return func(f *objectFunction, codeGenerationContext *CodeGenerationContext, receiver TypeName, methodName string) *dst.FuncDecl {
 		receiverIdent := f.idFactory.CreateIdentifier(receiver.Name(), NotExported)
 		receiverType := receiver.AsType(codeGenerationContext)
 
 		fn := &astbuilder.FuncDetails{
 			Name:          methodName,
 			ReceiverIdent: receiverIdent,
-			ReceiverType:  &ast.StarExpr{X: receiverType},
-			Body: []ast.Stmt{
-				&ast.ReturnStmt{
-					Decs: ast.ReturnStmtDecorations{
-						NodeDecs: ast.NodeDecs{
-							Before: ast.NewLine,
+			ReceiverType:  &dst.StarExpr{X: receiverType},
+			Body: []dst.Stmt{
+				&dst.ReturnStmt{
+					Decs: dst.ReturnStmtDecorations{
+						NodeDecs: dst.NodeDecs{
+							Before: dst.NewLine,
 						},
 					},
-					Results: []ast.Expr{
-						&ast.BasicLit{
+					Results: []dst.Expr{
+						&dst.BasicLit{
 							Kind:  token.STRING,
 							Value: fixedValue,
 						},
@@ -365,7 +365,7 @@ func (k *objectFunction) References() TypeNameSet {
 	return k.o.References()
 }
 
-func (k *objectFunction) AsFunc(codeGenerationContext *CodeGenerationContext, receiver TypeName) *ast.FuncDecl {
+func (k *objectFunction) AsFunc(codeGenerationContext *CodeGenerationContext, receiver TypeName) *dst.FuncDecl {
 	return k.asFunc(k, codeGenerationContext, receiver, k.name)
 }
 
@@ -384,44 +384,44 @@ func IsKubernetesResourceProperty(name PropertyName) bool {
 }
 
 // ownerFunction returns a function that returns the owner of the resource
-func ownerFunction(k *objectFunction, codeGenerationContext *CodeGenerationContext, receiver TypeName, methodName string) *ast.FuncDecl {
+func ownerFunction(k *objectFunction, codeGenerationContext *CodeGenerationContext, receiver TypeName, methodName string) *dst.FuncDecl {
 
 	receiverIdent := k.idFactory.CreateIdentifier(receiver.Name(), NotExported)
 
 	fn := &astbuilder.FuncDetails{
 		Name:          methodName,
 		ReceiverIdent: receiverIdent,
-		ReceiverType: &ast.StarExpr{
+		ReceiverType: &dst.StarExpr{
 			X: receiver.AsType(codeGenerationContext),
 		},
 		Params: nil,
-		Returns: []*ast.Field{
+		Returns: []*dst.Field{
 			{
-				Type: &ast.StarExpr{
-					X: &ast.SelectorExpr{
-						X:   ast.NewIdent(GenRuntimePackageName),
-						Sel: ast.NewIdent("ResourceReference"),
+				Type: &dst.StarExpr{
+					X: &dst.SelectorExpr{
+						X:   dst.NewIdent(GenRuntimePackageName),
+						Sel: dst.NewIdent("ResourceReference"),
 					},
 				},
 			},
 		},
-		Body: []ast.Stmt{
+		Body: []dst.Stmt{
 			lookupGroupAndKindStmt(
 				"group",
 				"kind",
-				&ast.SelectorExpr{
-					X:   ast.NewIdent(receiverIdent),
-					Sel: ast.NewIdent("Spec"),
+				&dst.SelectorExpr{
+					X:   dst.NewIdent(receiverIdent),
+					Sel: dst.NewIdent("Spec"),
 				},
 			),
-			&ast.ReturnStmt{
-				Results: []ast.Expr{
+			&dst.ReturnStmt{
+				Results: []dst.Expr{
 					createResourceReference(
 						"group",
 						"kind",
-						&ast.SelectorExpr{
-							X:   ast.NewIdent(receiverIdent),
-							Sel: ast.NewIdent("Spec"),
+						&dst.SelectorExpr{
+							X:   dst.NewIdent(receiverIdent),
+							Sel: dst.NewIdent("Spec"),
 						},
 					),
 				},
@@ -437,21 +437,21 @@ func ownerFunction(k *objectFunction, codeGenerationContext *CodeGenerationConte
 func lookupGroupAndKindStmt(
 	groupIdent string,
 	kindIdent string,
-	specSelector *ast.SelectorExpr) *ast.AssignStmt {
+	specSelector *dst.SelectorExpr) *dst.AssignStmt {
 
-	return &ast.AssignStmt{
-		Lhs: []ast.Expr{
-			ast.NewIdent(groupIdent),
-			ast.NewIdent(kindIdent),
+	return &dst.AssignStmt{
+		Lhs: []dst.Expr{
+			dst.NewIdent(groupIdent),
+			dst.NewIdent(kindIdent),
 		},
 		Tok: token.DEFINE,
-		Rhs: []ast.Expr{
-			&ast.CallExpr{
-				Fun: &ast.SelectorExpr{
-					X:   ast.NewIdent(GenRuntimePackageName),
-					Sel: ast.NewIdent("LookupOwnerGroupKind"),
+		Rhs: []dst.Expr{
+			&dst.CallExpr{
+				Fun: &dst.SelectorExpr{
+					X:   dst.NewIdent(GenRuntimePackageName),
+					Sel: dst.NewIdent("LookupOwnerGroupKind"),
 				},
-				Args: []ast.Expr{
+				Args: []dst.Expr{
 					specSelector,
 				},
 			},
@@ -462,32 +462,32 @@ func lookupGroupAndKindStmt(
 func createResourceReference(
 	groupIdent string,
 	kindIdent string,
-	specSelector *ast.SelectorExpr) ast.Expr {
+	specSelector *dst.SelectorExpr) dst.Expr {
 
 	return astbuilder.AddrOf(
-		&ast.CompositeLit{
-			Type: &ast.SelectorExpr{
-				X:   ast.NewIdent(GenRuntimePackageName),
-				Sel: ast.NewIdent("ResourceReference"),
+		&dst.CompositeLit{
+			Type: &dst.SelectorExpr{
+				X:   dst.NewIdent(GenRuntimePackageName),
+				Sel: dst.NewIdent("ResourceReference"),
 			},
-			Elts: []ast.Expr{
-				&ast.KeyValueExpr{
-					Key: ast.NewIdent("Name"),
-					Value: &ast.SelectorExpr{
-						X: &ast.SelectorExpr{
+			Elts: []dst.Expr{
+				&dst.KeyValueExpr{
+					Key: dst.NewIdent("Name"),
+					Value: &dst.SelectorExpr{
+						X: &dst.SelectorExpr{
 							X:   specSelector,
-							Sel: ast.NewIdent(OwnerProperty),
+							Sel: dst.NewIdent(OwnerProperty),
 						},
-						Sel: ast.NewIdent("Name"),
+						Sel: dst.NewIdent("Name"),
 					},
 				},
-				&ast.KeyValueExpr{
-					Key:   ast.NewIdent("Group"),
-					Value: ast.NewIdent(groupIdent),
+				&dst.KeyValueExpr{
+					Key:   dst.NewIdent("Group"),
+					Value: dst.NewIdent(groupIdent),
 				},
-				&ast.KeyValueExpr{
-					Key:   ast.NewIdent("Kind"),
-					Value: ast.NewIdent(kindIdent),
+				&dst.KeyValueExpr{
+					Key:   dst.NewIdent("Kind"),
+					Value: dst.NewIdent(kindIdent),
 				},
 			},
 		})
@@ -495,40 +495,40 @@ func createResourceReference(
 
 // defaultAzureNameFunction returns a function that defaults the AzureName property of the resource spec
 // to the Name property of the resource spec
-func defaultAzureNameFunction(k *objectFunction, codeGenerationContext *CodeGenerationContext, receiver TypeName, methodName string) *ast.FuncDecl {
+func defaultAzureNameFunction(k *objectFunction, codeGenerationContext *CodeGenerationContext, receiver TypeName, methodName string) *dst.FuncDecl {
 	receiverIdent := k.idFactory.CreateIdentifier(receiver.Name(), NotExported)
 	receiverType := receiver.AsType(codeGenerationContext)
 
-	specSelector := &ast.SelectorExpr{
-		X:   ast.NewIdent(receiverIdent),
-		Sel: ast.NewIdent("Spec"),
+	specSelector := &dst.SelectorExpr{
+		X:   dst.NewIdent(receiverIdent),
+		Sel: dst.NewIdent("Spec"),
 	}
 
-	azureNameProp := &ast.SelectorExpr{
+	azureNameProp := &dst.SelectorExpr{
 		X:   specSelector,
-		Sel: ast.NewIdent(AzureNameProperty),
+		Sel: dst.NewIdent(AzureNameProperty),
 	}
 
-	nameProp := &ast.SelectorExpr{
-		X:   ast.NewIdent(receiverIdent),
-		Sel: ast.NewIdent("Name"), // this comes from ObjectMeta
+	nameProp := &dst.SelectorExpr{
+		X:   dst.NewIdent(receiverIdent),
+		Sel: dst.NewIdent("Name"), // this comes from ObjectMeta
 	}
 
 	fn := &astbuilder.FuncDetails{
 		Name:          methodName,
 		ReceiverIdent: receiverIdent,
-		ReceiverType: &ast.StarExpr{
+		ReceiverType: &dst.StarExpr{
 			X: receiverType,
 		},
-		Body: []ast.Stmt{
-			&ast.IfStmt{
-				Cond: &ast.BinaryExpr{
-					X:  ast.Clone(azureNameProp).(ast.Expr),
+		Body: []dst.Stmt{
+			&dst.IfStmt{
+				Cond: &dst.BinaryExpr{
+					X:  dst.Clone(azureNameProp).(dst.Expr),
 					Op: token.EQL,
-					Y:  &ast.BasicLit{Kind: token.STRING, Value: "\"\""},
+					Y:  &dst.BasicLit{Kind: token.STRING, Value: "\"\""},
 				},
-				Body: &ast.BlockStmt{
-					List: []ast.Stmt{
+				Body: &dst.BlockStmt{
+					List: []dst.Stmt{
 						astbuilder.SimpleAssignment(
 							azureNameProp,
 							token.ASSIGN,
@@ -545,57 +545,57 @@ func defaultAzureNameFunction(k *objectFunction, codeGenerationContext *CodeGene
 
 // setStringAzureNameFunction returns a function that sets the Name property of
 // the resource spec to the argument string
-func setStringAzureNameFunction(k *objectFunction, codeGenerationContext *CodeGenerationContext, receiver TypeName, methodName string) *ast.FuncDecl {
+func setStringAzureNameFunction(k *objectFunction, codeGenerationContext *CodeGenerationContext, receiver TypeName, methodName string) *dst.FuncDecl {
 	receiverIdent := k.idFactory.CreateIdentifier(receiver.Name(), NotExported)
 	receiverType := receiver.AsType(codeGenerationContext)
 
 	fn := &astbuilder.FuncDetails{
 		Name:          methodName,
 		ReceiverIdent: receiverIdent,
-		ReceiverType: &ast.StarExpr{
+		ReceiverType: &dst.StarExpr{
 			X: receiverType,
 		},
-		Body: []ast.Stmt{
+		Body: []dst.Stmt{
 			astbuilder.SimpleAssignment(
-				&ast.SelectorExpr{
-					X:   ast.NewIdent(receiverIdent),
-					Sel: ast.NewIdent(AzureNameProperty),
+				&dst.SelectorExpr{
+					X:   dst.NewIdent(receiverIdent),
+					Sel: dst.NewIdent(AzureNameProperty),
 				},
 				token.ASSIGN,
-				ast.NewIdent("azureName")),
+				dst.NewIdent("azureName")),
 		},
 	}
 
 	fn.AddComments("sets the Azure name of the resource")
-	fn.AddParameter("azureName", ast.NewIdent("string"))
+	fn.AddParameter("azureName", dst.NewIdent("string"))
 	return fn.DefineFunc()
 }
 
 // getStringAzureNameFunction returns a function that returns the Name property of the resource spec
-func getStringAzureNameFunction(k *objectFunction, codeGenerationContext *CodeGenerationContext, receiver TypeName, methodName string) *ast.FuncDecl {
+func getStringAzureNameFunction(k *objectFunction, codeGenerationContext *CodeGenerationContext, receiver TypeName, methodName string) *dst.FuncDecl {
 	receiverIdent := k.idFactory.CreateIdentifier(receiver.Name(), NotExported)
 	receiverType := receiver.AsType(codeGenerationContext)
 
 	fn := &astbuilder.FuncDetails{
 		Name:          methodName,
 		ReceiverIdent: receiverIdent,
-		ReceiverType: &ast.StarExpr{
+		ReceiverType: &dst.StarExpr{
 			X: receiverType,
 		},
-		Body: []ast.Stmt{
-			&ast.ReturnStmt{
-				Decs: ast.ReturnStmtDecorations{
-					NodeDecs: ast.NodeDecs{
-						Before: ast.NewLine,
+		Body: []dst.Stmt{
+			&dst.ReturnStmt{
+				Decs: dst.ReturnStmtDecorations{
+					NodeDecs: dst.NodeDecs{
+						Before: dst.NewLine,
 					},
 				},
-				Results: []ast.Expr{
-					&ast.SelectorExpr{
-						X: &ast.SelectorExpr{
-							X:   ast.NewIdent(receiverIdent),
-							Sel: ast.NewIdent("Spec"),
+				Results: []dst.Expr{
+					&dst.SelectorExpr{
+						X: &dst.SelectorExpr{
+							X:   dst.NewIdent(receiverIdent),
+							Sel: dst.NewIdent("Spec"),
 						},
-						Sel: ast.NewIdent(AzureNameProperty),
+						Sel: dst.NewIdent(AzureNameProperty),
 					},
 				},
 			},

--- a/hack/generator/pkg/astmodel/map_type.go
+++ b/hack/generator/pkg/astmodel/map_type.go
@@ -8,7 +8,7 @@ package astmodel
 import (
 	"fmt"
 
-	ast "github.com/dave/dst"
+	"github.com/dave/dst"
 )
 
 // MapType is used to define properties that contain additional property values
@@ -40,13 +40,13 @@ func NewStringMapType(value Type) *MapType {
 // assert that we implemented Type correctly
 var _ Type = (*MapType)(nil)
 
-func (m *MapType) AsDeclarations(codeGenerationContext *CodeGenerationContext, declContext DeclarationContext) []ast.Decl {
+func (m *MapType) AsDeclarations(codeGenerationContext *CodeGenerationContext, declContext DeclarationContext) []dst.Decl {
 	return AsSimpleDeclarations(codeGenerationContext, declContext, m)
 }
 
 // AsType implements Type for MapType to create the abstract syntax tree for a map
-func (m *MapType) AsType(codeGenerationContext *CodeGenerationContext) ast.Expr {
-	return &ast.MapType{
+func (m *MapType) AsType(codeGenerationContext *CodeGenerationContext) dst.Expr {
+	return &dst.MapType{
 		Key:   m.key.AsType(codeGenerationContext),
 		Value: m.value.AsType(codeGenerationContext),
 	}

--- a/hack/generator/pkg/astmodel/object_type.go
+++ b/hack/generator/pkg/astmodel/object_type.go
@@ -10,7 +10,7 @@ import (
 	"sort"
 
 	"github.com/Azure/k8s-infra/hack/generator/pkg/astbuilder"
-	ast "github.com/dave/dst"
+	"github.com/dave/dst"
 	"github.com/pkg/errors"
 )
 
@@ -40,18 +40,18 @@ func NewObjectType() *ObjectType {
 	}
 }
 
-func (objectType *ObjectType) AsDeclarations(codeGenerationContext *CodeGenerationContext, declContext DeclarationContext) []ast.Decl {
-	declaration := &ast.GenDecl{
-		Decs: ast.GenDeclDecorations{
-			NodeDecs: ast.NodeDecs{
-				Before: ast.EmptyLine,
-				After:  ast.EmptyLine,
+func (objectType *ObjectType) AsDeclarations(codeGenerationContext *CodeGenerationContext, declContext DeclarationContext) []dst.Decl {
+	declaration := &dst.GenDecl{
+		Decs: dst.GenDeclDecorations{
+			NodeDecs: dst.NodeDecs{
+				Before: dst.EmptyLine,
+				After:  dst.EmptyLine,
 			},
 		},
 		Tok: token.TYPE,
-		Specs: []ast.Spec{
-			&ast.TypeSpec{
-				Name: ast.NewIdent(declContext.Name.Name()),
+		Specs: []dst.Spec{
+			&dst.TypeSpec{
+				Name: dst.NewIdent(declContext.Name.Name()),
 				Type: objectType.AsType(codeGenerationContext),
 			},
 		},
@@ -60,14 +60,14 @@ func (objectType *ObjectType) AsDeclarations(codeGenerationContext *CodeGenerati
 	astbuilder.AddWrappedComments(&declaration.Decs.Start, declContext.Description, 200)
 	AddValidationComments(&declaration.Decs.Start, declContext.Validations)
 
-	result := []ast.Decl{declaration}
+	result := []dst.Decl{declaration}
 	result = append(result, objectType.InterfaceImplementer.AsDeclarations(codeGenerationContext, declContext.Name, nil)...)
 	result = append(result, objectType.generateMethodDecls(codeGenerationContext, declContext.Name)...)
 	return result
 }
 
-func (objectType *ObjectType) generateMethodDecls(codeGenerationContext *CodeGenerationContext, typeName TypeName) []ast.Decl {
-	var result []ast.Decl
+func (objectType *ObjectType) generateMethodDecls(codeGenerationContext *CodeGenerationContext, typeName TypeName) []dst.Decl {
+	var result []dst.Decl
 
 	// Functions must be ordered by name for deterministic output
 	var functions []Function
@@ -87,15 +87,15 @@ func (objectType *ObjectType) generateMethodDecls(codeGenerationContext *CodeGen
 	return result
 }
 
-func defineField(fieldName string, fieldType ast.Expr, tag string) *ast.Field {
+func defineField(fieldName string, fieldType dst.Expr, tag string) *dst.Field {
 
-	result := &ast.Field{
+	result := &dst.Field{
 		Type: fieldType,
 		Tag:  astbuilder.TextLiteral(tag),
 	}
 
 	if fieldName != "" {
-		result.Names = []*ast.Ident{ast.NewIdent(fieldName)}
+		result.Names = []*dst.Ident{dst.NewIdent(fieldName)}
 	}
 
 	return result
@@ -157,10 +157,10 @@ func (objectType *ObjectType) HasFunctionWithName(name string) bool {
 }
 
 // AsType implements Type for ObjectType
-func (objectType *ObjectType) AsType(codeGenerationContext *CodeGenerationContext) ast.Expr {
+func (objectType *ObjectType) AsType(codeGenerationContext *CodeGenerationContext) dst.Expr {
 	embedded := objectType.EmbeddedProperties()
 	properties := objectType.Properties()
-	var fields []*ast.Field
+	var fields []*dst.Field
 
 	for _, f := range embedded {
 		fields = append(fields, f.AsField(codeGenerationContext))
@@ -173,11 +173,11 @@ func (objectType *ObjectType) AsType(codeGenerationContext *CodeGenerationContex
 	if len(fields) > 0 {
 		// if first field has Before:EmptyLine decoration, switch it to NewLine
 		// this makes the output look nicer 🙂
-		fields[0].Decs.Before = ast.NewLine
+		fields[0].Decs.Before = dst.NewLine
 	}
 
-	return &ast.StructType{
-		Fields: &ast.FieldList{
+	return &dst.StructType{
+		Fields: &dst.FieldList{
 			List: fields,
 		},
 	}

--- a/hack/generator/pkg/astmodel/one_of_json_marshal_function.go
+++ b/hack/generator/pkg/astmodel/one_of_json_marshal_function.go
@@ -10,7 +10,7 @@ import (
 	"go/token"
 
 	"github.com/Azure/k8s-infra/hack/generator/pkg/astbuilder"
-	ast "github.com/dave/dst"
+	"github.com/dave/dst"
 )
 
 const JSONMarshalFunctionName string = "MarshalJSON"
@@ -49,41 +49,41 @@ func (f *OneOfJSONMarshalFunction) References() TypeNameSet {
 	return f.oneOfObject.References()
 }
 
-// AsFunc returns the function as a go ast
+// AsFunc returns the function as a go dst
 func (f *OneOfJSONMarshalFunction) AsFunc(
 	codeGenerationContext *CodeGenerationContext,
-	receiver TypeName) *ast.FuncDecl {
+	receiver TypeName) *dst.FuncDecl {
 
 	jsonPackage := codeGenerationContext.MustGetImportedPackageName(JsonReference)
 
 	receiverName := f.idFactory.CreateIdentifier(receiver.name, NotExported)
 
-	var statements []ast.Stmt
+	var statements []dst.Stmt
 
 	for _, property := range f.oneOfObject.Properties() {
 
-		ifStatement := ast.IfStmt{
-			Cond: &ast.BinaryExpr{
-				X: &ast.SelectorExpr{
-					X:   ast.NewIdent(receiverName),
-					Sel: ast.NewIdent(string(property.propertyName)),
+		ifStatement := dst.IfStmt{
+			Cond: &dst.BinaryExpr{
+				X: &dst.SelectorExpr{
+					X:   dst.NewIdent(receiverName),
+					Sel: dst.NewIdent(string(property.propertyName)),
 				},
 				Op: token.NEQ,
-				Y:  ast.NewIdent("nil"),
+				Y:  dst.NewIdent("nil"),
 			},
-			Body: &ast.BlockStmt{
-				List: []ast.Stmt{
-					&ast.ReturnStmt{
-						Results: []ast.Expr{
-							&ast.CallExpr{
-								Fun: &ast.SelectorExpr{
-									X:   ast.NewIdent(jsonPackage),
-									Sel: ast.NewIdent("Marshal"),
+			Body: &dst.BlockStmt{
+				List: []dst.Stmt{
+					&dst.ReturnStmt{
+						Results: []dst.Expr{
+							&dst.CallExpr{
+								Fun: &dst.SelectorExpr{
+									X:   dst.NewIdent(jsonPackage),
+									Sel: dst.NewIdent("Marshal"),
 								},
-								Args: []ast.Expr{
-									&ast.SelectorExpr{
-										X:   ast.NewIdent(receiverName),
-										Sel: ast.NewIdent(string(property.propertyName)),
+								Args: []dst.Expr{
+									&dst.SelectorExpr{
+										X:   dst.NewIdent(receiverName),
+										Sel: dst.NewIdent(string(property.propertyName)),
 									},
 								},
 							},
@@ -96,10 +96,10 @@ func (f *OneOfJSONMarshalFunction) AsFunc(
 		statements = append(statements, &ifStatement)
 	}
 
-	finalReturnStatement := &ast.ReturnStmt{
-		Results: []ast.Expr{
-			ast.NewIdent("nil"),
-			ast.NewIdent("nil"),
+	finalReturnStatement := &dst.ReturnStmt{
+		Results: []dst.Expr{
+			dst.NewIdent("nil"),
+			dst.NewIdent("nil"),
 		},
 	}
 	statements = append(statements, finalReturnStatement)

--- a/hack/generator/pkg/astmodel/oneof_type.go
+++ b/hack/generator/pkg/astmodel/oneof_type.go
@@ -10,7 +10,7 @@ import (
 	"sort"
 	"strings"
 
-	ast "github.com/dave/dst"
+	"github.com/dave/dst"
 	"github.com/pkg/errors"
 )
 
@@ -74,13 +74,13 @@ var oneOfPanicMsg = "OneOfType should have been replaced by generation time by '
 
 // AsType always panics; OneOf cannot be represented by the Go AST and must be
 // lowered to an object type
-func (oneOf OneOfType) AsType(_ *CodeGenerationContext) ast.Expr {
+func (oneOf OneOfType) AsType(_ *CodeGenerationContext) dst.Expr {
 	panic(errors.New(oneOfPanicMsg))
 }
 
 // AsDeclarations always panics; OneOf cannot be represented by the Go AST and must be
 // lowered to an object type
-func (oneOf OneOfType) AsDeclarations(_ *CodeGenerationContext, _ DeclarationContext) []ast.Decl {
+func (oneOf OneOfType) AsDeclarations(_ *CodeGenerationContext, _ DeclarationContext) []dst.Decl {
 	panic(errors.New(oneOfPanicMsg))
 }
 

--- a/hack/generator/pkg/astmodel/optional_type.go
+++ b/hack/generator/pkg/astmodel/optional_type.go
@@ -8,7 +8,7 @@ package astmodel
 import (
 	"fmt"
 
-	ast "github.com/dave/dst"
+	"github.com/dave/dst"
 )
 
 // OptionalType is used for items that may or may not be present
@@ -48,18 +48,18 @@ func (optional *OptionalType) Element() Type {
 // assert we implemented Type correctly
 var _ Type = (*OptionalType)(nil)
 
-func (optional *OptionalType) AsDeclarations(codeGenerationContext *CodeGenerationContext, declContext DeclarationContext) []ast.Decl {
+func (optional *OptionalType) AsDeclarations(codeGenerationContext *CodeGenerationContext, declContext DeclarationContext) []dst.Decl {
 	return AsSimpleDeclarations(codeGenerationContext, declContext, optional)
 }
 
 // AsType renders the Go abstract syntax tree for an optional type
-func (optional *OptionalType) AsType(codeGenerationContext *CodeGenerationContext) ast.Expr {
+func (optional *OptionalType) AsType(codeGenerationContext *CodeGenerationContext) dst.Expr {
 	// Special case interface{} as it shouldn't be a pointer
 	if optional.element == AnyType {
 		return optional.element.AsType(codeGenerationContext)
 	}
 
-	return &ast.StarExpr{
+	return &dst.StarExpr{
 		X: optional.element.AsType(codeGenerationContext),
 	}
 }

--- a/hack/generator/pkg/astmodel/package_import.go
+++ b/hack/generator/pkg/astmodel/package_import.go
@@ -9,7 +9,7 @@ import (
 	"fmt"
 
 	"github.com/Azure/k8s-infra/hack/generator/pkg/astbuilder"
-	ast "github.com/dave/dst"
+	"github.com/dave/dst"
 )
 
 // PackageImport represents an import of a name from a package
@@ -33,13 +33,13 @@ func (pi PackageImport) WithName(name string) PackageImport {
 	return pi
 }
 
-func (pi PackageImport) AsImportSpec() *ast.ImportSpec {
-	var name *ast.Ident
+func (pi PackageImport) AsImportSpec() *dst.ImportSpec {
+	var name *dst.Ident
 	if pi.name != "" {
-		name = ast.NewIdent(pi.name)
+		name = dst.NewIdent(pi.name)
 	}
 
-	return &ast.ImportSpec{
+	return &dst.ImportSpec{
 		Name: name,
 		Path: astbuilder.StringLiteral(pi.packageReference.PackagePath()),
 	}

--- a/hack/generator/pkg/astmodel/primitive_type.go
+++ b/hack/generator/pkg/astmodel/primitive_type.go
@@ -6,7 +6,7 @@
 package astmodel
 
 import (
-	ast "github.com/dave/dst"
+	"github.com/dave/dst"
 )
 
 // PrimitiveType represents a Go primitive type
@@ -39,11 +39,11 @@ var AnyType = &PrimitiveType{"interface{}"}
 var _ Type = (*PrimitiveType)(nil)
 
 // AsType implements Type for PrimitiveType returning an abstract syntax tree
-func (prim *PrimitiveType) AsType(_ *CodeGenerationContext) ast.Expr {
-	return ast.NewIdent(prim.name)
+func (prim *PrimitiveType) AsType(_ *CodeGenerationContext) dst.Expr {
+	return dst.NewIdent(prim.name)
 }
 
-func (prim *PrimitiveType) AsDeclarations(genContext *CodeGenerationContext, declContext DeclarationContext) []ast.Decl {
+func (prim *PrimitiveType) AsDeclarations(genContext *CodeGenerationContext, declContext DeclarationContext) []dst.Decl {
 	return AsSimpleDeclarations(genContext, declContext, prim)
 }
 

--- a/hack/generator/pkg/astmodel/property_definition.go
+++ b/hack/generator/pkg/astmodel/property_definition.go
@@ -11,7 +11,7 @@ import (
 	"strings"
 
 	"github.com/Azure/k8s-infra/hack/generator/pkg/astbuilder"
-	ast "github.com/dave/dst"
+	"github.com/dave/dst"
 )
 
 // PropertyName is a semantic type
@@ -237,15 +237,15 @@ func (property *PropertyDefinition) renderedTags() string {
 }
 
 // AsField generates a Go AST field node representing this property definition
-func (property *PropertyDefinition) AsField(codeGenerationContext *CodeGenerationContext) *ast.Field {
+func (property *PropertyDefinition) AsField(codeGenerationContext *CodeGenerationContext) *dst.Field {
 	tags := property.renderedTags()
 
-	var names []*ast.Ident
+	var names []*dst.Ident
 	if property.propertyName != "" {
-		names = []*ast.Ident{ast.NewIdent(string(property.propertyName))}
+		names = []*dst.Ident{dst.NewIdent(string(property.propertyName))}
 	}
 
-	var doc ast.Decorations
+	var doc dst.Decorations
 	if property.IsRequired() {
 		AddValidationComments(&doc, []KubeBuilderValidation{ValidateRequired()})
 	}
@@ -257,15 +257,15 @@ func (property *PropertyDefinition) AsField(codeGenerationContext *CodeGeneratio
 		AddValidationComments(&doc, validated.Validations().ToKubeBuilderValidations())
 	}
 
-	before := ast.NewLine
+	before := dst.NewLine
 	if len(doc) > 0 {
-		before = ast.EmptyLine
+		before = dst.EmptyLine
 	}
 
 	// We don't use StringLiteral() for the tag as it adds extra quotes
-	result := &ast.Field{
-		Decs: ast.FieldDecorations{
-			NodeDecs: ast.NodeDecs{
+	result := &dst.Field{
+		Decs: dst.FieldDecorations{
+			NodeDecs: dst.NodeDecs{
 				Start:  doc,
 				Before: before,
 			},
@@ -277,7 +277,7 @@ func (property *PropertyDefinition) AsField(codeGenerationContext *CodeGeneratio
 
 	// generate comment:
 	if property.description != "" {
-		result.Decs.Before = ast.EmptyLine
+		result.Decs.Before = dst.EmptyLine
 		astbuilder.AddWrappedComment(&result.Decs.Start, fmt.Sprintf("%s: %s", property.propertyName, property.description), 80)
 	}
 

--- a/hack/generator/pkg/astmodel/test_case.go
+++ b/hack/generator/pkg/astmodel/test_case.go
@@ -5,7 +5,7 @@
 
 package astmodel
 
-import ast "github.com/dave/dst"
+import "github.com/dave/dst"
 
 // TestCase represents a test we generate to ensure the generated code works as expected
 type TestCase interface {
@@ -21,7 +21,7 @@ type TestCase interface {
 	// AsFuncs renders the current test case and any supporting methods as Go abstract syntax trees
 	// subject is the name of the type under test
 	// codeGenerationContext contains reference material to use when generating
-	AsFuncs(subject TypeName, codeGenerationContext *CodeGenerationContext) []ast.Decl
+	AsFuncs(subject TypeName, codeGenerationContext *CodeGenerationContext) []dst.Decl
 
 	// Equals determines if this TestCase is equal to another one
 	Equals(f TestCase) bool

--- a/hack/generator/pkg/astmodel/test_case_test.go
+++ b/hack/generator/pkg/astmodel/test_case_test.go
@@ -6,7 +6,7 @@
 package astmodel
 
 import (
-	ast "github.com/dave/dst"
+	"github.com/dave/dst"
 )
 
 type FakeTestCase struct {
@@ -33,7 +33,7 @@ func (f FakeTestCase) RequiredImports() *PackageImportSet {
 	panic("implement me")
 }
 
-func (f FakeTestCase) AsFuncs(subject TypeName, codeGenerationContext *CodeGenerationContext) []ast.Decl {
+func (f FakeTestCase) AsFuncs(subject TypeName, codeGenerationContext *CodeGenerationContext) []dst.Decl {
 	panic("implement me")
 }
 

--- a/hack/generator/pkg/astmodel/test_file_definition.go
+++ b/hack/generator/pkg/astmodel/test_file_definition.go
@@ -11,7 +11,7 @@ import (
 	"io"
 	"os"
 
-	ast "github.com/dave/dst"
+	"github.com/dave/dst"
 	"github.com/dave/dst/decorator"
 	"k8s.io/klog/v2"
 )
@@ -61,13 +61,13 @@ func (file TestFileDefinition) SaveToFile(filePath string) error {
 }
 
 // AsAst generates an array of declarations for the content of the file
-func (file *TestFileDefinition) AsAst() *ast.File {
+func (file *TestFileDefinition) AsAst() *dst.File {
 
 	// Create context from imports
 	codeGenContext := NewCodeGenerationContext(file.packageReference, file.generateImports(), file.generatedPackages)
 
 	// Emit all test cases:
-	var testcases []ast.Decl
+	var testcases []dst.Decl
 	for _, s := range file.definitions {
 		definer, ok := s.Type().(TestCaseDefiner)
 		if !ok {
@@ -79,12 +79,12 @@ func (file *TestFileDefinition) AsAst() *ast.File {
 		}
 	}
 
-	var decls []ast.Decl
+	var decls []dst.Decl
 
 	// Create import header if needed
 	usedImports := codeGenContext.UsedPackageImports()
 	if usedImports.Length() > 0 {
-		decls = append(decls, &ast.GenDecl{Tok: token.IMPORT, Specs: file.generateImportSpecs(usedImports)})
+		decls = append(decls, &dst.GenDecl{Tok: token.IMPORT, Specs: file.generateImportSpecs(usedImports)})
 	}
 
 	decls = append(decls, testcases...)
@@ -97,14 +97,14 @@ func (file *TestFileDefinition) AsAst() *ast.File {
 
 	packageName := file.packageReference.PackageName()
 
-	result := &ast.File{
-		Decs: ast.FileDecorations{
-			NodeDecs: ast.NodeDecs{
+	result := &dst.File{
+		Decs: dst.FileDecorations{
+			NodeDecs: dst.NodeDecs{
 				Start: header,
-				After: ast.EmptyLine,
+				After: dst.EmptyLine,
 			},
 		},
-		Name:  ast.NewIdent(packageName),
+		Name:  dst.NewIdent(packageName),
 		Decls: decls,
 	}
 
@@ -147,8 +147,8 @@ func (file *TestFileDefinition) generateImports() *PackageImportSet {
 	return requiredImports
 }
 
-func (file *TestFileDefinition) generateImportSpecs(imports *PackageImportSet) []ast.Spec {
-	var importSpecs []ast.Spec
+func (file *TestFileDefinition) generateImportSpecs(imports *PackageImportSet) []dst.Spec {
+	var importSpecs []dst.Spec
 	for _, requiredImport := range imports.AsSortedSlice() {
 		importSpecs = append(importSpecs, requiredImport.AsImportSpec())
 	}

--- a/hack/generator/pkg/astmodel/type.go
+++ b/hack/generator/pkg/astmodel/type.go
@@ -8,7 +8,7 @@ package astmodel
 import (
 	"fmt"
 
-	ast "github.com/dave/dst"
+	"github.com/dave/dst"
 )
 
 // Type represents something that is a Go type
@@ -23,10 +23,10 @@ type Type interface {
 
 	// AsType renders as a Go abstract syntax tree for a type
 	// (yes this says ast.Expr but that is what the Go 'ast' package uses for types)
-	AsType(codeGenerationContext *CodeGenerationContext) ast.Expr
+	AsType(codeGenerationContext *CodeGenerationContext) dst.Expr
 
 	// AsDeclarations renders as a Go abstract syntax tree for a declaration
-	AsDeclarations(codeGenerationContext *CodeGenerationContext, declContext DeclarationContext) []ast.Decl
+	AsDeclarations(codeGenerationContext *CodeGenerationContext, declContext DeclarationContext) []dst.Decl
 
 	// Equals returns true if the passed type is the same as this one, false otherwise
 	Equals(t Type) bool

--- a/hack/generator/pkg/astmodel/type_definition.go
+++ b/hack/generator/pkg/astmodel/type_definition.go
@@ -9,7 +9,7 @@ import (
 	"go/token"
 
 	"github.com/Azure/k8s-infra/hack/generator/pkg/astbuilder"
-	ast "github.com/dave/dst"
+	"github.com/dave/dst"
 	"github.com/pkg/errors"
 )
 
@@ -67,7 +67,7 @@ func (def TypeDefinition) WithName(typeName TypeName) TypeDefinition {
 	return result
 }
 
-func (def TypeDefinition) AsDeclarations(codeGenerationContext *CodeGenerationContext) []ast.Decl {
+func (def TypeDefinition) AsDeclarations(codeGenerationContext *CodeGenerationContext) []dst.Decl {
 	declContext := DeclarationContext{
 		Name:        def.name,
 		Description: def.description,
@@ -80,32 +80,32 @@ func (def TypeDefinition) AsDeclarations(codeGenerationContext *CodeGenerationCo
 func AsSimpleDeclarations(
 	codeGenerationContext *CodeGenerationContext,
 	declContext DeclarationContext,
-	theType Type) []ast.Decl {
+	theType Type) []dst.Decl {
 
-	var docComments ast.Decorations
+	var docComments dst.Decorations
 	if len(declContext.Description) > 0 {
 		astbuilder.AddWrappedComments(&docComments, declContext.Description, 120)
 	}
 
 	AddValidationComments(&docComments, declContext.Validations)
 
-	result := &ast.GenDecl{
-		Decs: ast.GenDeclDecorations{
-			NodeDecs: ast.NodeDecs{
+	result := &dst.GenDecl{
+		Decs: dst.GenDeclDecorations{
+			NodeDecs: dst.NodeDecs{
 				Start:  docComments,
-				Before: ast.EmptyLine,
+				Before: dst.EmptyLine,
 			},
 		},
 		Tok: token.TYPE,
-		Specs: []ast.Spec{
-			&ast.TypeSpec{
-				Name: ast.NewIdent(declContext.Name.Name()),
+		Specs: []dst.Spec{
+			&dst.TypeSpec{
+				Name: dst.NewIdent(declContext.Name.Name()),
 				Type: theType.AsType(codeGenerationContext),
 			},
 		},
 	}
 
-	return []ast.Decl{result}
+	return []dst.Decl{result}
 }
 
 // RequiredImports returns a list of packages required by this type

--- a/hack/generator/pkg/astmodel/type_name.go
+++ b/hack/generator/pkg/astmodel/type_name.go
@@ -9,7 +9,7 @@ import (
 	"fmt"
 	"strings"
 
-	ast "github.com/dave/dst"
+	"github.com/dave/dst"
 	"github.com/gobuffalo/flect"
 )
 
@@ -40,18 +40,18 @@ func (typeName TypeName) Name() string {
 // it is simply a reference to the name.
 var _ Type = TypeName{}
 
-func (typeName TypeName) AsDeclarations(codeGenerationContext *CodeGenerationContext, declContext DeclarationContext) []ast.Decl {
+func (typeName TypeName) AsDeclarations(codeGenerationContext *CodeGenerationContext, declContext DeclarationContext) []dst.Decl {
 	return AsSimpleDeclarations(codeGenerationContext, declContext, typeName)
 }
 
 // AsType implements Type for TypeName
-func (typeName TypeName) AsType(codeGenerationContext *CodeGenerationContext) ast.Expr {
+func (typeName TypeName) AsType(codeGenerationContext *CodeGenerationContext) dst.Expr {
 	// If our package is being referenced, we need to ensure we include a selector for that reference
 	packageName, err := codeGenerationContext.GetImportedPackageName(typeName.PackageReference)
 	if err == nil {
-		return &ast.SelectorExpr{
-			X:   ast.NewIdent(packageName),
-			Sel: ast.NewIdent(typeName.Name()),
+		return &dst.SelectorExpr{
+			X:   dst.NewIdent(packageName),
+			Sel: dst.NewIdent(typeName.Name()),
 		}
 	}
 
@@ -63,7 +63,7 @@ func (typeName TypeName) AsType(codeGenerationContext *CodeGenerationContext) as
 			codeGenerationContext.currentPackage))
 	}
 
-	return ast.NewIdent(typeName.name)
+	return dst.NewIdent(typeName.name)
 }
 
 // References returns a set containing this type name.

--- a/hack/generator/pkg/astmodel/validated_type.go
+++ b/hack/generator/pkg/astmodel/validated_type.go
@@ -10,7 +10,7 @@ import (
 	"math/big"
 	"regexp"
 
-	ast "github.com/dave/dst"
+	"github.com/dave/dst"
 )
 
 type ArrayValidations struct {
@@ -162,12 +162,12 @@ func (v ValidatedType) WithType(newElement Type) ValidatedType {
 
 var _ Type = ValidatedType{}
 
-func (v ValidatedType) AsDeclarations(c *CodeGenerationContext, declContext DeclarationContext) []ast.Decl {
+func (v ValidatedType) AsDeclarations(c *CodeGenerationContext, declContext DeclarationContext) []dst.Decl {
 	declContext.Validations = append(declContext.Validations, v.validations.ToKubeBuilderValidations()...)
 	return v.ElementType().AsDeclarations(c, declContext)
 }
 
-func (v ValidatedType) AsType(_ *CodeGenerationContext) ast.Expr {
+func (v ValidatedType) AsType(_ *CodeGenerationContext) dst.Expr {
 	panic("Should never happen: validated types must either be named (handled by 'name types for CRDs' pipeline stage) or be directly under properties (handled by PropertyDefinition.AsField)")
 }
 


### PR DESCRIPTION
When we migrated to the `dave/dst` library, we used the alias `ast` to minimize changes in case we needed to rollback; we've had enough experience now to know that we're unlikely to do that - and normalizing the imports is a good tidyup.