### PR TITLE
Begin to obey Retry-After

### DIFF
--- a/hack/generated/controllers/crd_cosmosdb_test.go
+++ b/hack/generated/controllers/crd_cosmosdb_test.go
@@ -73,7 +73,7 @@ func Test_CosmosDB_CRUD(t *testing.T) {
 	g.Eventually(acct).Should(testContext.Match.BeDeleted(ctx))
 
 	// Ensure that the resource group was really deleted in Azure
-	exists, err, retryAfter := testContext.AzureClient.HeadResource(ctx, armId, "2015-04-08")
+	exists, retryAfter, err := testContext.AzureClient.HeadResource(ctx, armId, "2015-04-08")
 	g.Expect(err).ToNot(HaveOccurred())
 	g.Expect(retryAfter).To(BeZero())
 	g.Expect(exists).To(BeFalse())

--- a/hack/generated/controllers/crd_cosmosdb_test.go
+++ b/hack/generated/controllers/crd_cosmosdb_test.go
@@ -73,7 +73,8 @@ func Test_CosmosDB_CRUD(t *testing.T) {
 	g.Eventually(acct).Should(testContext.Match.BeDeleted(ctx))
 
 	// Ensure that the resource group was really deleted in Azure
-	exists, err := testContext.AzureClient.HeadResource(ctx, armId, "2015-04-08")
+	exists, err, retryAfter := testContext.AzureClient.HeadResource(ctx, armId, "2015-04-08")
 	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(retryAfter).To(BeZero())
 	g.Expect(exists).To(BeFalse())
 }

--- a/hack/generated/controllers/crd_resourcegroup_test.go
+++ b/hack/generated/controllers/crd_resourcegroup_test.go
@@ -42,7 +42,7 @@ func Test_ResourceGroup_CRUD(t *testing.T) {
 
 	// Ensure that the resource group was really deleted in Azure
 	// TODO: Do we want to just use an SDK here? This process is quite icky as is...
-	exists, err, _ := testContext.AzureClient.HeadResource(
+	exists, _, err := testContext.AzureClient.HeadResource(
 		ctx,
 		armId,
 		"2020-06-01")

--- a/hack/generated/controllers/crd_resourcegroup_test.go
+++ b/hack/generated/controllers/crd_resourcegroup_test.go
@@ -42,7 +42,7 @@ func Test_ResourceGroup_CRUD(t *testing.T) {
 
 	// Ensure that the resource group was really deleted in Azure
 	// TODO: Do we want to just use an SDK here? This process is quite icky as is...
-	exists, err := testContext.AzureClient.HeadResource(
+	exists, err, _ := testContext.AzureClient.HeadResource(
 		ctx,
 		armId,
 		"2020-06-01")

--- a/hack/generated/controllers/crd_storageaccount_test.go
+++ b/hack/generated/controllers/crd_storageaccount_test.go
@@ -71,7 +71,7 @@ func Test_StorageAccount_CRUD(t *testing.T) {
 	g.Eventually(acct).Should(testContext.Match.BeDeleted(ctx))
 
 	// Ensure that the resource group was really deleted in Azure
-	exists, err := testContext.AzureClient.HeadResource(
+	exists, err, _ := testContext.AzureClient.HeadResource(
 		ctx,
 		armId,
 		"2019-04-01")

--- a/hack/generated/controllers/crd_storageaccount_test.go
+++ b/hack/generated/controllers/crd_storageaccount_test.go
@@ -71,7 +71,7 @@ func Test_StorageAccount_CRUD(t *testing.T) {
 	g.Eventually(acct).Should(testContext.Match.BeDeleted(ctx))
 
 	// Ensure that the resource group was really deleted in Azure
-	exists, err, _ := testContext.AzureClient.HeadResource(
+	exists, _, err := testContext.AzureClient.HeadResource(
 		ctx,
 		armId,
 		"2019-04-01")

--- a/hack/generated/controllers/generic_controller.go
+++ b/hack/generated/controllers/generic_controller.go
@@ -350,7 +350,7 @@ func (gr *GenericReconciler) MonitorDelete(
 	found, err, retryAfter := gr.ARMClient.HeadResource(ctx, resource.GetId(), resource.Spec().GetApiVersion())
 	if err != nil {
 		if retryAfter != 0 {
-			data.log.V(3).Info("Error performing HEAD on resource, will retry", "delay", retryAfter/time.Second)
+			data.log.V(3).Info("Error performing HEAD on resource, will retry", "delaySec", retryAfter/time.Second)
 			return ctrl.Result{RequeueAfter: retryAfter}, nil
 		}
 
@@ -424,7 +424,7 @@ func (gr *GenericReconciler) MonitorDeployment(ctx context.Context, action Recon
 	deployment, err, retryAfter := gr.ARMClient.GetDeployment(ctx, deployment.Id)
 	if err != nil {
 		if retryAfter != 0 {
-			data.log.V(3).Info("Error performing GET on deployment, will retry", "delay", retryAfter/time.Second)
+			data.log.V(3).Info("Error performing GET on deployment, will retry", "delaySec", retryAfter/time.Second)
 			return ctrl.Result{RequeueAfter: retryAfter}, nil
 		}
 

--- a/hack/generated/controllers/generic_controller.go
+++ b/hack/generated/controllers/generic_controller.go
@@ -68,6 +68,7 @@ type GenericReconciler struct {
 	Name                 string
 	GVK                  schema.GroupVersionKind
 	Controller           controller.Controller
+	RequeueDelay         time.Duration
 	CreateDeploymentName func(obj metav1.Object) (string, error)
 }
 
@@ -90,10 +91,16 @@ type Options struct {
 	controller.Options
 
 	// options specific to our controller
+	RequeueDelay         time.Duration
 	CreateDeploymentName func(obj metav1.Object) (string, error)
 }
 
 func (options *Options) setDefaults() {
+	// default requeue delay to 5 seconds
+	if options.RequeueDelay == 0 {
+		options.RequeueDelay = 5 * time.Second
+	}
+
 	// override deployment name generator, if provided
 	if options.CreateDeploymentName == nil {
 		options.CreateDeploymentName = createDeploymentName
@@ -142,6 +149,7 @@ func register(mgr ctrl.Manager, applier armclient.Applier, obj runtime.Object, l
 		Log:                  log.WithName(controllerName),
 		Recorder:             mgr.GetEventRecorderFor(controllerName),
 		GVK:                  gvk,
+		RequeueDelay:         options.RequeueDelay,
 		CreateDeploymentName: options.CreateDeploymentName,
 	}
 
@@ -323,11 +331,15 @@ func (gr *GenericReconciler) StartDeleteOfResource(
 		return ctrl.Result{}, errors.Wrap(err, "patching after delete")
 	}
 
-	data.log.V(4).Info("Resource deletion started, will check again", "delaySec", retryAfter/time.Second)
-
 	// delete has started, check back to seen when the finalizer can be removed
-	// NB: we need to set Requeue: true in case retryAfter is 0
-	return ctrl.Result{Requeue: true, RequeueAfter: retryAfter}, nil
+	requeueDelay := gr.RequeueDelay
+	if retryAfter > requeueDelay {
+		requeueDelay = retryAfter
+	}
+
+	data.log.V(3).Info("Resource deletion started, will check again", "delaySec", requeueDelay/time.Second)
+
+	return ctrl.Result{Requeue: true, RequeueAfter: requeueDelay}, nil
 }
 
 // MonitorDelete will call Azure to check if the resource still exists. If so, it will requeue, else,
@@ -359,7 +371,7 @@ func (gr *GenericReconciler) MonitorDelete(
 
 	if found {
 		data.log.V(0).Info("Found resource: continuing to wait for deletion...")
-		return ctrl.Result{Requeue: true}, nil
+		return ctrl.Result{Requeue: true, RequeueAfter: gr.RequeueDelay}, nil
 	}
 
 	err = gr.deleteResourceSucceeded(ctx, data)
@@ -406,9 +418,10 @@ func (gr *GenericReconciler) CreateDeployment(ctx context.Context, action Reconc
 		return ctrl.Result{}, errors.Wrap(client.IgnoreNotFound(err), "patching")
 	}
 
-	result := ctrl.Result{
-		// need to check again if deployment hasn’t terminated
-		Requeue: !deployment.IsTerminalProvisioningState(),
+	result := ctrl.Result{}
+	// TODO: This is going to be common... need a wrapper/helper somehow?
+	if !deployment.IsTerminalProvisioningState() {
+		result = ctrl.Result{RequeueAfter: gr.RequeueDelay}
 	}
 
 	return result, err
@@ -507,10 +520,15 @@ func (gr *GenericReconciler) MonitorDeployment(ctx context.Context, action Recon
 		return ctrl.Result{}, nil
 	}
 
-	data.log.V(3).Info("Deployment still running, will check again", "delaySec", retryAfter/time.Second)
-	// need to check back; still creating resources or deleting the deployment itself
-	// NB: we need to set Requeue: true in case retryAfter is 0
-	return ctrl.Result{Requeue: true, RequeueAfter: retryAfter}, err
+	requeueDelay := gr.RequeueDelay
+	if retryAfter > requeueDelay {
+		// use the Retry-After that was returned by Azure when deleting the deployment
+		requeueDelay = retryAfter
+	}
+
+	data.log.V(3).Info("Deployment still running, will check again", "delaySec", requeueDelay/time.Second)
+
+	return ctrl.Result{RequeueAfter: requeueDelay}, err
 }
 
 func (gr *GenericReconciler) ManageOwnership(ctx context.Context, action ReconcileAction, data *ReconcileMetadata) (ctrl.Result, error) {

--- a/hack/generated/controllers/generic_controller.go
+++ b/hack/generated/controllers/generic_controller.go
@@ -613,7 +613,7 @@ func (gr *GenericReconciler) getStatus(ctx context.Context, id string, data *Rec
 		return nil, zeroDuration, errors.Wrapf(err, "converting ARM status to Kubernetes status")
 	}
 
-	return status, 0, nil
+	return status, zeroDuration, nil
 }
 
 func (gr *GenericReconciler) resourceSpecToDeployment(ctx context.Context, data *ReconcileMetadata) (*armclient.Deployment, error) {

--- a/hack/generated/controllers/recordings/Test_CosmosDB_CRUD.yaml
+++ b/hack/generated/controllers/recordings/Test_CosmosDB_CRUD.yaml
@@ -2,7 +2,7 @@
 version: 1
 interactions:
 - request:
-    body: '{"name":"k8s_df555267-f893-56c9-a777-fb81bb3748d5","location":"westus","Properties":{"Error":null,"debugSetting":{"detailLevel":"requestContent,responseContent"},"mode":"Incremental","template":{"$schema":"https://schema.management.azure.com/schemas/2018-05-01/subscriptionDeploymentTemplate.json#","contentVersion":"1.0.0.0","resources":[{"apiVersion":"2020-06-01","name":"k8sinfratest-rg-dnhfns","location":"westus","tags":{"CreatedAt":"2021-01-19T22:02:38Z"},"type":"Microsoft.Resources/resourceGroups"}],"outputs":{"resourceId":{"type":"string","value":"[resourceId(''Microsoft.Resources/resourceGroups'', ''k8sinfratest-rg-dnhfns'')]"}}}}}'
+    body: '{"name":"k8s_df555267-f893-56c9-a777-fb81bb3748d5","location":"westus","Properties":{"Error":null,"debugSetting":{"detailLevel":"requestContent,responseContent"},"mode":"Incremental","template":{"$schema":"https://schema.management.azure.com/schemas/2018-05-01/subscriptionDeploymentTemplate.json#","contentVersion":"1.0.0.0","resources":[{"apiVersion":"2020-06-01","name":"k8sinfratest-rg-dnhfns","location":"westus","tags":{"CreatedAt":"2021-01-21T23:44:14Z"},"type":"Microsoft.Resources/resourceGroups"}],"outputs":{"resourceId":{"type":"string","value":"[resourceId(''Microsoft.Resources/resourceGroups'', ''k8sinfratest-rg-dnhfns'')]"}}}}}'
     form: {}
     headers:
       Content-Type:
@@ -12,10 +12,10 @@ interactions:
     url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Resources/deployments/k8s_df555267-f893-56c9-a777-fb81bb3748d5?api-version=2019-10-01
     method: PUT
   response:
-    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Resources/deployments/k8s_df555267-f893-56c9-a777-fb81bb3748d5","name":"k8s_df555267-f893-56c9-a777-fb81bb3748d5","type":"Microsoft.Resources/deployments","location":"westus","properties":{"templateHash":"10038291771661172997","mode":"Incremental","debugSetting":{"detailLevel":"RequestContent, ResponseContent"},"provisioningState":"Accepted","timestamp":"2021-01-19T22:02:55.790435Z","duration":"PT4.4548204S","correlationId":"a2f88a52-5f58-4584-9e73-af017ac7976f","providers":[{"namespace":"Microsoft.Resources","resourceTypes":[{"resourceType":"resourceGroups","locations":["westus"]}]}],"dependencies":[]}}'
+    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Resources/deployments/k8s_df555267-f893-56c9-a777-fb81bb3748d5","name":"k8s_df555267-f893-56c9-a777-fb81bb3748d5","type":"Microsoft.Resources/deployments","location":"westus","properties":{"templateHash":"9066647199355949189","mode":"Incremental","debugSetting":{"detailLevel":"RequestContent, ResponseContent"},"provisioningState":"Accepted","timestamp":"2021-01-21T23:44:24.7346576Z","duration":"PT4.4337753S","correlationId":"8151a1e5-c6c3-4a1e-abf3-3770f47c6dd6","providers":[{"namespace":"Microsoft.Resources","resourceTypes":[{"resourceType":"resourceGroups","locations":["westus"]}]}],"dependencies":[]}}'
     headers:
       Azure-Asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Resources/deployments/k8s_df555267-f893-56c9-a777-fb81bb3748d5/operationStatuses/08585905131141419981?api-version=2019-10-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Resources/deployments/k8s_df555267-f893-56c9-a777-fb81bb3748d5/operationStatuses/08585903342251767316?api-version=2019-10-01
       Cache-Control:
       - no-cache
       Content-Length:
@@ -23,7 +23,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 19 Jan 2021 22:02:55 GMT
+      - Thu, 21 Jan 2021 23:44:25 GMT
       Expires:
       - "-1"
       Pragma:
@@ -46,14 +46,14 @@ interactions:
     url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Resources/deployments/k8s_df555267-f893-56c9-a777-fb81bb3748d5?api-version=2019-10-01
     method: GET
   response:
-    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Resources/deployments/k8s_df555267-f893-56c9-a777-fb81bb3748d5","name":"k8s_df555267-f893-56c9-a777-fb81bb3748d5","type":"Microsoft.Resources/deployments","location":"westus","properties":{"templateHash":"10038291771661172997","mode":"Incremental","debugSetting":{"detailLevel":"RequestContent, ResponseContent"},"provisioningState":"Accepted","timestamp":"2021-01-19T22:02:55.790435Z","duration":"PT4.4548204S","correlationId":"a2f88a52-5f58-4584-9e73-af017ac7976f","providers":[{"namespace":"Microsoft.Resources","resourceTypes":[{"resourceType":"resourceGroups","locations":["westus"]}]}],"dependencies":[]}}'
+    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Resources/deployments/k8s_df555267-f893-56c9-a777-fb81bb3748d5","name":"k8s_df555267-f893-56c9-a777-fb81bb3748d5","type":"Microsoft.Resources/deployments","location":"westus","properties":{"templateHash":"9066647199355949189","mode":"Incremental","debugSetting":{"detailLevel":"RequestContent, ResponseContent"},"provisioningState":"Accepted","timestamp":"2021-01-21T23:44:24.7346576Z","duration":"PT4.4337753S","correlationId":"8151a1e5-c6c3-4a1e-abf3-3770f47c6dd6","providers":[{"namespace":"Microsoft.Resources","resourceTypes":[{"resourceType":"resourceGroups","locations":["westus"]}]}],"dependencies":[]}}'
     headers:
       Cache-Control:
       - no-cache
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 19 Jan 2021 22:02:56 GMT
+      - Thu, 21 Jan 2021 23:44:25 GMT
       Expires:
       - "-1"
       Pragma:
@@ -80,14 +80,14 @@ interactions:
     url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Resources/deployments/k8s_df555267-f893-56c9-a777-fb81bb3748d5?api-version=2019-10-01
     method: GET
   response:
-    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Resources/deployments/k8s_df555267-f893-56c9-a777-fb81bb3748d5","name":"k8s_df555267-f893-56c9-a777-fb81bb3748d5","type":"Microsoft.Resources/deployments","location":"westus","properties":{"templateHash":"10038291771661172997","mode":"Incremental","debugSetting":{"detailLevel":"RequestContent, ResponseContent"},"provisioningState":"Running","timestamp":"2021-01-19T22:02:57.1941298Z","duration":"PT5.8585152S","correlationId":"a2f88a52-5f58-4584-9e73-af017ac7976f","providers":[{"namespace":"Microsoft.Resources","resourceTypes":[{"resourceType":"resourceGroups","locations":["westus"]}]}],"dependencies":[]}}'
+    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Resources/deployments/k8s_df555267-f893-56c9-a777-fb81bb3748d5","name":"k8s_df555267-f893-56c9-a777-fb81bb3748d5","type":"Microsoft.Resources/deployments","location":"westus","properties":{"templateHash":"9066647199355949189","mode":"Incremental","debugSetting":{"detailLevel":"RequestContent, ResponseContent"},"provisioningState":"Running","timestamp":"2021-01-21T23:44:26.0607811Z","duration":"PT5.7598988S","correlationId":"8151a1e5-c6c3-4a1e-abf3-3770f47c6dd6","providers":[{"namespace":"Microsoft.Resources","resourceTypes":[{"resourceType":"resourceGroups","locations":["westus"]}]}],"dependencies":[]}}'
     headers:
       Cache-Control:
       - no-cache
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 19 Jan 2021 22:03:01 GMT
+      - Thu, 21 Jan 2021 23:44:30 GMT
       Expires:
       - "-1"
       Pragma:
@@ -114,14 +114,14 @@ interactions:
     url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Resources/deployments/k8s_df555267-f893-56c9-a777-fb81bb3748d5?api-version=2019-10-01
     method: GET
   response:
-    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Resources/deployments/k8s_df555267-f893-56c9-a777-fb81bb3748d5","name":"k8s_df555267-f893-56c9-a777-fb81bb3748d5","type":"Microsoft.Resources/deployments","location":"westus","properties":{"templateHash":"10038291771661172997","mode":"Incremental","debugSetting":{"detailLevel":"RequestContent, ResponseContent"},"provisioningState":"Running","timestamp":"2021-01-19T22:02:57.1941298Z","duration":"PT5.8585152S","correlationId":"a2f88a52-5f58-4584-9e73-af017ac7976f","providers":[{"namespace":"Microsoft.Resources","resourceTypes":[{"resourceType":"resourceGroups","locations":["westus"]}]}],"dependencies":[]}}'
+    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Resources/deployments/k8s_df555267-f893-56c9-a777-fb81bb3748d5","name":"k8s_df555267-f893-56c9-a777-fb81bb3748d5","type":"Microsoft.Resources/deployments","location":"westus","properties":{"templateHash":"9066647199355949189","mode":"Incremental","debugSetting":{"detailLevel":"RequestContent, ResponseContent"},"provisioningState":"Running","timestamp":"2021-01-21T23:44:26.0607811Z","duration":"PT5.7598988S","correlationId":"8151a1e5-c6c3-4a1e-abf3-3770f47c6dd6","providers":[{"namespace":"Microsoft.Resources","resourceTypes":[{"resourceType":"resourceGroups","locations":["westus"]}]}],"dependencies":[]}}'
     headers:
       Cache-Control:
       - no-cache
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 19 Jan 2021 22:03:01 GMT
+      - Thu, 21 Jan 2021 23:44:30 GMT
       Expires:
       - "-1"
       Pragma:
@@ -148,14 +148,14 @@ interactions:
     url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Resources/deployments/k8s_df555267-f893-56c9-a777-fb81bb3748d5?api-version=2019-10-01
     method: GET
   response:
-    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Resources/deployments/k8s_df555267-f893-56c9-a777-fb81bb3748d5","name":"k8s_df555267-f893-56c9-a777-fb81bb3748d5","type":"Microsoft.Resources/deployments","location":"westus","properties":{"templateHash":"10038291771661172997","mode":"Incremental","debugSetting":{"detailLevel":"RequestContent, ResponseContent"},"provisioningState":"Succeeded","timestamp":"2021-01-19T22:03:02.8029726Z","duration":"PT11.467358S","correlationId":"a2f88a52-5f58-4584-9e73-af017ac7976f","providers":[{"namespace":"Microsoft.Resources","resourceTypes":[{"resourceType":"resourceGroups","locations":["westus"]}]}],"dependencies":[],"outputs":{"resourceId":{"type":"String","value":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Resources/resourceGroups/k8sinfratest-rg-dnhfns"}},"outputResources":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns"}]}}'
+    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Resources/deployments/k8s_df555267-f893-56c9-a777-fb81bb3748d5","name":"k8s_df555267-f893-56c9-a777-fb81bb3748d5","type":"Microsoft.Resources/deployments","location":"westus","properties":{"templateHash":"9066647199355949189","mode":"Incremental","debugSetting":{"detailLevel":"RequestContent, ResponseContent"},"provisioningState":"Succeeded","timestamp":"2021-01-21T23:44:34.7705058Z","duration":"PT14.4696235S","correlationId":"8151a1e5-c6c3-4a1e-abf3-3770f47c6dd6","providers":[{"namespace":"Microsoft.Resources","resourceTypes":[{"resourceType":"resourceGroups","locations":["westus"]}]}],"dependencies":[],"outputs":{"resourceId":{"type":"String","value":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Resources/resourceGroups/k8sinfratest-rg-dnhfns"}},"outputResources":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns"}]}}'
     headers:
       Cache-Control:
       - no-cache
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 19 Jan 2021 22:03:06 GMT
+      - Thu, 21 Jan 2021 23:44:35 GMT
       Expires:
       - "-1"
       Pragma:
@@ -180,14 +180,14 @@ interactions:
     url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns?api-version=2020-06-01
     method: GET
   response:
-    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns","name":"k8sinfratest-rg-dnhfns","type":"Microsoft.Resources/resourceGroups","location":"westus","tags":{"CreatedAt":"2021-01-19T22:02:38Z"},"properties":{"provisioningState":"Succeeded"}}'
+    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns","name":"k8sinfratest-rg-dnhfns","type":"Microsoft.Resources/resourceGroups","location":"westus","tags":{"CreatedAt":"2021-01-21T23:44:14Z"},"properties":{"provisioningState":"Succeeded"}}'
     headers:
       Cache-Control:
       - no-cache
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 19 Jan 2021 22:03:06 GMT
+      - Thu, 21 Jan 2021 23:44:35 GMT
       Expires:
       - "-1"
       Pragma:
@@ -219,7 +219,7 @@ interactions:
       Content-Length:
       - "0"
       Date:
-      - Tue, 19 Jan 2021 22:03:09 GMT
+      - Thu, 21 Jan 2021 23:44:37 GMT
       Expires:
       - "-1"
       Location:
@@ -233,7 +233,7 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Ms-Ratelimit-Remaining-Subscription-Deletes:
-      - "14999"
+      - "14997"
     status: 202 Accepted
     code: 202
     duration: ""
@@ -248,10 +248,10 @@ interactions:
     url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/k8sinfratest-rg-dnhfns/providers/Microsoft.Resources/deployments/k8s_234c5afb-56ca-5133-b1e2-9d901f2b7ea1?api-version=2019-10-01
     method: PUT
   response:
-    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.Resources/deployments/k8s_234c5afb-56ca-5133-b1e2-9d901f2b7ea1","name":"k8s_234c5afb-56ca-5133-b1e2-9d901f2b7ea1","type":"Microsoft.Resources/deployments","properties":{"templateHash":"6776755900857513625","mode":"Incremental","debugSetting":{"detailLevel":"RequestContent, ResponseContent"},"provisioningState":"Accepted","timestamp":"2021-01-19T22:03:10.8614013Z","duration":"PT1.1650422S","correlationId":"735af330-dbcd-4bf7-b22c-1205b3cea15a","providers":[{"namespace":"Microsoft.DocumentDB","resourceTypes":[{"resourceType":"databaseAccounts","locations":["westus"]}]}],"dependencies":[]}}'
+    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.Resources/deployments/k8s_234c5afb-56ca-5133-b1e2-9d901f2b7ea1","name":"k8s_234c5afb-56ca-5133-b1e2-9d901f2b7ea1","type":"Microsoft.Resources/deployments","properties":{"templateHash":"6776755900857513625","mode":"Incremental","debugSetting":{"detailLevel":"RequestContent, ResponseContent"},"provisioningState":"Accepted","timestamp":"2021-01-21T23:44:40.7109819Z","duration":"PT0.9059934S","correlationId":"4c2dbabb-d675-4f55-b146-1ff14b697e1c","providers":[{"namespace":"Microsoft.DocumentDB","resourceTypes":[{"resourceType":"databaseAccounts","locations":["westus"]}]}],"dependencies":[]}}'
     headers:
       Azure-Asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/k8sinfratest-rg-dnhfns/providers/Microsoft.Resources/deployments/k8s_234c5afb-56ca-5133-b1e2-9d901f2b7ea1/operationStatuses/08585905130957812510?api-version=2019-10-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/k8sinfratest-rg-dnhfns/providers/Microsoft.Resources/deployments/k8s_234c5afb-56ca-5133-b1e2-9d901f2b7ea1/operationStatuses/08585903342056726174?api-version=2019-10-01
       Cache-Control:
       - no-cache
       Content-Length:
@@ -259,7 +259,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 19 Jan 2021 22:03:11 GMT
+      - Thu, 21 Jan 2021 23:44:40 GMT
       Expires:
       - "-1"
       Pragma:
@@ -272,6 +272,40 @@ interactions:
     code: 201
     duration: ""
 - request:
+    body: '{"name":"k8s_234c5afb-56ca-5133-b1e2-9d901f2b7ea1","Properties":{"Error":null,"debugSetting":{"detailLevel":"requestContent,responseContent"},"mode":"Incremental","template":{"$schema":"https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#","contentVersion":"1.0.0.0","resources":[{"apiVersion":"2015-04-08","kind":"GlobalDocumentDB","location":"westus","name":"k8sinfratestdbhmayhx","properties":{"databaseAccountOfferType":"Standard","locations":[{"locationName":"westus"}]},"type":"Microsoft.DocumentDB/databaseAccounts"}],"outputs":{"resourceId":{"type":"string","value":"[resourceId(''Microsoft.DocumentDB/databaseAccounts'', ''k8sinfratestdbhmayhx'')]"}}}}}'
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Go/go1.15.6 (amd64-linux) go-autorest/v14.1.1 k8sinfra-generated
+    url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/k8sinfratest-rg-dnhfns/providers/Microsoft.Resources/deployments/k8s_234c5afb-56ca-5133-b1e2-9d901f2b7ea1?api-version=2019-10-01
+    method: PUT
+  response:
+    body: '{"error":{"code":"DeploymentActive","message":"Unable to edit or replace deployment ''k8s_234c5afb-56ca-5133-b1e2-9d901f2b7ea1'': previous deployment from ''1/21/2021 11:44:40 PM'' is still active (expiration time is ''1/28/2021 11:44:39 PM''). Please see https://aka.ms/arm-deploy for usage details."}}'
+    headers:
+      Cache-Control:
+      - no-cache
+      Content-Length:
+      - "297"
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 21 Jan 2021 23:44:41 GMT
+      Expires:
+      - "-1"
+      Pragma:
+      - no-cache
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      X-Ms-Failure-Cause:
+      - gateway
+    status: 409 Conflict
+    code: 409
+    duration: ""
+- request:
     body: ""
     form: {}
     headers:
@@ -282,14 +316,14 @@ interactions:
     url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.Resources/deployments/k8s_234c5afb-56ca-5133-b1e2-9d901f2b7ea1?api-version=2019-10-01
     method: GET
   response:
-    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.Resources/deployments/k8s_234c5afb-56ca-5133-b1e2-9d901f2b7ea1","name":"k8s_234c5afb-56ca-5133-b1e2-9d901f2b7ea1","type":"Microsoft.Resources/deployments","properties":{"templateHash":"6776755900857513625","mode":"Incremental","debugSetting":{"detailLevel":"RequestContent, ResponseContent"},"provisioningState":"Accepted","timestamp":"2021-01-19T22:03:10.8614013Z","duration":"PT1.1650422S","correlationId":"735af330-dbcd-4bf7-b22c-1205b3cea15a","providers":[{"namespace":"Microsoft.DocumentDB","resourceTypes":[{"resourceType":"databaseAccounts","locations":["westus"]}]}],"dependencies":[]}}'
+    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.Resources/deployments/k8s_234c5afb-56ca-5133-b1e2-9d901f2b7ea1","name":"k8s_234c5afb-56ca-5133-b1e2-9d901f2b7ea1","type":"Microsoft.Resources/deployments","properties":{"templateHash":"6776755900857513625","mode":"Incremental","debugSetting":{"detailLevel":"RequestContent, ResponseContent"},"provisioningState":"Running","timestamp":"2021-01-21T23:44:41.8653275Z","duration":"PT2.060339S","correlationId":"4c2dbabb-d675-4f55-b146-1ff14b697e1c","providers":[{"namespace":"Microsoft.DocumentDB","resourceTypes":[{"resourceType":"databaseAccounts","locations":["westus"]}]}],"dependencies":[]}}'
     headers:
       Cache-Control:
       - no-cache
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 19 Jan 2021 22:03:11 GMT
+      - Thu, 21 Jan 2021 23:44:41 GMT
       Expires:
       - "-1"
       Pragma:
@@ -316,14 +350,14 @@ interactions:
     url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.Resources/deployments/k8s_234c5afb-56ca-5133-b1e2-9d901f2b7ea1?api-version=2019-10-01
     method: GET
   response:
-    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.Resources/deployments/k8s_234c5afb-56ca-5133-b1e2-9d901f2b7ea1","name":"k8s_234c5afb-56ca-5133-b1e2-9d901f2b7ea1","type":"Microsoft.Resources/deployments","properties":{"templateHash":"6776755900857513625","mode":"Incremental","debugSetting":{"detailLevel":"RequestContent, ResponseContent"},"provisioningState":"Running","timestamp":"2021-01-19T22:03:11.8591071Z","duration":"PT2.162748S","correlationId":"735af330-dbcd-4bf7-b22c-1205b3cea15a","providers":[{"namespace":"Microsoft.DocumentDB","resourceTypes":[{"resourceType":"databaseAccounts","locations":["westus"]}]}],"dependencies":[]}}'
+    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.Resources/deployments/k8s_234c5afb-56ca-5133-b1e2-9d901f2b7ea1","name":"k8s_234c5afb-56ca-5133-b1e2-9d901f2b7ea1","type":"Microsoft.Resources/deployments","properties":{"templateHash":"6776755900857513625","mode":"Incremental","debugSetting":{"detailLevel":"RequestContent, ResponseContent"},"provisioningState":"Running","timestamp":"2021-01-21T23:44:41.8653275Z","duration":"PT2.060339S","correlationId":"4c2dbabb-d675-4f55-b146-1ff14b697e1c","providers":[{"namespace":"Microsoft.DocumentDB","resourceTypes":[{"resourceType":"databaseAccounts","locations":["westus"]}]}],"dependencies":[]}}'
     headers:
       Cache-Control:
       - no-cache
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 19 Jan 2021 22:03:16 GMT
+      - Thu, 21 Jan 2021 23:44:42 GMT
       Expires:
       - "-1"
       Pragma:
@@ -350,14 +384,14 @@ interactions:
     url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.Resources/deployments/k8s_234c5afb-56ca-5133-b1e2-9d901f2b7ea1?api-version=2019-10-01
     method: GET
   response:
-    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.Resources/deployments/k8s_234c5afb-56ca-5133-b1e2-9d901f2b7ea1","name":"k8s_234c5afb-56ca-5133-b1e2-9d901f2b7ea1","type":"Microsoft.Resources/deployments","properties":{"templateHash":"6776755900857513625","mode":"Incremental","debugSetting":{"detailLevel":"RequestContent, ResponseContent"},"provisioningState":"Running","timestamp":"2021-01-19T22:03:11.8591071Z","duration":"PT2.162748S","correlationId":"735af330-dbcd-4bf7-b22c-1205b3cea15a","providers":[{"namespace":"Microsoft.DocumentDB","resourceTypes":[{"resourceType":"databaseAccounts","locations":["westus"]}]}],"dependencies":[]}}'
+    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.Resources/deployments/k8s_234c5afb-56ca-5133-b1e2-9d901f2b7ea1","name":"k8s_234c5afb-56ca-5133-b1e2-9d901f2b7ea1","type":"Microsoft.Resources/deployments","properties":{"templateHash":"6776755900857513625","mode":"Incremental","debugSetting":{"detailLevel":"RequestContent, ResponseContent"},"provisioningState":"Running","timestamp":"2021-01-21T23:44:41.8653275Z","duration":"PT2.060339S","correlationId":"4c2dbabb-d675-4f55-b146-1ff14b697e1c","providers":[{"namespace":"Microsoft.DocumentDB","resourceTypes":[{"resourceType":"databaseAccounts","locations":["westus"]}]}],"dependencies":[]}}'
     headers:
       Cache-Control:
       - no-cache
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 19 Jan 2021 22:03:17 GMT
+      - Thu, 21 Jan 2021 23:44:46 GMT
       Expires:
       - "-1"
       Pragma:
@@ -384,14 +418,14 @@ interactions:
     url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.Resources/deployments/k8s_234c5afb-56ca-5133-b1e2-9d901f2b7ea1?api-version=2019-10-01
     method: GET
   response:
-    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.Resources/deployments/k8s_234c5afb-56ca-5133-b1e2-9d901f2b7ea1","name":"k8s_234c5afb-56ca-5133-b1e2-9d901f2b7ea1","type":"Microsoft.Resources/deployments","properties":{"templateHash":"6776755900857513625","mode":"Incremental","debugSetting":{"detailLevel":"RequestContent, ResponseContent"},"provisioningState":"Running","timestamp":"2021-01-19T22:03:11.8591071Z","duration":"PT2.162748S","correlationId":"735af330-dbcd-4bf7-b22c-1205b3cea15a","providers":[{"namespace":"Microsoft.DocumentDB","resourceTypes":[{"resourceType":"databaseAccounts","locations":["westus"]}]}],"dependencies":[]}}'
+    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.Resources/deployments/k8s_234c5afb-56ca-5133-b1e2-9d901f2b7ea1","name":"k8s_234c5afb-56ca-5133-b1e2-9d901f2b7ea1","type":"Microsoft.Resources/deployments","properties":{"templateHash":"6776755900857513625","mode":"Incremental","debugSetting":{"detailLevel":"RequestContent, ResponseContent"},"provisioningState":"Running","timestamp":"2021-01-21T23:44:41.8653275Z","duration":"PT2.060339S","correlationId":"4c2dbabb-d675-4f55-b146-1ff14b697e1c","providers":[{"namespace":"Microsoft.DocumentDB","resourceTypes":[{"resourceType":"databaseAccounts","locations":["westus"]}]}],"dependencies":[]}}'
     headers:
       Cache-Control:
       - no-cache
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 19 Jan 2021 22:03:22 GMT
+      - Thu, 21 Jan 2021 23:44:51 GMT
       Expires:
       - "-1"
       Pragma:
@@ -418,14 +452,218 @@ interactions:
     url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.Resources/deployments/k8s_234c5afb-56ca-5133-b1e2-9d901f2b7ea1?api-version=2019-10-01
     method: GET
   response:
-    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.Resources/deployments/k8s_234c5afb-56ca-5133-b1e2-9d901f2b7ea1","name":"k8s_234c5afb-56ca-5133-b1e2-9d901f2b7ea1","type":"Microsoft.Resources/deployments","properties":{"templateHash":"6776755900857513625","mode":"Incremental","debugSetting":{"detailLevel":"RequestContent, ResponseContent"},"provisioningState":"Running","timestamp":"2021-01-19T22:03:25.5016499Z","duration":"PT15.8052908S","correlationId":"735af330-dbcd-4bf7-b22c-1205b3cea15a","providers":[{"namespace":"Microsoft.DocumentDB","resourceTypes":[{"resourceType":"databaseAccounts","locations":["westus"]}]}],"dependencies":[]}}'
+    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.Resources/deployments/k8s_234c5afb-56ca-5133-b1e2-9d901f2b7ea1","name":"k8s_234c5afb-56ca-5133-b1e2-9d901f2b7ea1","type":"Microsoft.Resources/deployments","properties":{"templateHash":"6776755900857513625","mode":"Incremental","debugSetting":{"detailLevel":"RequestContent, ResponseContent"},"provisioningState":"Running","timestamp":"2021-01-21T23:44:55.5688313Z","duration":"PT15.7638428S","correlationId":"4c2dbabb-d675-4f55-b146-1ff14b697e1c","providers":[{"namespace":"Microsoft.DocumentDB","resourceTypes":[{"resourceType":"databaseAccounts","locations":["westus"]}]}],"dependencies":[]}}'
     headers:
       Cache-Control:
       - no-cache
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 19 Jan 2021 22:03:27 GMT
+      - Thu, 21 Jan 2021 23:44:56 GMT
+      Expires:
+      - "-1"
+      Pragma:
+      - no-cache
+      Retry-After:
+      - "15"
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Go/go1.15.6 (amd64-linux) go-autorest/v14.1.1 k8sinfra-generated
+    url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.Resources/deployments/k8s_234c5afb-56ca-5133-b1e2-9d901f2b7ea1?api-version=2019-10-01
+    method: GET
+  response:
+    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.Resources/deployments/k8s_234c5afb-56ca-5133-b1e2-9d901f2b7ea1","name":"k8s_234c5afb-56ca-5133-b1e2-9d901f2b7ea1","type":"Microsoft.Resources/deployments","properties":{"templateHash":"6776755900857513625","mode":"Incremental","debugSetting":{"detailLevel":"RequestContent, ResponseContent"},"provisioningState":"Running","timestamp":"2021-01-21T23:44:55.5688313Z","duration":"PT15.7638428S","correlationId":"4c2dbabb-d675-4f55-b146-1ff14b697e1c","providers":[{"namespace":"Microsoft.DocumentDB","resourceTypes":[{"resourceType":"databaseAccounts","locations":["westus"]}]}],"dependencies":[]}}'
+    headers:
+      Cache-Control:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 21 Jan 2021 23:45:02 GMT
+      Expires:
+      - "-1"
+      Pragma:
+      - no-cache
+      Retry-After:
+      - "9"
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Go/go1.15.6 (amd64-linux) go-autorest/v14.1.1 k8sinfra-generated
+    url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.Resources/deployments/k8s_234c5afb-56ca-5133-b1e2-9d901f2b7ea1?api-version=2019-10-01
+    method: GET
+  response:
+    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.Resources/deployments/k8s_234c5afb-56ca-5133-b1e2-9d901f2b7ea1","name":"k8s_234c5afb-56ca-5133-b1e2-9d901f2b7ea1","type":"Microsoft.Resources/deployments","properties":{"templateHash":"6776755900857513625","mode":"Incremental","debugSetting":{"detailLevel":"RequestContent, ResponseContent"},"provisioningState":"Running","timestamp":"2021-01-21T23:44:55.5688313Z","duration":"PT15.7638428S","correlationId":"4c2dbabb-d675-4f55-b146-1ff14b697e1c","providers":[{"namespace":"Microsoft.DocumentDB","resourceTypes":[{"resourceType":"databaseAccounts","locations":["westus"]}]}],"dependencies":[]}}'
+    headers:
+      Cache-Control:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 21 Jan 2021 23:45:07 GMT
+      Expires:
+      - "-1"
+      Pragma:
+      - no-cache
+      Retry-After:
+      - "5"
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Go/go1.15.6 (amd64-linux) go-autorest/v14.1.1 k8sinfra-generated
+    url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.Resources/deployments/k8s_234c5afb-56ca-5133-b1e2-9d901f2b7ea1?api-version=2019-10-01
+    method: GET
+  response:
+    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.Resources/deployments/k8s_234c5afb-56ca-5133-b1e2-9d901f2b7ea1","name":"k8s_234c5afb-56ca-5133-b1e2-9d901f2b7ea1","type":"Microsoft.Resources/deployments","properties":{"templateHash":"6776755900857513625","mode":"Incremental","debugSetting":{"detailLevel":"RequestContent, ResponseContent"},"provisioningState":"Running","timestamp":"2021-01-21T23:45:11.9072244Z","duration":"PT32.1022359S","correlationId":"4c2dbabb-d675-4f55-b146-1ff14b697e1c","providers":[{"namespace":"Microsoft.DocumentDB","resourceTypes":[{"resourceType":"databaseAccounts","locations":["westus"]}]}],"dependencies":[]}}'
+    headers:
+      Cache-Control:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 21 Jan 2021 23:45:12 GMT
+      Expires:
+      - "-1"
+      Pragma:
+      - no-cache
+      Retry-After:
+      - "15"
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Go/go1.15.6 (amd64-linux) go-autorest/v14.1.1 k8sinfra-generated
+    url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.Resources/deployments/k8s_234c5afb-56ca-5133-b1e2-9d901f2b7ea1?api-version=2019-10-01
+    method: GET
+  response:
+    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.Resources/deployments/k8s_234c5afb-56ca-5133-b1e2-9d901f2b7ea1","name":"k8s_234c5afb-56ca-5133-b1e2-9d901f2b7ea1","type":"Microsoft.Resources/deployments","properties":{"templateHash":"6776755900857513625","mode":"Incremental","debugSetting":{"detailLevel":"RequestContent, ResponseContent"},"provisioningState":"Running","timestamp":"2021-01-21T23:45:11.9072244Z","duration":"PT32.1022359S","correlationId":"4c2dbabb-d675-4f55-b146-1ff14b697e1c","providers":[{"namespace":"Microsoft.DocumentDB","resourceTypes":[{"resourceType":"databaseAccounts","locations":["westus"]}]}],"dependencies":[]}}'
+    headers:
+      Cache-Control:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 21 Jan 2021 23:45:18 GMT
+      Expires:
+      - "-1"
+      Pragma:
+      - no-cache
+      Retry-After:
+      - "9"
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Go/go1.15.6 (amd64-linux) go-autorest/v14.1.1 k8sinfra-generated
+    url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.Resources/deployments/k8s_234c5afb-56ca-5133-b1e2-9d901f2b7ea1?api-version=2019-10-01
+    method: GET
+  response:
+    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.Resources/deployments/k8s_234c5afb-56ca-5133-b1e2-9d901f2b7ea1","name":"k8s_234c5afb-56ca-5133-b1e2-9d901f2b7ea1","type":"Microsoft.Resources/deployments","properties":{"templateHash":"6776755900857513625","mode":"Incremental","debugSetting":{"detailLevel":"RequestContent, ResponseContent"},"provisioningState":"Running","timestamp":"2021-01-21T23:45:11.9072244Z","duration":"PT32.1022359S","correlationId":"4c2dbabb-d675-4f55-b146-1ff14b697e1c","providers":[{"namespace":"Microsoft.DocumentDB","resourceTypes":[{"resourceType":"databaseAccounts","locations":["westus"]}]}],"dependencies":[]}}'
+    headers:
+      Cache-Control:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 21 Jan 2021 23:45:23 GMT
+      Expires:
+      - "-1"
+      Pragma:
+      - no-cache
+      Retry-After:
+      - "5"
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Go/go1.15.6 (amd64-linux) go-autorest/v14.1.1 k8sinfra-generated
+    url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.Resources/deployments/k8s_234c5afb-56ca-5133-b1e2-9d901f2b7ea1?api-version=2019-10-01
+    method: GET
+  response:
+    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.Resources/deployments/k8s_234c5afb-56ca-5133-b1e2-9d901f2b7ea1","name":"k8s_234c5afb-56ca-5133-b1e2-9d901f2b7ea1","type":"Microsoft.Resources/deployments","properties":{"templateHash":"6776755900857513625","mode":"Incremental","debugSetting":{"detailLevel":"RequestContent, ResponseContent"},"provisioningState":"Running","timestamp":"2021-01-21T23:45:27.4863919Z","duration":"PT47.6814034S","correlationId":"4c2dbabb-d675-4f55-b146-1ff14b697e1c","providers":[{"namespace":"Microsoft.DocumentDB","resourceTypes":[{"resourceType":"databaseAccounts","locations":["westus"]}]}],"dependencies":[]}}'
+    headers:
+      Cache-Control:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 21 Jan 2021 23:45:29 GMT
       Expires:
       - "-1"
       Pragma:
@@ -452,14 +690,14 @@ interactions:
     url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.Resources/deployments/k8s_234c5afb-56ca-5133-b1e2-9d901f2b7ea1?api-version=2019-10-01
     method: GET
   response:
-    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.Resources/deployments/k8s_234c5afb-56ca-5133-b1e2-9d901f2b7ea1","name":"k8s_234c5afb-56ca-5133-b1e2-9d901f2b7ea1","type":"Microsoft.Resources/deployments","properties":{"templateHash":"6776755900857513625","mode":"Incremental","debugSetting":{"detailLevel":"RequestContent, ResponseContent"},"provisioningState":"Running","timestamp":"2021-01-19T22:03:25.5016499Z","duration":"PT15.8052908S","correlationId":"735af330-dbcd-4bf7-b22c-1205b3cea15a","providers":[{"namespace":"Microsoft.DocumentDB","resourceTypes":[{"resourceType":"databaseAccounts","locations":["westus"]}]}],"dependencies":[]}}'
+    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.Resources/deployments/k8s_234c5afb-56ca-5133-b1e2-9d901f2b7ea1","name":"k8s_234c5afb-56ca-5133-b1e2-9d901f2b7ea1","type":"Microsoft.Resources/deployments","properties":{"templateHash":"6776755900857513625","mode":"Incremental","debugSetting":{"detailLevel":"RequestContent, ResponseContent"},"provisioningState":"Running","timestamp":"2021-01-21T23:45:27.4863919Z","duration":"PT47.6814034S","correlationId":"4c2dbabb-d675-4f55-b146-1ff14b697e1c","providers":[{"namespace":"Microsoft.DocumentDB","resourceTypes":[{"resourceType":"databaseAccounts","locations":["westus"]}]}],"dependencies":[]}}'
     headers:
       Cache-Control:
       - no-cache
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 19 Jan 2021 22:03:32 GMT
+      - Thu, 21 Jan 2021 23:45:34 GMT
       Expires:
       - "-1"
       Pragma:
@@ -486,14 +724,14 @@ interactions:
     url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.Resources/deployments/k8s_234c5afb-56ca-5133-b1e2-9d901f2b7ea1?api-version=2019-10-01
     method: GET
   response:
-    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.Resources/deployments/k8s_234c5afb-56ca-5133-b1e2-9d901f2b7ea1","name":"k8s_234c5afb-56ca-5133-b1e2-9d901f2b7ea1","type":"Microsoft.Resources/deployments","properties":{"templateHash":"6776755900857513625","mode":"Incremental","debugSetting":{"detailLevel":"RequestContent, ResponseContent"},"provisioningState":"Running","timestamp":"2021-01-19T22:03:25.5016499Z","duration":"PT15.8052908S","correlationId":"735af330-dbcd-4bf7-b22c-1205b3cea15a","providers":[{"namespace":"Microsoft.DocumentDB","resourceTypes":[{"resourceType":"databaseAccounts","locations":["westus"]}]}],"dependencies":[]}}'
+    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.Resources/deployments/k8s_234c5afb-56ca-5133-b1e2-9d901f2b7ea1","name":"k8s_234c5afb-56ca-5133-b1e2-9d901f2b7ea1","type":"Microsoft.Resources/deployments","properties":{"templateHash":"6776755900857513625","mode":"Incremental","debugSetting":{"detailLevel":"RequestContent, ResponseContent"},"provisioningState":"Running","timestamp":"2021-01-21T23:45:27.4863919Z","duration":"PT47.6814034S","correlationId":"4c2dbabb-d675-4f55-b146-1ff14b697e1c","providers":[{"namespace":"Microsoft.DocumentDB","resourceTypes":[{"resourceType":"databaseAccounts","locations":["westus"]}]}],"dependencies":[]}}'
     headers:
       Cache-Control:
       - no-cache
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 19 Jan 2021 22:03:38 GMT
+      - Thu, 21 Jan 2021 23:45:40 GMT
       Expires:
       - "-1"
       Pragma:
@@ -520,20 +758,20 @@ interactions:
     url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.Resources/deployments/k8s_234c5afb-56ca-5133-b1e2-9d901f2b7ea1?api-version=2019-10-01
     method: GET
   response:
-    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.Resources/deployments/k8s_234c5afb-56ca-5133-b1e2-9d901f2b7ea1","name":"k8s_234c5afb-56ca-5133-b1e2-9d901f2b7ea1","type":"Microsoft.Resources/deployments","properties":{"templateHash":"6776755900857513625","mode":"Incremental","debugSetting":{"detailLevel":"RequestContent, ResponseContent"},"provisioningState":"Running","timestamp":"2021-01-19T22:03:42.0422034Z","duration":"PT32.3458443S","correlationId":"735af330-dbcd-4bf7-b22c-1205b3cea15a","providers":[{"namespace":"Microsoft.DocumentDB","resourceTypes":[{"resourceType":"databaseAccounts","locations":["westus"]}]}],"dependencies":[]}}'
+    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.Resources/deployments/k8s_234c5afb-56ca-5133-b1e2-9d901f2b7ea1","name":"k8s_234c5afb-56ca-5133-b1e2-9d901f2b7ea1","type":"Microsoft.Resources/deployments","properties":{"templateHash":"6776755900857513625","mode":"Incremental","debugSetting":{"detailLevel":"RequestContent, ResponseContent"},"provisioningState":"Running","timestamp":"2021-01-21T23:45:43.3605795Z","duration":"PT1M3.555591S","correlationId":"4c2dbabb-d675-4f55-b146-1ff14b697e1c","providers":[{"namespace":"Microsoft.DocumentDB","resourceTypes":[{"resourceType":"databaseAccounts","locations":["westus"]}]}],"dependencies":[]}}'
     headers:
       Cache-Control:
       - no-cache
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 19 Jan 2021 22:03:43 GMT
+      - Thu, 21 Jan 2021 23:45:45 GMT
       Expires:
       - "-1"
       Pragma:
       - no-cache
       Retry-After:
-      - "15"
+      - "14"
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Vary:
@@ -554,14 +792,14 @@ interactions:
     url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.Resources/deployments/k8s_234c5afb-56ca-5133-b1e2-9d901f2b7ea1?api-version=2019-10-01
     method: GET
   response:
-    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.Resources/deployments/k8s_234c5afb-56ca-5133-b1e2-9d901f2b7ea1","name":"k8s_234c5afb-56ca-5133-b1e2-9d901f2b7ea1","type":"Microsoft.Resources/deployments","properties":{"templateHash":"6776755900857513625","mode":"Incremental","debugSetting":{"detailLevel":"RequestContent, ResponseContent"},"provisioningState":"Running","timestamp":"2021-01-19T22:03:42.0422034Z","duration":"PT32.3458443S","correlationId":"735af330-dbcd-4bf7-b22c-1205b3cea15a","providers":[{"namespace":"Microsoft.DocumentDB","resourceTypes":[{"resourceType":"databaseAccounts","locations":["westus"]}]}],"dependencies":[]}}'
+    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.Resources/deployments/k8s_234c5afb-56ca-5133-b1e2-9d901f2b7ea1","name":"k8s_234c5afb-56ca-5133-b1e2-9d901f2b7ea1","type":"Microsoft.Resources/deployments","properties":{"templateHash":"6776755900857513625","mode":"Incremental","debugSetting":{"detailLevel":"RequestContent, ResponseContent"},"provisioningState":"Running","timestamp":"2021-01-21T23:45:43.3605795Z","duration":"PT1M3.555591S","correlationId":"4c2dbabb-d675-4f55-b146-1ff14b697e1c","providers":[{"namespace":"Microsoft.DocumentDB","resourceTypes":[{"resourceType":"databaseAccounts","locations":["westus"]}]}],"dependencies":[]}}'
     headers:
       Cache-Control:
       - no-cache
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 19 Jan 2021 22:03:48 GMT
+      - Thu, 21 Jan 2021 23:45:50 GMT
       Expires:
       - "-1"
       Pragma:
@@ -588,14 +826,14 @@ interactions:
     url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.Resources/deployments/k8s_234c5afb-56ca-5133-b1e2-9d901f2b7ea1?api-version=2019-10-01
     method: GET
   response:
-    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.Resources/deployments/k8s_234c5afb-56ca-5133-b1e2-9d901f2b7ea1","name":"k8s_234c5afb-56ca-5133-b1e2-9d901f2b7ea1","type":"Microsoft.Resources/deployments","properties":{"templateHash":"6776755900857513625","mode":"Incremental","debugSetting":{"detailLevel":"RequestContent, ResponseContent"},"provisioningState":"Running","timestamp":"2021-01-19T22:03:42.0422034Z","duration":"PT32.3458443S","correlationId":"735af330-dbcd-4bf7-b22c-1205b3cea15a","providers":[{"namespace":"Microsoft.DocumentDB","resourceTypes":[{"resourceType":"databaseAccounts","locations":["westus"]}]}],"dependencies":[]}}'
+    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.Resources/deployments/k8s_234c5afb-56ca-5133-b1e2-9d901f2b7ea1","name":"k8s_234c5afb-56ca-5133-b1e2-9d901f2b7ea1","type":"Microsoft.Resources/deployments","properties":{"templateHash":"6776755900857513625","mode":"Incremental","debugSetting":{"detailLevel":"RequestContent, ResponseContent"},"provisioningState":"Running","timestamp":"2021-01-21T23:45:43.3605795Z","duration":"PT1M3.555591S","correlationId":"4c2dbabb-d675-4f55-b146-1ff14b697e1c","providers":[{"namespace":"Microsoft.DocumentDB","resourceTypes":[{"resourceType":"databaseAccounts","locations":["westus"]}]}],"dependencies":[]}}'
     headers:
       Cache-Control:
       - no-cache
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 19 Jan 2021 22:03:54 GMT
+      - Thu, 21 Jan 2021 23:45:56 GMT
       Expires:
       - "-1"
       Pragma:
@@ -622,14 +860,14 @@ interactions:
     url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.Resources/deployments/k8s_234c5afb-56ca-5133-b1e2-9d901f2b7ea1?api-version=2019-10-01
     method: GET
   response:
-    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.Resources/deployments/k8s_234c5afb-56ca-5133-b1e2-9d901f2b7ea1","name":"k8s_234c5afb-56ca-5133-b1e2-9d901f2b7ea1","type":"Microsoft.Resources/deployments","properties":{"templateHash":"6776755900857513625","mode":"Incremental","debugSetting":{"detailLevel":"RequestContent, ResponseContent"},"provisioningState":"Succeeded","timestamp":"2021-01-19T22:03:59.3206089Z","duration":"PT49.6242498S","correlationId":"735af330-dbcd-4bf7-b22c-1205b3cea15a","providers":[{"namespace":"Microsoft.DocumentDB","resourceTypes":[{"resourceType":"databaseAccounts","locations":["westus"]}]}],"dependencies":[],"outputs":{"resourceId":{"type":"String","value":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx"}},"outputResources":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx"}]}}'
+    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.Resources/deployments/k8s_234c5afb-56ca-5133-b1e2-9d901f2b7ea1","name":"k8s_234c5afb-56ca-5133-b1e2-9d901f2b7ea1","type":"Microsoft.Resources/deployments","properties":{"templateHash":"6776755900857513625","mode":"Incremental","debugSetting":{"detailLevel":"RequestContent, ResponseContent"},"provisioningState":"Succeeded","timestamp":"2021-01-21T23:46:00.7289034Z","duration":"PT1M20.9239149S","correlationId":"4c2dbabb-d675-4f55-b146-1ff14b697e1c","providers":[{"namespace":"Microsoft.DocumentDB","resourceTypes":[{"resourceType":"databaseAccounts","locations":["westus"]}]}],"dependencies":[],"outputs":{"resourceId":{"type":"String","value":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx"}},"outputResources":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx"}]}}'
     headers:
       Cache-Control:
       - no-cache
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 19 Jan 2021 22:03:59 GMT
+      - Thu, 21 Jan 2021 23:46:01 GMT
       Expires:
       - "-1"
       Pragma:
@@ -654,14 +892,14 @@ interactions:
     url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx?api-version=2015-04-08
     method: GET
   response:
-    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx","name":"k8sinfratestdbhmayhx","location":"West US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2021-01-19T22:03:48.2932101Z"},"properties":{"provisioningState":"Succeeded","documentEndpoint":"https://k8sinfratestdbhmayhx.documents.azure.com:443/","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"instanceId":"65c2d03c-7a90-4781-ae94-221c028bd8e3","createMode":"Default","databaseAccountOfferType":"Standard","ipRangeFilter":"","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Succeeded","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Succeeded","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Succeeded","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","failoverPriority":0}],"cors":[],"capabilities":[],"backupPolicy":{"type":"Periodic","periodicModeProperties":{"backupIntervalInMinutes":240,"backupRetentionIntervalInHours":8}}}}'
+    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx","name":"k8sinfratestdbhmayhx","location":"West US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2021-01-21T23:45:30.2444381Z"},"properties":{"provisioningState":"Succeeded","documentEndpoint":"https://k8sinfratestdbhmayhx.documents.azure.com:443/","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"instanceId":"be52cc07-6378-4a29-a5c8-9d7d7a694291","createMode":"Default","databaseAccountOfferType":"Standard","ipRangeFilter":"","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Succeeded","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Succeeded","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Succeeded","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","failoverPriority":0}],"cors":[],"capabilities":[],"backupPolicy":{"type":"Periodic","periodicModeProperties":{"backupIntervalInMinutes":240,"backupRetentionIntervalInHours":8}}}}'
     headers:
       Cache-Control:
       - no-store, no-cache
       Content-Type:
       - application/json
       Date:
-      - Tue, 19 Jan 2021 22:03:59 GMT
+      - Thu, 21 Jan 2021 23:46:01 GMT
       Pragma:
       - no-cache
       Server:
@@ -695,7 +933,7 @@ interactions:
       Content-Length:
       - "0"
       Date:
-      - Tue, 19 Jan 2021 22:04:03 GMT
+      - Thu, 21 Jan 2021 23:46:03 GMT
       Expires:
       - "-1"
       Location:
@@ -709,7 +947,7 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Ms-Ratelimit-Remaining-Subscription-Deletes:
-      - "14998"
+      - "14989"
     status: 202 Accepted
     code: 202
     duration: ""
@@ -727,7 +965,7 @@ interactions:
     body: '{"status":"Enqueued"}'
     headers:
       Azure-Asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/3f3bef73-7ab2-4802-9120-259bd166f460?api-version=2015-04-08
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/ee8b9b22-6d2e-4cf5-b9d1-40f5dcf6e8d2?api-version=2015-04-08
       Cache-Control:
       - no-store, no-cache
       Content-Length:
@@ -735,9 +973,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 19 Jan 2021 22:04:05 GMT
+      - Thu, 21 Jan 2021 23:46:05 GMT
       Location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationResults/3f3bef73-7ab2-4802-9120-259bd166f460?api-version=2015-04-08
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationResults/ee8b9b22-6d2e-4cf5-b9d1-40f5dcf6e8d2?api-version=2015-04-08
       Pragma:
       - no-cache
       Server:
@@ -749,7 +987,7 @@ interactions:
       X-Ms-Gatewayversion:
       - version=2.11.0
       X-Ms-Ratelimit-Remaining-Subscription-Deletes:
-      - "14997"
+      - "14988"
     status: 202 Accepted
     code: 202
     duration: ""
@@ -764,14 +1002,14 @@ interactions:
     url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx?api-version=2015-04-08
     method: GET
   response:
-    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx","name":"k8sinfratestdbhmayhx","location":"West US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2021-01-19T22:03:48.2932101Z"},"properties":{"provisioningState":"Deleting","documentEndpoint":"https://k8sinfratestdbhmayhx.documents.azure.com:443/","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"instanceId":"65c2d03c-7a90-4781-ae94-221c028bd8e3","createMode":"Default","databaseAccountOfferType":"Standard","ipRangeFilter":"","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","failoverPriority":0}],"cors":[],"capabilities":[],"backupPolicy":{"type":"Periodic","periodicModeProperties":{"backupIntervalInMinutes":240,"backupRetentionIntervalInHours":8}}}}'
+    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx","name":"k8sinfratestdbhmayhx","location":"West US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2021-01-21T23:45:30.2444381Z"},"properties":{"provisioningState":"Deleting","documentEndpoint":"https://k8sinfratestdbhmayhx.documents.azure.com:443/","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"instanceId":"be52cc07-6378-4a29-a5c8-9d7d7a694291","createMode":"Default","databaseAccountOfferType":"Standard","ipRangeFilter":"","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","failoverPriority":0}],"cors":[],"capabilities":[],"backupPolicy":{"type":"Periodic","periodicModeProperties":{"backupIntervalInMinutes":240,"backupRetentionIntervalInHours":8}}}}'
     headers:
       Cache-Control:
       - no-store, no-cache
       Content-Type:
       - application/json
       Date:
-      - Tue, 19 Jan 2021 22:04:06 GMT
+      - Thu, 21 Jan 2021 23:46:05 GMT
       Pragma:
       - no-cache
       Server:
@@ -798,14 +1036,14 @@ interactions:
     url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx?api-version=2015-04-08
     method: GET
   response:
-    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx","name":"k8sinfratestdbhmayhx","location":"West US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2021-01-19T22:03:48.2932101Z"},"properties":{"provisioningState":"Deleting","documentEndpoint":"https://k8sinfratestdbhmayhx.documents.azure.com:443/","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"instanceId":"65c2d03c-7a90-4781-ae94-221c028bd8e3","createMode":"Default","databaseAccountOfferType":"Standard","ipRangeFilter":"","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","failoverPriority":0}],"cors":[],"capabilities":[],"backupPolicy":{"type":"Periodic","periodicModeProperties":{"backupIntervalInMinutes":240,"backupRetentionIntervalInHours":8}}}}'
+    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx","name":"k8sinfratestdbhmayhx","location":"West US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2021-01-21T23:45:30.2444381Z"},"properties":{"provisioningState":"Deleting","documentEndpoint":"https://k8sinfratestdbhmayhx.documents.azure.com:443/","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"instanceId":"be52cc07-6378-4a29-a5c8-9d7d7a694291","createMode":"Default","databaseAccountOfferType":"Standard","ipRangeFilter":"","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","failoverPriority":0}],"cors":[],"capabilities":[],"backupPolicy":{"type":"Periodic","periodicModeProperties":{"backupIntervalInMinutes":240,"backupRetentionIntervalInHours":8}}}}'
     headers:
       Cache-Control:
       - no-store, no-cache
       Content-Type:
       - application/json
       Date:
-      - Tue, 19 Jan 2021 22:04:11 GMT
+      - Thu, 21 Jan 2021 23:46:05 GMT
       Pragma:
       - no-cache
       Server:
@@ -832,14 +1070,14 @@ interactions:
     url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx?api-version=2015-04-08
     method: GET
   response:
-    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx","name":"k8sinfratestdbhmayhx","location":"West US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2021-01-19T22:03:48.2932101Z"},"properties":{"provisioningState":"Deleting","documentEndpoint":"https://k8sinfratestdbhmayhx.documents.azure.com:443/","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"instanceId":"65c2d03c-7a90-4781-ae94-221c028bd8e3","createMode":"Default","databaseAccountOfferType":"Standard","ipRangeFilter":"","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","failoverPriority":0}],"cors":[],"capabilities":[],"backupPolicy":{"type":"Periodic","periodicModeProperties":{"backupIntervalInMinutes":240,"backupRetentionIntervalInHours":8}}}}'
+    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx","name":"k8sinfratestdbhmayhx","location":"West US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2021-01-21T23:45:30.2444381Z"},"properties":{"provisioningState":"Deleting","documentEndpoint":"https://k8sinfratestdbhmayhx.documents.azure.com:443/","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"instanceId":"be52cc07-6378-4a29-a5c8-9d7d7a694291","createMode":"Default","databaseAccountOfferType":"Standard","ipRangeFilter":"","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","failoverPriority":0}],"cors":[],"capabilities":[],"backupPolicy":{"type":"Periodic","periodicModeProperties":{"backupIntervalInMinutes":240,"backupRetentionIntervalInHours":8}}}}'
     headers:
       Cache-Control:
       - no-store, no-cache
       Content-Type:
       - application/json
       Date:
-      - Tue, 19 Jan 2021 22:04:17 GMT
+      - Thu, 21 Jan 2021 23:46:11 GMT
       Pragma:
       - no-cache
       Server:
@@ -866,14 +1104,14 @@ interactions:
     url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx?api-version=2015-04-08
     method: GET
   response:
-    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx","name":"k8sinfratestdbhmayhx","location":"West US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2021-01-19T22:03:48.2932101Z"},"properties":{"provisioningState":"Deleting","documentEndpoint":"https://k8sinfratestdbhmayhx.documents.azure.com:443/","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"instanceId":"65c2d03c-7a90-4781-ae94-221c028bd8e3","createMode":"Default","databaseAccountOfferType":"Standard","ipRangeFilter":"","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","failoverPriority":0}],"cors":[],"capabilities":[],"backupPolicy":{"type":"Periodic","periodicModeProperties":{"backupIntervalInMinutes":240,"backupRetentionIntervalInHours":8}}}}'
+    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx","name":"k8sinfratestdbhmayhx","location":"West US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2021-01-21T23:45:30.2444381Z"},"properties":{"provisioningState":"Deleting","documentEndpoint":"https://k8sinfratestdbhmayhx.documents.azure.com:443/","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"instanceId":"be52cc07-6378-4a29-a5c8-9d7d7a694291","createMode":"Default","databaseAccountOfferType":"Standard","ipRangeFilter":"","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","failoverPriority":0}],"cors":[],"capabilities":[],"backupPolicy":{"type":"Periodic","periodicModeProperties":{"backupIntervalInMinutes":240,"backupRetentionIntervalInHours":8}}}}'
     headers:
       Cache-Control:
       - no-store, no-cache
       Content-Type:
       - application/json
       Date:
-      - Tue, 19 Jan 2021 22:04:24 GMT
+      - Thu, 21 Jan 2021 23:46:17 GMT
       Pragma:
       - no-cache
       Server:
@@ -900,14 +1138,14 @@ interactions:
     url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx?api-version=2015-04-08
     method: GET
   response:
-    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx","name":"k8sinfratestdbhmayhx","location":"West US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2021-01-19T22:03:48.2932101Z"},"properties":{"provisioningState":"Deleting","documentEndpoint":"https://k8sinfratestdbhmayhx.documents.azure.com:443/","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"instanceId":"65c2d03c-7a90-4781-ae94-221c028bd8e3","createMode":"Default","databaseAccountOfferType":"Standard","ipRangeFilter":"","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","failoverPriority":0}],"cors":[],"capabilities":[],"backupPolicy":{"type":"Periodic","periodicModeProperties":{"backupIntervalInMinutes":240,"backupRetentionIntervalInHours":8}}}}'
+    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx","name":"k8sinfratestdbhmayhx","location":"West US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2021-01-21T23:45:30.2444381Z"},"properties":{"provisioningState":"Deleting","documentEndpoint":"https://k8sinfratestdbhmayhx.documents.azure.com:443/","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"instanceId":"be52cc07-6378-4a29-a5c8-9d7d7a694291","createMode":"Default","databaseAccountOfferType":"Standard","ipRangeFilter":"","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","failoverPriority":0}],"cors":[],"capabilities":[],"backupPolicy":{"type":"Periodic","periodicModeProperties":{"backupIntervalInMinutes":240,"backupRetentionIntervalInHours":8}}}}'
     headers:
       Cache-Control:
       - no-store, no-cache
       Content-Type:
       - application/json
       Date:
-      - Tue, 19 Jan 2021 22:04:30 GMT
+      - Thu, 21 Jan 2021 23:46:23 GMT
       Pragma:
       - no-cache
       Server:
@@ -934,14 +1172,14 @@ interactions:
     url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx?api-version=2015-04-08
     method: GET
   response:
-    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx","name":"k8sinfratestdbhmayhx","location":"West US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2021-01-19T22:03:48.2932101Z"},"properties":{"provisioningState":"Deleting","documentEndpoint":"https://k8sinfratestdbhmayhx.documents.azure.com:443/","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"instanceId":"65c2d03c-7a90-4781-ae94-221c028bd8e3","createMode":"Default","databaseAccountOfferType":"Standard","ipRangeFilter":"","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","failoverPriority":0}],"cors":[],"capabilities":[],"backupPolicy":{"type":"Periodic","periodicModeProperties":{"backupIntervalInMinutes":240,"backupRetentionIntervalInHours":8}}}}'
+    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx","name":"k8sinfratestdbhmayhx","location":"West US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2021-01-21T23:45:30.2444381Z"},"properties":{"provisioningState":"Deleting","documentEndpoint":"https://k8sinfratestdbhmayhx.documents.azure.com:443/","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"instanceId":"be52cc07-6378-4a29-a5c8-9d7d7a694291","createMode":"Default","databaseAccountOfferType":"Standard","ipRangeFilter":"","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","failoverPriority":0}],"cors":[],"capabilities":[],"backupPolicy":{"type":"Periodic","periodicModeProperties":{"backupIntervalInMinutes":240,"backupRetentionIntervalInHours":8}}}}'
     headers:
       Cache-Control:
       - no-store, no-cache
       Content-Type:
       - application/json
       Date:
-      - Tue, 19 Jan 2021 22:04:36 GMT
+      - Thu, 21 Jan 2021 23:46:28 GMT
       Pragma:
       - no-cache
       Server:
@@ -968,14 +1206,14 @@ interactions:
     url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx?api-version=2015-04-08
     method: GET
   response:
-    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx","name":"k8sinfratestdbhmayhx","location":"West US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2021-01-19T22:03:48.2932101Z"},"properties":{"provisioningState":"Deleting","documentEndpoint":"https://k8sinfratestdbhmayhx.documents.azure.com:443/","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"instanceId":"65c2d03c-7a90-4781-ae94-221c028bd8e3","createMode":"Default","databaseAccountOfferType":"Standard","ipRangeFilter":"","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","failoverPriority":0}],"cors":[],"capabilities":[],"backupPolicy":{"type":"Periodic","periodicModeProperties":{"backupIntervalInMinutes":240,"backupRetentionIntervalInHours":8}}}}'
+    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx","name":"k8sinfratestdbhmayhx","location":"West US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2021-01-21T23:45:30.2444381Z"},"properties":{"provisioningState":"Deleting","documentEndpoint":"https://k8sinfratestdbhmayhx.documents.azure.com:443/","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"instanceId":"be52cc07-6378-4a29-a5c8-9d7d7a694291","createMode":"Default","databaseAccountOfferType":"Standard","ipRangeFilter":"","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","failoverPriority":0}],"cors":[],"capabilities":[],"backupPolicy":{"type":"Periodic","periodicModeProperties":{"backupIntervalInMinutes":240,"backupRetentionIntervalInHours":8}}}}'
     headers:
       Cache-Control:
       - no-store, no-cache
       Content-Type:
       - application/json
       Date:
-      - Tue, 19 Jan 2021 22:04:43 GMT
+      - Thu, 21 Jan 2021 23:46:33 GMT
       Pragma:
       - no-cache
       Server:
@@ -1002,14 +1240,14 @@ interactions:
     url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx?api-version=2015-04-08
     method: GET
   response:
-    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx","name":"k8sinfratestdbhmayhx","location":"West US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2021-01-19T22:03:48.2932101Z"},"properties":{"provisioningState":"Deleting","documentEndpoint":"https://k8sinfratestdbhmayhx.documents.azure.com:443/","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"instanceId":"65c2d03c-7a90-4781-ae94-221c028bd8e3","createMode":"Default","databaseAccountOfferType":"Standard","ipRangeFilter":"","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","failoverPriority":0}],"cors":[],"capabilities":[],"backupPolicy":{"type":"Periodic","periodicModeProperties":{"backupIntervalInMinutes":240,"backupRetentionIntervalInHours":8}}}}'
+    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx","name":"k8sinfratestdbhmayhx","location":"West US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2021-01-21T23:45:30.2444381Z"},"properties":{"provisioningState":"Deleting","documentEndpoint":"https://k8sinfratestdbhmayhx.documents.azure.com:443/","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"instanceId":"be52cc07-6378-4a29-a5c8-9d7d7a694291","createMode":"Default","databaseAccountOfferType":"Standard","ipRangeFilter":"","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","failoverPriority":0}],"cors":[],"capabilities":[],"backupPolicy":{"type":"Periodic","periodicModeProperties":{"backupIntervalInMinutes":240,"backupRetentionIntervalInHours":8}}}}'
     headers:
       Cache-Control:
       - no-store, no-cache
       Content-Type:
       - application/json
       Date:
-      - Tue, 19 Jan 2021 22:04:49 GMT
+      - Thu, 21 Jan 2021 23:46:40 GMT
       Pragma:
       - no-cache
       Server:
@@ -1036,14 +1274,14 @@ interactions:
     url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx?api-version=2015-04-08
     method: GET
   response:
-    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx","name":"k8sinfratestdbhmayhx","location":"West US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2021-01-19T22:03:48.2932101Z"},"properties":{"provisioningState":"Deleting","documentEndpoint":"https://k8sinfratestdbhmayhx.documents.azure.com:443/","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"instanceId":"65c2d03c-7a90-4781-ae94-221c028bd8e3","createMode":"Default","databaseAccountOfferType":"Standard","ipRangeFilter":"","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","failoverPriority":0}],"cors":[],"capabilities":[],"backupPolicy":{"type":"Periodic","periodicModeProperties":{"backupIntervalInMinutes":240,"backupRetentionIntervalInHours":8}}}}'
+    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx","name":"k8sinfratestdbhmayhx","location":"West US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2021-01-21T23:45:30.2444381Z"},"properties":{"provisioningState":"Deleting","documentEndpoint":"https://k8sinfratestdbhmayhx.documents.azure.com:443/","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"instanceId":"be52cc07-6378-4a29-a5c8-9d7d7a694291","createMode":"Default","databaseAccountOfferType":"Standard","ipRangeFilter":"","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","failoverPriority":0}],"cors":[],"capabilities":[],"backupPolicy":{"type":"Periodic","periodicModeProperties":{"backupIntervalInMinutes":240,"backupRetentionIntervalInHours":8}}}}'
     headers:
       Cache-Control:
       - no-store, no-cache
       Content-Type:
       - application/json
       Date:
-      - Tue, 19 Jan 2021 22:04:55 GMT
+      - Thu, 21 Jan 2021 23:46:46 GMT
       Pragma:
       - no-cache
       Server:
@@ -1070,14 +1308,14 @@ interactions:
     url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx?api-version=2015-04-08
     method: GET
   response:
-    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx","name":"k8sinfratestdbhmayhx","location":"West US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2021-01-19T22:03:48.2932101Z"},"properties":{"provisioningState":"Deleting","documentEndpoint":"https://k8sinfratestdbhmayhx.documents.azure.com:443/","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"instanceId":"65c2d03c-7a90-4781-ae94-221c028bd8e3","createMode":"Default","databaseAccountOfferType":"Standard","ipRangeFilter":"","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","failoverPriority":0}],"cors":[],"capabilities":[],"backupPolicy":{"type":"Periodic","periodicModeProperties":{"backupIntervalInMinutes":240,"backupRetentionIntervalInHours":8}}}}'
+    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx","name":"k8sinfratestdbhmayhx","location":"West US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2021-01-21T23:45:30.2444381Z"},"properties":{"provisioningState":"Deleting","documentEndpoint":"https://k8sinfratestdbhmayhx.documents.azure.com:443/","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"instanceId":"be52cc07-6378-4a29-a5c8-9d7d7a694291","createMode":"Default","databaseAccountOfferType":"Standard","ipRangeFilter":"","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","failoverPriority":0}],"cors":[],"capabilities":[],"backupPolicy":{"type":"Periodic","periodicModeProperties":{"backupIntervalInMinutes":240,"backupRetentionIntervalInHours":8}}}}'
     headers:
       Cache-Control:
       - no-store, no-cache
       Content-Type:
       - application/json
       Date:
-      - Tue, 19 Jan 2021 22:05:02 GMT
+      - Thu, 21 Jan 2021 23:46:53 GMT
       Pragma:
       - no-cache
       Server:
@@ -1104,14 +1342,14 @@ interactions:
     url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx?api-version=2015-04-08
     method: GET
   response:
-    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx","name":"k8sinfratestdbhmayhx","location":"West US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2021-01-19T22:03:48.2932101Z"},"properties":{"provisioningState":"Deleting","documentEndpoint":"https://k8sinfratestdbhmayhx.documents.azure.com:443/","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"instanceId":"65c2d03c-7a90-4781-ae94-221c028bd8e3","createMode":"Default","databaseAccountOfferType":"Standard","ipRangeFilter":"","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","failoverPriority":0}],"cors":[],"capabilities":[],"backupPolicy":{"type":"Periodic","periodicModeProperties":{"backupIntervalInMinutes":240,"backupRetentionIntervalInHours":8}}}}'
+    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx","name":"k8sinfratestdbhmayhx","location":"West US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2021-01-21T23:45:30.2444381Z"},"properties":{"provisioningState":"Deleting","documentEndpoint":"https://k8sinfratestdbhmayhx.documents.azure.com:443/","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"instanceId":"be52cc07-6378-4a29-a5c8-9d7d7a694291","createMode":"Default","databaseAccountOfferType":"Standard","ipRangeFilter":"","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","failoverPriority":0}],"cors":[],"capabilities":[],"backupPolicy":{"type":"Periodic","periodicModeProperties":{"backupIntervalInMinutes":240,"backupRetentionIntervalInHours":8}}}}'
     headers:
       Cache-Control:
       - no-store, no-cache
       Content-Type:
       - application/json
       Date:
-      - Tue, 19 Jan 2021 22:05:07 GMT
+      - Thu, 21 Jan 2021 23:46:59 GMT
       Pragma:
       - no-cache
       Server:
@@ -1138,14 +1376,14 @@ interactions:
     url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx?api-version=2015-04-08
     method: GET
   response:
-    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx","name":"k8sinfratestdbhmayhx","location":"West US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2021-01-19T22:03:48.2932101Z"},"properties":{"provisioningState":"Deleting","documentEndpoint":"https://k8sinfratestdbhmayhx.documents.azure.com:443/","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"instanceId":"65c2d03c-7a90-4781-ae94-221c028bd8e3","createMode":"Default","databaseAccountOfferType":"Standard","ipRangeFilter":"","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","failoverPriority":0}],"cors":[],"capabilities":[],"backupPolicy":{"type":"Periodic","periodicModeProperties":{"backupIntervalInMinutes":240,"backupRetentionIntervalInHours":8}}}}'
+    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx","name":"k8sinfratestdbhmayhx","location":"West US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2021-01-21T23:45:30.2444381Z"},"properties":{"provisioningState":"Deleting","documentEndpoint":"https://k8sinfratestdbhmayhx.documents.azure.com:443/","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"instanceId":"be52cc07-6378-4a29-a5c8-9d7d7a694291","createMode":"Default","databaseAccountOfferType":"Standard","ipRangeFilter":"","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","failoverPriority":0}],"cors":[],"capabilities":[],"backupPolicy":{"type":"Periodic","periodicModeProperties":{"backupIntervalInMinutes":240,"backupRetentionIntervalInHours":8}}}}'
     headers:
       Cache-Control:
       - no-store, no-cache
       Content-Type:
       - application/json
       Date:
-      - Tue, 19 Jan 2021 22:05:12 GMT
+      - Thu, 21 Jan 2021 23:47:04 GMT
       Pragma:
       - no-cache
       Server:
@@ -1172,14 +1410,14 @@ interactions:
     url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx?api-version=2015-04-08
     method: GET
   response:
-    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx","name":"k8sinfratestdbhmayhx","location":"West US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2021-01-19T22:03:48.2932101Z"},"properties":{"provisioningState":"Deleting","documentEndpoint":"https://k8sinfratestdbhmayhx.documents.azure.com:443/","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"instanceId":"65c2d03c-7a90-4781-ae94-221c028bd8e3","createMode":"Default","databaseAccountOfferType":"Standard","ipRangeFilter":"","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","failoverPriority":0}],"cors":[],"capabilities":[],"backupPolicy":{"type":"Periodic","periodicModeProperties":{"backupIntervalInMinutes":240,"backupRetentionIntervalInHours":8}}}}'
+    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx","name":"k8sinfratestdbhmayhx","location":"West US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2021-01-21T23:45:30.2444381Z"},"properties":{"provisioningState":"Deleting","documentEndpoint":"https://k8sinfratestdbhmayhx.documents.azure.com:443/","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"instanceId":"be52cc07-6378-4a29-a5c8-9d7d7a694291","createMode":"Default","databaseAccountOfferType":"Standard","ipRangeFilter":"","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","failoverPriority":0}],"cors":[],"capabilities":[],"backupPolicy":{"type":"Periodic","periodicModeProperties":{"backupIntervalInMinutes":240,"backupRetentionIntervalInHours":8}}}}'
     headers:
       Cache-Control:
       - no-store, no-cache
       Content-Type:
       - application/json
       Date:
-      - Tue, 19 Jan 2021 22:05:19 GMT
+      - Thu, 21 Jan 2021 23:47:10 GMT
       Pragma:
       - no-cache
       Server:
@@ -1206,14 +1444,14 @@ interactions:
     url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx?api-version=2015-04-08
     method: GET
   response:
-    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx","name":"k8sinfratestdbhmayhx","location":"West US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2021-01-19T22:03:48.2932101Z"},"properties":{"provisioningState":"Deleting","documentEndpoint":"https://k8sinfratestdbhmayhx.documents.azure.com:443/","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"instanceId":"65c2d03c-7a90-4781-ae94-221c028bd8e3","createMode":"Default","databaseAccountOfferType":"Standard","ipRangeFilter":"","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","failoverPriority":0}],"cors":[],"capabilities":[],"backupPolicy":{"type":"Periodic","periodicModeProperties":{"backupIntervalInMinutes":240,"backupRetentionIntervalInHours":8}}}}'
+    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx","name":"k8sinfratestdbhmayhx","location":"West US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2021-01-21T23:45:30.2444381Z"},"properties":{"provisioningState":"Deleting","documentEndpoint":"https://k8sinfratestdbhmayhx.documents.azure.com:443/","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"instanceId":"be52cc07-6378-4a29-a5c8-9d7d7a694291","createMode":"Default","databaseAccountOfferType":"Standard","ipRangeFilter":"","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","failoverPriority":0}],"cors":[],"capabilities":[],"backupPolicy":{"type":"Periodic","periodicModeProperties":{"backupIntervalInMinutes":240,"backupRetentionIntervalInHours":8}}}}'
     headers:
       Cache-Control:
       - no-store, no-cache
       Content-Type:
       - application/json
       Date:
-      - Tue, 19 Jan 2021 22:05:25 GMT
+      - Thu, 21 Jan 2021 23:47:15 GMT
       Pragma:
       - no-cache
       Server:
@@ -1240,14 +1478,14 @@ interactions:
     url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx?api-version=2015-04-08
     method: GET
   response:
-    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx","name":"k8sinfratestdbhmayhx","location":"West US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2021-01-19T22:03:48.2932101Z"},"properties":{"provisioningState":"Deleting","documentEndpoint":"https://k8sinfratestdbhmayhx.documents.azure.com:443/","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"instanceId":"65c2d03c-7a90-4781-ae94-221c028bd8e3","createMode":"Default","databaseAccountOfferType":"Standard","ipRangeFilter":"","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","failoverPriority":0}],"cors":[],"capabilities":[],"backupPolicy":{"type":"Periodic","periodicModeProperties":{"backupIntervalInMinutes":240,"backupRetentionIntervalInHours":8}}}}'
+    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx","name":"k8sinfratestdbhmayhx","location":"West US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2021-01-21T23:45:30.2444381Z"},"properties":{"provisioningState":"Deleting","documentEndpoint":"https://k8sinfratestdbhmayhx.documents.azure.com:443/","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"instanceId":"be52cc07-6378-4a29-a5c8-9d7d7a694291","createMode":"Default","databaseAccountOfferType":"Standard","ipRangeFilter":"","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","failoverPriority":0}],"cors":[],"capabilities":[],"backupPolicy":{"type":"Periodic","periodicModeProperties":{"backupIntervalInMinutes":240,"backupRetentionIntervalInHours":8}}}}'
     headers:
       Cache-Control:
       - no-store, no-cache
       Content-Type:
       - application/json
       Date:
-      - Tue, 19 Jan 2021 22:05:32 GMT
+      - Thu, 21 Jan 2021 23:47:21 GMT
       Pragma:
       - no-cache
       Server:
@@ -1274,14 +1512,14 @@ interactions:
     url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx?api-version=2015-04-08
     method: GET
   response:
-    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx","name":"k8sinfratestdbhmayhx","location":"West US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2021-01-19T22:03:48.2932101Z"},"properties":{"provisioningState":"Deleting","documentEndpoint":"https://k8sinfratestdbhmayhx.documents.azure.com:443/","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"instanceId":"65c2d03c-7a90-4781-ae94-221c028bd8e3","createMode":"Default","databaseAccountOfferType":"Standard","ipRangeFilter":"","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","failoverPriority":0}],"cors":[],"capabilities":[],"backupPolicy":{"type":"Periodic","periodicModeProperties":{"backupIntervalInMinutes":240,"backupRetentionIntervalInHours":8}}}}'
+    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx","name":"k8sinfratestdbhmayhx","location":"West US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2021-01-21T23:45:30.2444381Z"},"properties":{"provisioningState":"Deleting","documentEndpoint":"https://k8sinfratestdbhmayhx.documents.azure.com:443/","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"instanceId":"be52cc07-6378-4a29-a5c8-9d7d7a694291","createMode":"Default","databaseAccountOfferType":"Standard","ipRangeFilter":"","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","failoverPriority":0}],"cors":[],"capabilities":[],"backupPolicy":{"type":"Periodic","periodicModeProperties":{"backupIntervalInMinutes":240,"backupRetentionIntervalInHours":8}}}}'
     headers:
       Cache-Control:
       - no-store, no-cache
       Content-Type:
       - application/json
       Date:
-      - Tue, 19 Jan 2021 22:05:37 GMT
+      - Thu, 21 Jan 2021 23:47:28 GMT
       Pragma:
       - no-cache
       Server:
@@ -1308,14 +1546,14 @@ interactions:
     url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx?api-version=2015-04-08
     method: GET
   response:
-    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx","name":"k8sinfratestdbhmayhx","location":"West US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2021-01-19T22:03:48.2932101Z"},"properties":{"provisioningState":"Deleting","documentEndpoint":"https://k8sinfratestdbhmayhx.documents.azure.com:443/","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"instanceId":"65c2d03c-7a90-4781-ae94-221c028bd8e3","createMode":"Default","databaseAccountOfferType":"Standard","ipRangeFilter":"","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","failoverPriority":0}],"cors":[],"capabilities":[],"backupPolicy":{"type":"Periodic","periodicModeProperties":{"backupIntervalInMinutes":240,"backupRetentionIntervalInHours":8}}}}'
+    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx","name":"k8sinfratestdbhmayhx","location":"West US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2021-01-21T23:45:30.2444381Z"},"properties":{"provisioningState":"Deleting","documentEndpoint":"https://k8sinfratestdbhmayhx.documents.azure.com:443/","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"instanceId":"be52cc07-6378-4a29-a5c8-9d7d7a694291","createMode":"Default","databaseAccountOfferType":"Standard","ipRangeFilter":"","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","failoverPriority":0}],"cors":[],"capabilities":[],"backupPolicy":{"type":"Periodic","periodicModeProperties":{"backupIntervalInMinutes":240,"backupRetentionIntervalInHours":8}}}}'
     headers:
       Cache-Control:
       - no-store, no-cache
       Content-Type:
       - application/json
       Date:
-      - Tue, 19 Jan 2021 22:05:42 GMT
+      - Thu, 21 Jan 2021 23:47:34 GMT
       Pragma:
       - no-cache
       Server:
@@ -1342,14 +1580,14 @@ interactions:
     url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx?api-version=2015-04-08
     method: GET
   response:
-    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx","name":"k8sinfratestdbhmayhx","location":"West US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2021-01-19T22:03:48.2932101Z"},"properties":{"provisioningState":"Deleting","documentEndpoint":"https://k8sinfratestdbhmayhx.documents.azure.com:443/","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"instanceId":"65c2d03c-7a90-4781-ae94-221c028bd8e3","createMode":"Default","databaseAccountOfferType":"Standard","ipRangeFilter":"","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","failoverPriority":0}],"cors":[],"capabilities":[],"backupPolicy":{"type":"Periodic","periodicModeProperties":{"backupIntervalInMinutes":240,"backupRetentionIntervalInHours":8}}}}'
+    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx","name":"k8sinfratestdbhmayhx","location":"West US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2021-01-21T23:45:30.2444381Z"},"properties":{"provisioningState":"Deleting","documentEndpoint":"https://k8sinfratestdbhmayhx.documents.azure.com:443/","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"instanceId":"be52cc07-6378-4a29-a5c8-9d7d7a694291","createMode":"Default","databaseAccountOfferType":"Standard","ipRangeFilter":"","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","failoverPriority":0}],"cors":[],"capabilities":[],"backupPolicy":{"type":"Periodic","periodicModeProperties":{"backupIntervalInMinutes":240,"backupRetentionIntervalInHours":8}}}}'
     headers:
       Cache-Control:
       - no-store, no-cache
       Content-Type:
       - application/json
       Date:
-      - Tue, 19 Jan 2021 22:05:47 GMT
+      - Thu, 21 Jan 2021 23:47:39 GMT
       Pragma:
       - no-cache
       Server:
@@ -1376,14 +1614,14 @@ interactions:
     url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx?api-version=2015-04-08
     method: GET
   response:
-    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx","name":"k8sinfratestdbhmayhx","location":"West US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2021-01-19T22:03:48.2932101Z"},"properties":{"provisioningState":"Deleting","documentEndpoint":"https://k8sinfratestdbhmayhx.documents.azure.com:443/","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"instanceId":"65c2d03c-7a90-4781-ae94-221c028bd8e3","createMode":"Default","databaseAccountOfferType":"Standard","ipRangeFilter":"","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","failoverPriority":0}],"cors":[],"capabilities":[],"backupPolicy":{"type":"Periodic","periodicModeProperties":{"backupIntervalInMinutes":240,"backupRetentionIntervalInHours":8}}}}'
+    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx","name":"k8sinfratestdbhmayhx","location":"West US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2021-01-21T23:45:30.2444381Z"},"properties":{"provisioningState":"Deleting","documentEndpoint":"https://k8sinfratestdbhmayhx.documents.azure.com:443/","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"instanceId":"be52cc07-6378-4a29-a5c8-9d7d7a694291","createMode":"Default","databaseAccountOfferType":"Standard","ipRangeFilter":"","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","failoverPriority":0}],"cors":[],"capabilities":[],"backupPolicy":{"type":"Periodic","periodicModeProperties":{"backupIntervalInMinutes":240,"backupRetentionIntervalInHours":8}}}}'
     headers:
       Cache-Control:
       - no-store, no-cache
       Content-Type:
       - application/json
       Date:
-      - Tue, 19 Jan 2021 22:05:54 GMT
+      - Thu, 21 Jan 2021 23:47:44 GMT
       Pragma:
       - no-cache
       Server:
@@ -1410,14 +1648,14 @@ interactions:
     url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx?api-version=2015-04-08
     method: GET
   response:
-    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx","name":"k8sinfratestdbhmayhx","location":"West US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2021-01-19T22:03:48.2932101Z"},"properties":{"provisioningState":"Deleting","documentEndpoint":"https://k8sinfratestdbhmayhx.documents.azure.com:443/","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"instanceId":"65c2d03c-7a90-4781-ae94-221c028bd8e3","createMode":"Default","databaseAccountOfferType":"Standard","ipRangeFilter":"","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","failoverPriority":0}],"cors":[],"capabilities":[],"backupPolicy":{"type":"Periodic","periodicModeProperties":{"backupIntervalInMinutes":240,"backupRetentionIntervalInHours":8}}}}'
+    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx","name":"k8sinfratestdbhmayhx","location":"West US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2021-01-21T23:45:30.2444381Z"},"properties":{"provisioningState":"Deleting","documentEndpoint":"https://k8sinfratestdbhmayhx.documents.azure.com:443/","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"instanceId":"be52cc07-6378-4a29-a5c8-9d7d7a694291","createMode":"Default","databaseAccountOfferType":"Standard","ipRangeFilter":"","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","failoverPriority":0}],"cors":[],"capabilities":[],"backupPolicy":{"type":"Periodic","periodicModeProperties":{"backupIntervalInMinutes":240,"backupRetentionIntervalInHours":8}}}}'
     headers:
       Cache-Control:
       - no-store, no-cache
       Content-Type:
       - application/json
       Date:
-      - Tue, 19 Jan 2021 22:06:00 GMT
+      - Thu, 21 Jan 2021 23:47:51 GMT
       Pragma:
       - no-cache
       Server:
@@ -1444,14 +1682,14 @@ interactions:
     url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx?api-version=2015-04-08
     method: GET
   response:
-    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx","name":"k8sinfratestdbhmayhx","location":"West US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2021-01-19T22:03:48.2932101Z"},"properties":{"provisioningState":"Deleting","documentEndpoint":"https://k8sinfratestdbhmayhx.documents.azure.com:443/","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"instanceId":"65c2d03c-7a90-4781-ae94-221c028bd8e3","createMode":"Default","databaseAccountOfferType":"Standard","ipRangeFilter":"","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","failoverPriority":0}],"cors":[],"capabilities":[],"backupPolicy":{"type":"Periodic","periodicModeProperties":{"backupIntervalInMinutes":240,"backupRetentionIntervalInHours":8}}}}'
+    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx","name":"k8sinfratestdbhmayhx","location":"West US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2021-01-21T23:45:30.2444381Z"},"properties":{"provisioningState":"Deleting","documentEndpoint":"https://k8sinfratestdbhmayhx.documents.azure.com:443/","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"instanceId":"be52cc07-6378-4a29-a5c8-9d7d7a694291","createMode":"Default","databaseAccountOfferType":"Standard","ipRangeFilter":"","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","failoverPriority":0}],"cors":[],"capabilities":[],"backupPolicy":{"type":"Periodic","periodicModeProperties":{"backupIntervalInMinutes":240,"backupRetentionIntervalInHours":8}}}}'
     headers:
       Cache-Control:
       - no-store, no-cache
       Content-Type:
       - application/json
       Date:
-      - Tue, 19 Jan 2021 22:06:06 GMT
+      - Thu, 21 Jan 2021 23:47:56 GMT
       Pragma:
       - no-cache
       Server:
@@ -1478,14 +1716,14 @@ interactions:
     url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx?api-version=2015-04-08
     method: GET
   response:
-    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx","name":"k8sinfratestdbhmayhx","location":"West US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2021-01-19T22:03:48.2932101Z"},"properties":{"provisioningState":"Deleting","documentEndpoint":"https://k8sinfratestdbhmayhx.documents.azure.com:443/","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"instanceId":"65c2d03c-7a90-4781-ae94-221c028bd8e3","createMode":"Default","databaseAccountOfferType":"Standard","ipRangeFilter":"","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","failoverPriority":0}],"cors":[],"capabilities":[],"backupPolicy":{"type":"Periodic","periodicModeProperties":{"backupIntervalInMinutes":240,"backupRetentionIntervalInHours":8}}}}'
+    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx","name":"k8sinfratestdbhmayhx","location":"West US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2021-01-21T23:45:30.2444381Z"},"properties":{"provisioningState":"Deleting","documentEndpoint":"https://k8sinfratestdbhmayhx.documents.azure.com:443/","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"instanceId":"be52cc07-6378-4a29-a5c8-9d7d7a694291","createMode":"Default","databaseAccountOfferType":"Standard","ipRangeFilter":"","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","failoverPriority":0}],"cors":[],"capabilities":[],"backupPolicy":{"type":"Periodic","periodicModeProperties":{"backupIntervalInMinutes":240,"backupRetentionIntervalInHours":8}}}}'
     headers:
       Cache-Control:
       - no-store, no-cache
       Content-Type:
       - application/json
       Date:
-      - Tue, 19 Jan 2021 22:06:12 GMT
+      - Thu, 21 Jan 2021 23:48:01 GMT
       Pragma:
       - no-cache
       Server:
@@ -1512,14 +1750,14 @@ interactions:
     url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx?api-version=2015-04-08
     method: GET
   response:
-    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx","name":"k8sinfratestdbhmayhx","location":"West US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2021-01-19T22:03:48.2932101Z"},"properties":{"provisioningState":"Deleting","documentEndpoint":"https://k8sinfratestdbhmayhx.documents.azure.com:443/","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"instanceId":"65c2d03c-7a90-4781-ae94-221c028bd8e3","createMode":"Default","databaseAccountOfferType":"Standard","ipRangeFilter":"","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","failoverPriority":0}],"cors":[],"capabilities":[],"backupPolicy":{"type":"Periodic","periodicModeProperties":{"backupIntervalInMinutes":240,"backupRetentionIntervalInHours":8}}}}'
+    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx","name":"k8sinfratestdbhmayhx","location":"West US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2021-01-21T23:45:30.2444381Z"},"properties":{"provisioningState":"Deleting","documentEndpoint":"https://k8sinfratestdbhmayhx.documents.azure.com:443/","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"instanceId":"be52cc07-6378-4a29-a5c8-9d7d7a694291","createMode":"Default","databaseAccountOfferType":"Standard","ipRangeFilter":"","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","failoverPriority":0}],"cors":[],"capabilities":[],"backupPolicy":{"type":"Periodic","periodicModeProperties":{"backupIntervalInMinutes":240,"backupRetentionIntervalInHours":8}}}}'
     headers:
       Cache-Control:
       - no-store, no-cache
       Content-Type:
       - application/json
       Date:
-      - Tue, 19 Jan 2021 22:06:19 GMT
+      - Thu, 21 Jan 2021 23:48:07 GMT
       Pragma:
       - no-cache
       Server:
@@ -1546,14 +1784,14 @@ interactions:
     url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx?api-version=2015-04-08
     method: GET
   response:
-    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx","name":"k8sinfratestdbhmayhx","location":"West US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2021-01-19T22:03:48.2932101Z"},"properties":{"provisioningState":"Deleting","documentEndpoint":"https://k8sinfratestdbhmayhx.documents.azure.com:443/","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"instanceId":"65c2d03c-7a90-4781-ae94-221c028bd8e3","createMode":"Default","databaseAccountOfferType":"Standard","ipRangeFilter":"","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","failoverPriority":0}],"cors":[],"capabilities":[],"backupPolicy":{"type":"Periodic","periodicModeProperties":{"backupIntervalInMinutes":240,"backupRetentionIntervalInHours":8}}}}'
+    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx","name":"k8sinfratestdbhmayhx","location":"West US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2021-01-21T23:45:30.2444381Z"},"properties":{"provisioningState":"Deleting","documentEndpoint":"https://k8sinfratestdbhmayhx.documents.azure.com:443/","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"instanceId":"be52cc07-6378-4a29-a5c8-9d7d7a694291","createMode":"Default","databaseAccountOfferType":"Standard","ipRangeFilter":"","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","failoverPriority":0}],"cors":[],"capabilities":[],"backupPolicy":{"type":"Periodic","periodicModeProperties":{"backupIntervalInMinutes":240,"backupRetentionIntervalInHours":8}}}}'
     headers:
       Cache-Control:
       - no-store, no-cache
       Content-Type:
       - application/json
       Date:
-      - Tue, 19 Jan 2021 22:06:25 GMT
+      - Thu, 21 Jan 2021 23:48:12 GMT
       Pragma:
       - no-cache
       Server:
@@ -1580,14 +1818,14 @@ interactions:
     url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx?api-version=2015-04-08
     method: GET
   response:
-    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx","name":"k8sinfratestdbhmayhx","location":"West US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2021-01-19T22:03:48.2932101Z"},"properties":{"provisioningState":"Deleting","documentEndpoint":"https://k8sinfratestdbhmayhx.documents.azure.com:443/","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"instanceId":"65c2d03c-7a90-4781-ae94-221c028bd8e3","createMode":"Default","databaseAccountOfferType":"Standard","ipRangeFilter":"","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","failoverPriority":0}],"cors":[],"capabilities":[],"backupPolicy":{"type":"Periodic","periodicModeProperties":{"backupIntervalInMinutes":240,"backupRetentionIntervalInHours":8}}}}'
+    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx","name":"k8sinfratestdbhmayhx","location":"West US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2021-01-21T23:45:30.2444381Z"},"properties":{"provisioningState":"Deleting","documentEndpoint":"https://k8sinfratestdbhmayhx.documents.azure.com:443/","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"instanceId":"be52cc07-6378-4a29-a5c8-9d7d7a694291","createMode":"Default","databaseAccountOfferType":"Standard","ipRangeFilter":"","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","failoverPriority":0}],"cors":[],"capabilities":[],"backupPolicy":{"type":"Periodic","periodicModeProperties":{"backupIntervalInMinutes":240,"backupRetentionIntervalInHours":8}}}}'
     headers:
       Cache-Control:
       - no-store, no-cache
       Content-Type:
       - application/json
       Date:
-      - Tue, 19 Jan 2021 22:06:30 GMT
+      - Thu, 21 Jan 2021 23:48:17 GMT
       Pragma:
       - no-cache
       Server:
@@ -1614,14 +1852,14 @@ interactions:
     url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx?api-version=2015-04-08
     method: GET
   response:
-    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx","name":"k8sinfratestdbhmayhx","location":"West US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2021-01-19T22:03:48.2932101Z"},"properties":{"provisioningState":"Deleting","documentEndpoint":"https://k8sinfratestdbhmayhx.documents.azure.com:443/","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"instanceId":"65c2d03c-7a90-4781-ae94-221c028bd8e3","createMode":"Default","databaseAccountOfferType":"Standard","ipRangeFilter":"","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","failoverPriority":0}],"cors":[],"capabilities":[],"backupPolicy":{"type":"Periodic","periodicModeProperties":{"backupIntervalInMinutes":240,"backupRetentionIntervalInHours":8}}}}'
+    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx","name":"k8sinfratestdbhmayhx","location":"West US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2021-01-21T23:45:30.2444381Z"},"properties":{"provisioningState":"Deleting","documentEndpoint":"https://k8sinfratestdbhmayhx.documents.azure.com:443/","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"instanceId":"be52cc07-6378-4a29-a5c8-9d7d7a694291","createMode":"Default","databaseAccountOfferType":"Standard","ipRangeFilter":"","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","failoverPriority":0}],"cors":[],"capabilities":[],"backupPolicy":{"type":"Periodic","periodicModeProperties":{"backupIntervalInMinutes":240,"backupRetentionIntervalInHours":8}}}}'
     headers:
       Cache-Control:
       - no-store, no-cache
       Content-Type:
       - application/json
       Date:
-      - Tue, 19 Jan 2021 22:06:38 GMT
+      - Thu, 21 Jan 2021 23:48:22 GMT
       Pragma:
       - no-cache
       Server:
@@ -1648,14 +1886,14 @@ interactions:
     url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx?api-version=2015-04-08
     method: GET
   response:
-    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx","name":"k8sinfratestdbhmayhx","location":"West US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2021-01-19T22:03:48.2932101Z"},"properties":{"provisioningState":"Deleting","documentEndpoint":"https://k8sinfratestdbhmayhx.documents.azure.com:443/","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"instanceId":"65c2d03c-7a90-4781-ae94-221c028bd8e3","createMode":"Default","databaseAccountOfferType":"Standard","ipRangeFilter":"","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","failoverPriority":0}],"cors":[],"capabilities":[],"backupPolicy":{"type":"Periodic","periodicModeProperties":{"backupIntervalInMinutes":240,"backupRetentionIntervalInHours":8}}}}'
+    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx","name":"k8sinfratestdbhmayhx","location":"West US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2021-01-21T23:45:30.2444381Z"},"properties":{"provisioningState":"Deleting","documentEndpoint":"https://k8sinfratestdbhmayhx.documents.azure.com:443/","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"instanceId":"be52cc07-6378-4a29-a5c8-9d7d7a694291","createMode":"Default","databaseAccountOfferType":"Standard","ipRangeFilter":"","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","failoverPriority":0}],"cors":[],"capabilities":[],"backupPolicy":{"type":"Periodic","periodicModeProperties":{"backupIntervalInMinutes":240,"backupRetentionIntervalInHours":8}}}}'
     headers:
       Cache-Control:
       - no-store, no-cache
       Content-Type:
       - application/json
       Date:
-      - Tue, 19 Jan 2021 22:06:44 GMT
+      - Thu, 21 Jan 2021 23:48:28 GMT
       Pragma:
       - no-cache
       Server:
@@ -1682,14 +1920,14 @@ interactions:
     url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx?api-version=2015-04-08
     method: GET
   response:
-    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx","name":"k8sinfratestdbhmayhx","location":"West US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2021-01-19T22:03:48.2932101Z"},"properties":{"provisioningState":"Deleting","documentEndpoint":"https://k8sinfratestdbhmayhx.documents.azure.com:443/","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"instanceId":"65c2d03c-7a90-4781-ae94-221c028bd8e3","createMode":"Default","databaseAccountOfferType":"Standard","ipRangeFilter":"","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","failoverPriority":0}],"cors":[],"capabilities":[],"backupPolicy":{"type":"Periodic","periodicModeProperties":{"backupIntervalInMinutes":240,"backupRetentionIntervalInHours":8}}}}'
+    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx","name":"k8sinfratestdbhmayhx","location":"West US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2021-01-21T23:45:30.2444381Z"},"properties":{"provisioningState":"Deleting","documentEndpoint":"https://k8sinfratestdbhmayhx.documents.azure.com:443/","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"instanceId":"be52cc07-6378-4a29-a5c8-9d7d7a694291","createMode":"Default","databaseAccountOfferType":"Standard","ipRangeFilter":"","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","failoverPriority":0}],"cors":[],"capabilities":[],"backupPolicy":{"type":"Periodic","periodicModeProperties":{"backupIntervalInMinutes":240,"backupRetentionIntervalInHours":8}}}}'
     headers:
       Cache-Control:
       - no-store, no-cache
       Content-Type:
       - application/json
       Date:
-      - Tue, 19 Jan 2021 22:06:50 GMT
+      - Thu, 21 Jan 2021 23:48:33 GMT
       Pragma:
       - no-cache
       Server:
@@ -1716,14 +1954,14 @@ interactions:
     url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx?api-version=2015-04-08
     method: GET
   response:
-    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx","name":"k8sinfratestdbhmayhx","location":"West US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2021-01-19T22:03:48.2932101Z"},"properties":{"provisioningState":"Deleting","documentEndpoint":"https://k8sinfratestdbhmayhx.documents.azure.com:443/","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"instanceId":"65c2d03c-7a90-4781-ae94-221c028bd8e3","createMode":"Default","databaseAccountOfferType":"Standard","ipRangeFilter":"","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","failoverPriority":0}],"cors":[],"capabilities":[],"backupPolicy":{"type":"Periodic","periodicModeProperties":{"backupIntervalInMinutes":240,"backupRetentionIntervalInHours":8}}}}'
+    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx","name":"k8sinfratestdbhmayhx","location":"West US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2021-01-21T23:45:30.2444381Z"},"properties":{"provisioningState":"Deleting","documentEndpoint":"https://k8sinfratestdbhmayhx.documents.azure.com:443/","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"instanceId":"be52cc07-6378-4a29-a5c8-9d7d7a694291","createMode":"Default","databaseAccountOfferType":"Standard","ipRangeFilter":"","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","failoverPriority":0}],"cors":[],"capabilities":[],"backupPolicy":{"type":"Periodic","periodicModeProperties":{"backupIntervalInMinutes":240,"backupRetentionIntervalInHours":8}}}}'
     headers:
       Cache-Control:
       - no-store, no-cache
       Content-Type:
       - application/json
       Date:
-      - Tue, 19 Jan 2021 22:06:56 GMT
+      - Thu, 21 Jan 2021 23:48:39 GMT
       Pragma:
       - no-cache
       Server:
@@ -1750,14 +1988,14 @@ interactions:
     url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx?api-version=2015-04-08
     method: GET
   response:
-    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx","name":"k8sinfratestdbhmayhx","location":"West US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2021-01-19T22:03:48.2932101Z"},"properties":{"provisioningState":"Deleting","documentEndpoint":"https://k8sinfratestdbhmayhx.documents.azure.com:443/","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"instanceId":"65c2d03c-7a90-4781-ae94-221c028bd8e3","createMode":"Default","databaseAccountOfferType":"Standard","ipRangeFilter":"","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","failoverPriority":0}],"cors":[],"capabilities":[],"backupPolicy":{"type":"Periodic","periodicModeProperties":{"backupIntervalInMinutes":240,"backupRetentionIntervalInHours":8}}}}'
+    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx","name":"k8sinfratestdbhmayhx","location":"West US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2021-01-21T23:45:30.2444381Z"},"properties":{"provisioningState":"Deleting","documentEndpoint":"https://k8sinfratestdbhmayhx.documents.azure.com:443/","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"instanceId":"be52cc07-6378-4a29-a5c8-9d7d7a694291","createMode":"Default","databaseAccountOfferType":"Standard","ipRangeFilter":"","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","failoverPriority":0}],"cors":[],"capabilities":[],"backupPolicy":{"type":"Periodic","periodicModeProperties":{"backupIntervalInMinutes":240,"backupRetentionIntervalInHours":8}}}}'
     headers:
       Cache-Control:
       - no-store, no-cache
       Content-Type:
       - application/json
       Date:
-      - Tue, 19 Jan 2021 22:07:03 GMT
+      - Thu, 21 Jan 2021 23:48:46 GMT
       Pragma:
       - no-cache
       Server:
@@ -1784,14 +2022,14 @@ interactions:
     url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx?api-version=2015-04-08
     method: GET
   response:
-    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx","name":"k8sinfratestdbhmayhx","location":"West US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2021-01-19T22:03:48.2932101Z"},"properties":{"provisioningState":"Deleting","documentEndpoint":"https://k8sinfratestdbhmayhx.documents.azure.com:443/","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"instanceId":"65c2d03c-7a90-4781-ae94-221c028bd8e3","createMode":"Default","databaseAccountOfferType":"Standard","ipRangeFilter":"","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","failoverPriority":0}],"cors":[],"capabilities":[],"backupPolicy":{"type":"Periodic","periodicModeProperties":{"backupIntervalInMinutes":240,"backupRetentionIntervalInHours":8}}}}'
+    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx","name":"k8sinfratestdbhmayhx","location":"West US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2021-01-21T23:45:30.2444381Z"},"properties":{"provisioningState":"Deleting","documentEndpoint":"https://k8sinfratestdbhmayhx.documents.azure.com:443/","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"instanceId":"be52cc07-6378-4a29-a5c8-9d7d7a694291","createMode":"Default","databaseAccountOfferType":"Standard","ipRangeFilter":"","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","failoverPriority":0}],"cors":[],"capabilities":[],"backupPolicy":{"type":"Periodic","periodicModeProperties":{"backupIntervalInMinutes":240,"backupRetentionIntervalInHours":8}}}}'
     headers:
       Cache-Control:
       - no-store, no-cache
       Content-Type:
       - application/json
       Date:
-      - Tue, 19 Jan 2021 22:07:08 GMT
+      - Thu, 21 Jan 2021 23:48:51 GMT
       Pragma:
       - no-cache
       Server:
@@ -1818,14 +2056,14 @@ interactions:
     url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx?api-version=2015-04-08
     method: GET
   response:
-    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx","name":"k8sinfratestdbhmayhx","location":"West US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2021-01-19T22:03:48.2932101Z"},"properties":{"provisioningState":"Deleting","documentEndpoint":"https://k8sinfratestdbhmayhx.documents.azure.com:443/","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"instanceId":"65c2d03c-7a90-4781-ae94-221c028bd8e3","createMode":"Default","databaseAccountOfferType":"Standard","ipRangeFilter":"","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","failoverPriority":0}],"cors":[],"capabilities":[],"backupPolicy":{"type":"Periodic","periodicModeProperties":{"backupIntervalInMinutes":240,"backupRetentionIntervalInHours":8}}}}'
+    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx","name":"k8sinfratestdbhmayhx","location":"West US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2021-01-21T23:45:30.2444381Z"},"properties":{"provisioningState":"Deleting","documentEndpoint":"https://k8sinfratestdbhmayhx.documents.azure.com:443/","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"instanceId":"be52cc07-6378-4a29-a5c8-9d7d7a694291","createMode":"Default","databaseAccountOfferType":"Standard","ipRangeFilter":"","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","failoverPriority":0}],"cors":[],"capabilities":[],"backupPolicy":{"type":"Periodic","periodicModeProperties":{"backupIntervalInMinutes":240,"backupRetentionIntervalInHours":8}}}}'
     headers:
       Cache-Control:
       - no-store, no-cache
       Content-Type:
       - application/json
       Date:
-      - Tue, 19 Jan 2021 22:07:14 GMT
+      - Thu, 21 Jan 2021 23:48:56 GMT
       Pragma:
       - no-cache
       Server:
@@ -1852,14 +2090,14 @@ interactions:
     url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx?api-version=2015-04-08
     method: GET
   response:
-    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx","name":"k8sinfratestdbhmayhx","location":"West US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2021-01-19T22:03:48.2932101Z"},"properties":{"provisioningState":"Deleting","documentEndpoint":"https://k8sinfratestdbhmayhx.documents.azure.com:443/","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"instanceId":"65c2d03c-7a90-4781-ae94-221c028bd8e3","createMode":"Default","databaseAccountOfferType":"Standard","ipRangeFilter":"","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","failoverPriority":0}],"cors":[],"capabilities":[],"backupPolicy":{"type":"Periodic","periodicModeProperties":{"backupIntervalInMinutes":240,"backupRetentionIntervalInHours":8}}}}'
+    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx","name":"k8sinfratestdbhmayhx","location":"West US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2021-01-21T23:45:30.2444381Z"},"properties":{"provisioningState":"Deleting","documentEndpoint":"https://k8sinfratestdbhmayhx.documents.azure.com:443/","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"instanceId":"be52cc07-6378-4a29-a5c8-9d7d7a694291","createMode":"Default","databaseAccountOfferType":"Standard","ipRangeFilter":"","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","failoverPriority":0}],"cors":[],"capabilities":[],"backupPolicy":{"type":"Periodic","periodicModeProperties":{"backupIntervalInMinutes":240,"backupRetentionIntervalInHours":8}}}}'
     headers:
       Cache-Control:
       - no-store, no-cache
       Content-Type:
       - application/json
       Date:
-      - Tue, 19 Jan 2021 22:07:19 GMT
+      - Thu, 21 Jan 2021 23:49:01 GMT
       Pragma:
       - no-cache
       Server:
@@ -1886,14 +2124,14 @@ interactions:
     url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx?api-version=2015-04-08
     method: GET
   response:
-    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx","name":"k8sinfratestdbhmayhx","location":"West US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2021-01-19T22:03:48.2932101Z"},"properties":{"provisioningState":"Deleting","documentEndpoint":"https://k8sinfratestdbhmayhx.documents.azure.com:443/","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"instanceId":"65c2d03c-7a90-4781-ae94-221c028bd8e3","createMode":"Default","databaseAccountOfferType":"Standard","ipRangeFilter":"","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","failoverPriority":0}],"cors":[],"capabilities":[],"backupPolicy":{"type":"Periodic","periodicModeProperties":{"backupIntervalInMinutes":240,"backupRetentionIntervalInHours":8}}}}'
+    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx","name":"k8sinfratestdbhmayhx","location":"West US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2021-01-21T23:45:30.2444381Z"},"properties":{"provisioningState":"Deleting","documentEndpoint":"https://k8sinfratestdbhmayhx.documents.azure.com:443/","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"instanceId":"be52cc07-6378-4a29-a5c8-9d7d7a694291","createMode":"Default","databaseAccountOfferType":"Standard","ipRangeFilter":"","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","failoverPriority":0}],"cors":[],"capabilities":[],"backupPolicy":{"type":"Periodic","periodicModeProperties":{"backupIntervalInMinutes":240,"backupRetentionIntervalInHours":8}}}}'
     headers:
       Cache-Control:
       - no-store, no-cache
       Content-Type:
       - application/json
       Date:
-      - Tue, 19 Jan 2021 22:07:25 GMT
+      - Thu, 21 Jan 2021 23:49:07 GMT
       Pragma:
       - no-cache
       Server:
@@ -1920,14 +2158,14 @@ interactions:
     url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx?api-version=2015-04-08
     method: GET
   response:
-    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx","name":"k8sinfratestdbhmayhx","location":"West US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2021-01-19T22:03:48.2932101Z"},"properties":{"provisioningState":"Deleting","documentEndpoint":"https://k8sinfratestdbhmayhx.documents.azure.com:443/","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"instanceId":"65c2d03c-7a90-4781-ae94-221c028bd8e3","createMode":"Default","databaseAccountOfferType":"Standard","ipRangeFilter":"","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","failoverPriority":0}],"cors":[],"capabilities":[],"backupPolicy":{"type":"Periodic","periodicModeProperties":{"backupIntervalInMinutes":240,"backupRetentionIntervalInHours":8}}}}'
+    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx","name":"k8sinfratestdbhmayhx","location":"West US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2021-01-21T23:45:30.2444381Z"},"properties":{"provisioningState":"Deleting","documentEndpoint":"https://k8sinfratestdbhmayhx.documents.azure.com:443/","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"instanceId":"be52cc07-6378-4a29-a5c8-9d7d7a694291","createMode":"Default","databaseAccountOfferType":"Standard","ipRangeFilter":"","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","failoverPriority":0}],"cors":[],"capabilities":[],"backupPolicy":{"type":"Periodic","periodicModeProperties":{"backupIntervalInMinutes":240,"backupRetentionIntervalInHours":8}}}}'
     headers:
       Cache-Control:
       - no-store, no-cache
       Content-Type:
       - application/json
       Date:
-      - Tue, 19 Jan 2021 22:07:31 GMT
+      - Thu, 21 Jan 2021 23:49:12 GMT
       Pragma:
       - no-cache
       Server:
@@ -1954,14 +2192,14 @@ interactions:
     url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx?api-version=2015-04-08
     method: GET
   response:
-    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx","name":"k8sinfratestdbhmayhx","location":"West US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2021-01-19T22:03:48.2932101Z"},"properties":{"provisioningState":"Deleting","documentEndpoint":"https://k8sinfratestdbhmayhx.documents.azure.com:443/","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"instanceId":"65c2d03c-7a90-4781-ae94-221c028bd8e3","createMode":"Default","databaseAccountOfferType":"Standard","ipRangeFilter":"","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","failoverPriority":0}],"cors":[],"capabilities":[],"backupPolicy":{"type":"Periodic","periodicModeProperties":{"backupIntervalInMinutes":240,"backupRetentionIntervalInHours":8}}}}'
+    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx","name":"k8sinfratestdbhmayhx","location":"West US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2021-01-21T23:45:30.2444381Z"},"properties":{"provisioningState":"Deleting","documentEndpoint":"https://k8sinfratestdbhmayhx.documents.azure.com:443/","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"instanceId":"be52cc07-6378-4a29-a5c8-9d7d7a694291","createMode":"Default","databaseAccountOfferType":"Standard","ipRangeFilter":"","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","failoverPriority":0}],"cors":[],"capabilities":[],"backupPolicy":{"type":"Periodic","periodicModeProperties":{"backupIntervalInMinutes":240,"backupRetentionIntervalInHours":8}}}}'
     headers:
       Cache-Control:
       - no-store, no-cache
       Content-Type:
       - application/json
       Date:
-      - Tue, 19 Jan 2021 22:07:38 GMT
+      - Thu, 21 Jan 2021 23:49:18 GMT
       Pragma:
       - no-cache
       Server:
@@ -1988,14 +2226,14 @@ interactions:
     url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx?api-version=2015-04-08
     method: GET
   response:
-    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx","name":"k8sinfratestdbhmayhx","location":"West US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2021-01-19T22:03:48.2932101Z"},"properties":{"provisioningState":"Deleting","documentEndpoint":"https://k8sinfratestdbhmayhx.documents.azure.com:443/","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"instanceId":"65c2d03c-7a90-4781-ae94-221c028bd8e3","createMode":"Default","databaseAccountOfferType":"Standard","ipRangeFilter":"","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","failoverPriority":0}],"cors":[],"capabilities":[],"backupPolicy":{"type":"Periodic","periodicModeProperties":{"backupIntervalInMinutes":240,"backupRetentionIntervalInHours":8}}}}'
+    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx","name":"k8sinfratestdbhmayhx","location":"West US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2021-01-21T23:45:30.2444381Z"},"properties":{"provisioningState":"Deleting","documentEndpoint":"https://k8sinfratestdbhmayhx.documents.azure.com:443/","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"instanceId":"be52cc07-6378-4a29-a5c8-9d7d7a694291","createMode":"Default","databaseAccountOfferType":"Standard","ipRangeFilter":"","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","failoverPriority":0}],"cors":[],"capabilities":[],"backupPolicy":{"type":"Periodic","periodicModeProperties":{"backupIntervalInMinutes":240,"backupRetentionIntervalInHours":8}}}}'
     headers:
       Cache-Control:
       - no-store, no-cache
       Content-Type:
       - application/json
       Date:
-      - Tue, 19 Jan 2021 22:07:44 GMT
+      - Thu, 21 Jan 2021 23:49:23 GMT
       Pragma:
       - no-cache
       Server:
@@ -2022,14 +2260,14 @@ interactions:
     url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx?api-version=2015-04-08
     method: GET
   response:
-    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx","name":"k8sinfratestdbhmayhx","location":"West US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2021-01-19T22:03:48.2932101Z"},"properties":{"provisioningState":"Deleting","documentEndpoint":"https://k8sinfratestdbhmayhx.documents.azure.com:443/","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"instanceId":"65c2d03c-7a90-4781-ae94-221c028bd8e3","createMode":"Default","databaseAccountOfferType":"Standard","ipRangeFilter":"","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","failoverPriority":0}],"cors":[],"capabilities":[],"backupPolicy":{"type":"Periodic","periodicModeProperties":{"backupIntervalInMinutes":240,"backupRetentionIntervalInHours":8}}}}'
+    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx","name":"k8sinfratestdbhmayhx","location":"West US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2021-01-21T23:45:30.2444381Z"},"properties":{"provisioningState":"Deleting","documentEndpoint":"https://k8sinfratestdbhmayhx.documents.azure.com:443/","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"instanceId":"be52cc07-6378-4a29-a5c8-9d7d7a694291","createMode":"Default","databaseAccountOfferType":"Standard","ipRangeFilter":"","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","failoverPriority":0}],"cors":[],"capabilities":[],"backupPolicy":{"type":"Periodic","periodicModeProperties":{"backupIntervalInMinutes":240,"backupRetentionIntervalInHours":8}}}}'
     headers:
       Cache-Control:
       - no-store, no-cache
       Content-Type:
       - application/json
       Date:
-      - Tue, 19 Jan 2021 22:07:49 GMT
+      - Thu, 21 Jan 2021 23:49:29 GMT
       Pragma:
       - no-cache
       Server:
@@ -2056,14 +2294,14 @@ interactions:
     url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx?api-version=2015-04-08
     method: GET
   response:
-    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx","name":"k8sinfratestdbhmayhx","location":"West US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2021-01-19T22:03:48.2932101Z"},"properties":{"provisioningState":"Deleting","documentEndpoint":"https://k8sinfratestdbhmayhx.documents.azure.com:443/","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"instanceId":"65c2d03c-7a90-4781-ae94-221c028bd8e3","createMode":"Default","databaseAccountOfferType":"Standard","ipRangeFilter":"","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","failoverPriority":0}],"cors":[],"capabilities":[],"backupPolicy":{"type":"Periodic","periodicModeProperties":{"backupIntervalInMinutes":240,"backupRetentionIntervalInHours":8}}}}'
+    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx","name":"k8sinfratestdbhmayhx","location":"West US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2021-01-21T23:45:30.2444381Z"},"properties":{"provisioningState":"Deleting","documentEndpoint":"https://k8sinfratestdbhmayhx.documents.azure.com:443/","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"instanceId":"be52cc07-6378-4a29-a5c8-9d7d7a694291","createMode":"Default","databaseAccountOfferType":"Standard","ipRangeFilter":"","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","failoverPriority":0}],"cors":[],"capabilities":[],"backupPolicy":{"type":"Periodic","periodicModeProperties":{"backupIntervalInMinutes":240,"backupRetentionIntervalInHours":8}}}}'
     headers:
       Cache-Control:
       - no-store, no-cache
       Content-Type:
       - application/json
       Date:
-      - Tue, 19 Jan 2021 22:07:55 GMT
+      - Thu, 21 Jan 2021 23:49:34 GMT
       Pragma:
       - no-cache
       Server:
@@ -2090,14 +2328,14 @@ interactions:
     url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx?api-version=2015-04-08
     method: GET
   response:
-    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx","name":"k8sinfratestdbhmayhx","location":"West US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2021-01-19T22:03:48.2932101Z"},"properties":{"provisioningState":"Deleting","documentEndpoint":"https://k8sinfratestdbhmayhx.documents.azure.com:443/","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"instanceId":"65c2d03c-7a90-4781-ae94-221c028bd8e3","createMode":"Default","databaseAccountOfferType":"Standard","ipRangeFilter":"","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","failoverPriority":0}],"cors":[],"capabilities":[],"backupPolicy":{"type":"Periodic","periodicModeProperties":{"backupIntervalInMinutes":240,"backupRetentionIntervalInHours":8}}}}'
+    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx","name":"k8sinfratestdbhmayhx","location":"West US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2021-01-21T23:45:30.2444381Z"},"properties":{"provisioningState":"Deleting","documentEndpoint":"https://k8sinfratestdbhmayhx.documents.azure.com:443/","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"instanceId":"be52cc07-6378-4a29-a5c8-9d7d7a694291","createMode":"Default","databaseAccountOfferType":"Standard","ipRangeFilter":"","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","failoverPriority":0}],"cors":[],"capabilities":[],"backupPolicy":{"type":"Periodic","periodicModeProperties":{"backupIntervalInMinutes":240,"backupRetentionIntervalInHours":8}}}}'
     headers:
       Cache-Control:
       - no-store, no-cache
       Content-Type:
       - application/json
       Date:
-      - Tue, 19 Jan 2021 22:08:02 GMT
+      - Thu, 21 Jan 2021 23:49:39 GMT
       Pragma:
       - no-cache
       Server:
@@ -2124,14 +2362,14 @@ interactions:
     url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx?api-version=2015-04-08
     method: GET
   response:
-    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx","name":"k8sinfratestdbhmayhx","location":"West US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2021-01-19T22:03:48.2932101Z"},"properties":{"provisioningState":"Deleting","documentEndpoint":"https://k8sinfratestdbhmayhx.documents.azure.com:443/","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"instanceId":"65c2d03c-7a90-4781-ae94-221c028bd8e3","createMode":"Default","databaseAccountOfferType":"Standard","ipRangeFilter":"","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","failoverPriority":0}],"cors":[],"capabilities":[],"backupPolicy":{"type":"Periodic","periodicModeProperties":{"backupIntervalInMinutes":240,"backupRetentionIntervalInHours":8}}}}'
+    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx","name":"k8sinfratestdbhmayhx","location":"West US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2021-01-21T23:45:30.2444381Z"},"properties":{"provisioningState":"Deleting","documentEndpoint":"https://k8sinfratestdbhmayhx.documents.azure.com:443/","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"instanceId":"be52cc07-6378-4a29-a5c8-9d7d7a694291","createMode":"Default","databaseAccountOfferType":"Standard","ipRangeFilter":"","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","failoverPriority":0}],"cors":[],"capabilities":[],"backupPolicy":{"type":"Periodic","periodicModeProperties":{"backupIntervalInMinutes":240,"backupRetentionIntervalInHours":8}}}}'
     headers:
       Cache-Control:
       - no-store, no-cache
       Content-Type:
       - application/json
       Date:
-      - Tue, 19 Jan 2021 22:08:08 GMT
+      - Thu, 21 Jan 2021 23:49:44 GMT
       Pragma:
       - no-cache
       Server:
@@ -2158,14 +2396,14 @@ interactions:
     url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx?api-version=2015-04-08
     method: GET
   response:
-    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx","name":"k8sinfratestdbhmayhx","location":"West US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2021-01-19T22:03:48.2932101Z"},"properties":{"provisioningState":"Deleting","documentEndpoint":"https://k8sinfratestdbhmayhx.documents.azure.com:443/","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"instanceId":"65c2d03c-7a90-4781-ae94-221c028bd8e3","createMode":"Default","databaseAccountOfferType":"Standard","ipRangeFilter":"","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","failoverPriority":0}],"cors":[],"capabilities":[],"backupPolicy":{"type":"Periodic","periodicModeProperties":{"backupIntervalInMinutes":240,"backupRetentionIntervalInHours":8}}}}'
+    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx","name":"k8sinfratestdbhmayhx","location":"West US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2021-01-21T23:45:30.2444381Z"},"properties":{"provisioningState":"Deleting","documentEndpoint":"https://k8sinfratestdbhmayhx.documents.azure.com:443/","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"instanceId":"be52cc07-6378-4a29-a5c8-9d7d7a694291","createMode":"Default","databaseAccountOfferType":"Standard","ipRangeFilter":"","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","failoverPriority":0}],"cors":[],"capabilities":[],"backupPolicy":{"type":"Periodic","periodicModeProperties":{"backupIntervalInMinutes":240,"backupRetentionIntervalInHours":8}}}}'
     headers:
       Cache-Control:
       - no-store, no-cache
       Content-Type:
       - application/json
       Date:
-      - Tue, 19 Jan 2021 22:08:16 GMT
+      - Thu, 21 Jan 2021 23:49:50 GMT
       Pragma:
       - no-cache
       Server:
@@ -2192,14 +2430,14 @@ interactions:
     url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx?api-version=2015-04-08
     method: GET
   response:
-    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx","name":"k8sinfratestdbhmayhx","location":"West US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2021-01-19T22:03:48.2932101Z"},"properties":{"provisioningState":"Deleting","documentEndpoint":"https://k8sinfratestdbhmayhx.documents.azure.com:443/","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"instanceId":"65c2d03c-7a90-4781-ae94-221c028bd8e3","createMode":"Default","databaseAccountOfferType":"Standard","ipRangeFilter":"","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","failoverPriority":0}],"cors":[],"capabilities":[],"backupPolicy":{"type":"Periodic","periodicModeProperties":{"backupIntervalInMinutes":240,"backupRetentionIntervalInHours":8}}}}'
+    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx","name":"k8sinfratestdbhmayhx","location":"West US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2021-01-21T23:45:30.2444381Z"},"properties":{"provisioningState":"Deleting","documentEndpoint":"https://k8sinfratestdbhmayhx.documents.azure.com:443/","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"instanceId":"be52cc07-6378-4a29-a5c8-9d7d7a694291","createMode":"Default","databaseAccountOfferType":"Standard","ipRangeFilter":"","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","failoverPriority":0}],"cors":[],"capabilities":[],"backupPolicy":{"type":"Periodic","periodicModeProperties":{"backupIntervalInMinutes":240,"backupRetentionIntervalInHours":8}}}}'
     headers:
       Cache-Control:
       - no-store, no-cache
       Content-Type:
       - application/json
       Date:
-      - Tue, 19 Jan 2021 22:08:23 GMT
+      - Thu, 21 Jan 2021 23:49:55 GMT
       Pragma:
       - no-cache
       Server:
@@ -2226,14 +2464,14 @@ interactions:
     url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx?api-version=2015-04-08
     method: GET
   response:
-    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx","name":"k8sinfratestdbhmayhx","location":"West US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2021-01-19T22:03:48.2932101Z"},"properties":{"provisioningState":"Deleting","documentEndpoint":"https://k8sinfratestdbhmayhx.documents.azure.com:443/","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"instanceId":"65c2d03c-7a90-4781-ae94-221c028bd8e3","createMode":"Default","databaseAccountOfferType":"Standard","ipRangeFilter":"","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","failoverPriority":0}],"cors":[],"capabilities":[],"backupPolicy":{"type":"Periodic","periodicModeProperties":{"backupIntervalInMinutes":240,"backupRetentionIntervalInHours":8}}}}'
+    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx","name":"k8sinfratestdbhmayhx","location":"West US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2021-01-21T23:45:30.2444381Z"},"properties":{"provisioningState":"Deleting","documentEndpoint":"https://k8sinfratestdbhmayhx.documents.azure.com:443/","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"instanceId":"be52cc07-6378-4a29-a5c8-9d7d7a694291","createMode":"Default","databaseAccountOfferType":"Standard","ipRangeFilter":"","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","failoverPriority":0}],"cors":[],"capabilities":[],"backupPolicy":{"type":"Periodic","periodicModeProperties":{"backupIntervalInMinutes":240,"backupRetentionIntervalInHours":8}}}}'
     headers:
       Cache-Control:
       - no-store, no-cache
       Content-Type:
       - application/json
       Date:
-      - Tue, 19 Jan 2021 22:08:29 GMT
+      - Thu, 21 Jan 2021 23:50:00 GMT
       Pragma:
       - no-cache
       Server:
@@ -2260,14 +2498,14 @@ interactions:
     url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx?api-version=2015-04-08
     method: GET
   response:
-    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx","name":"k8sinfratestdbhmayhx","location":"West US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2021-01-19T22:03:48.2932101Z"},"properties":{"provisioningState":"Deleting","documentEndpoint":"https://k8sinfratestdbhmayhx.documents.azure.com:443/","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"instanceId":"65c2d03c-7a90-4781-ae94-221c028bd8e3","createMode":"Default","databaseAccountOfferType":"Standard","ipRangeFilter":"","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","failoverPriority":0}],"cors":[],"capabilities":[],"backupPolicy":{"type":"Periodic","periodicModeProperties":{"backupIntervalInMinutes":240,"backupRetentionIntervalInHours":8}}}}'
+    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx","name":"k8sinfratestdbhmayhx","location":"West US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2021-01-21T23:45:30.2444381Z"},"properties":{"provisioningState":"Deleting","documentEndpoint":"https://k8sinfratestdbhmayhx.documents.azure.com:443/","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"instanceId":"be52cc07-6378-4a29-a5c8-9d7d7a694291","createMode":"Default","databaseAccountOfferType":"Standard","ipRangeFilter":"","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","failoverPriority":0}],"cors":[],"capabilities":[],"backupPolicy":{"type":"Periodic","periodicModeProperties":{"backupIntervalInMinutes":240,"backupRetentionIntervalInHours":8}}}}'
     headers:
       Cache-Control:
       - no-store, no-cache
       Content-Type:
       - application/json
       Date:
-      - Tue, 19 Jan 2021 22:08:35 GMT
+      - Thu, 21 Jan 2021 23:50:05 GMT
       Pragma:
       - no-cache
       Server:
@@ -2294,14 +2532,14 @@ interactions:
     url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx?api-version=2015-04-08
     method: GET
   response:
-    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx","name":"k8sinfratestdbhmayhx","location":"West US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2021-01-19T22:03:48.2932101Z"},"properties":{"provisioningState":"Deleting","documentEndpoint":"https://k8sinfratestdbhmayhx.documents.azure.com:443/","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"instanceId":"65c2d03c-7a90-4781-ae94-221c028bd8e3","createMode":"Default","databaseAccountOfferType":"Standard","ipRangeFilter":"","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","failoverPriority":0}],"cors":[],"capabilities":[],"backupPolicy":{"type":"Periodic","periodicModeProperties":{"backupIntervalInMinutes":240,"backupRetentionIntervalInHours":8}}}}'
+    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx","name":"k8sinfratestdbhmayhx","location":"West US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2021-01-21T23:45:30.2444381Z"},"properties":{"provisioningState":"Deleting","documentEndpoint":"https://k8sinfratestdbhmayhx.documents.azure.com:443/","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"instanceId":"be52cc07-6378-4a29-a5c8-9d7d7a694291","createMode":"Default","databaseAccountOfferType":"Standard","ipRangeFilter":"","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","failoverPriority":0}],"cors":[],"capabilities":[],"backupPolicy":{"type":"Periodic","periodicModeProperties":{"backupIntervalInMinutes":240,"backupRetentionIntervalInHours":8}}}}'
     headers:
       Cache-Control:
       - no-store, no-cache
       Content-Type:
       - application/json
       Date:
-      - Tue, 19 Jan 2021 22:08:41 GMT
+      - Thu, 21 Jan 2021 23:50:11 GMT
       Pragma:
       - no-cache
       Server:
@@ -2328,14 +2566,14 @@ interactions:
     url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx?api-version=2015-04-08
     method: GET
   response:
-    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx","name":"k8sinfratestdbhmayhx","location":"West US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2021-01-19T22:03:48.2932101Z"},"properties":{"provisioningState":"Deleting","documentEndpoint":"https://k8sinfratestdbhmayhx.documents.azure.com:443/","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"instanceId":"65c2d03c-7a90-4781-ae94-221c028bd8e3","createMode":"Default","databaseAccountOfferType":"Standard","ipRangeFilter":"","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","failoverPriority":0}],"cors":[],"capabilities":[],"backupPolicy":{"type":"Periodic","periodicModeProperties":{"backupIntervalInMinutes":240,"backupRetentionIntervalInHours":8}}}}'
+    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx","name":"k8sinfratestdbhmayhx","location":"West US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2021-01-21T23:45:30.2444381Z"},"properties":{"provisioningState":"Deleting","documentEndpoint":"https://k8sinfratestdbhmayhx.documents.azure.com:443/","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"instanceId":"be52cc07-6378-4a29-a5c8-9d7d7a694291","createMode":"Default","databaseAccountOfferType":"Standard","ipRangeFilter":"","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","failoverPriority":0}],"cors":[],"capabilities":[],"backupPolicy":{"type":"Periodic","periodicModeProperties":{"backupIntervalInMinutes":240,"backupRetentionIntervalInHours":8}}}}'
     headers:
       Cache-Control:
       - no-store, no-cache
       Content-Type:
       - application/json
       Date:
-      - Tue, 19 Jan 2021 22:08:48 GMT
+      - Thu, 21 Jan 2021 23:50:16 GMT
       Pragma:
       - no-cache
       Server:
@@ -2362,14 +2600,14 @@ interactions:
     url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx?api-version=2015-04-08
     method: GET
   response:
-    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx","name":"k8sinfratestdbhmayhx","location":"West US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2021-01-19T22:03:48.2932101Z"},"properties":{"provisioningState":"Deleting","documentEndpoint":"https://k8sinfratestdbhmayhx.documents.azure.com:443/","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"instanceId":"65c2d03c-7a90-4781-ae94-221c028bd8e3","createMode":"Default","databaseAccountOfferType":"Standard","ipRangeFilter":"","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","failoverPriority":0}],"cors":[],"capabilities":[],"backupPolicy":{"type":"Periodic","periodicModeProperties":{"backupIntervalInMinutes":240,"backupRetentionIntervalInHours":8}}}}'
+    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx","name":"k8sinfratestdbhmayhx","location":"West US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2021-01-21T23:45:30.2444381Z"},"properties":{"provisioningState":"Deleting","documentEndpoint":"https://k8sinfratestdbhmayhx.documents.azure.com:443/","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"instanceId":"be52cc07-6378-4a29-a5c8-9d7d7a694291","createMode":"Default","databaseAccountOfferType":"Standard","ipRangeFilter":"","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","failoverPriority":0}],"cors":[],"capabilities":[],"backupPolicy":{"type":"Periodic","periodicModeProperties":{"backupIntervalInMinutes":240,"backupRetentionIntervalInHours":8}}}}'
     headers:
       Cache-Control:
       - no-store, no-cache
       Content-Type:
       - application/json
       Date:
-      - Tue, 19 Jan 2021 22:08:54 GMT
+      - Thu, 21 Jan 2021 23:50:21 GMT
       Pragma:
       - no-cache
       Server:
@@ -2396,14 +2634,14 @@ interactions:
     url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx?api-version=2015-04-08
     method: GET
   response:
-    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx","name":"k8sinfratestdbhmayhx","location":"West US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2021-01-19T22:03:48.2932101Z"},"properties":{"provisioningState":"Deleting","documentEndpoint":"https://k8sinfratestdbhmayhx.documents.azure.com:443/","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"instanceId":"65c2d03c-7a90-4781-ae94-221c028bd8e3","createMode":"Default","databaseAccountOfferType":"Standard","ipRangeFilter":"","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","failoverPriority":0}],"cors":[],"capabilities":[],"backupPolicy":{"type":"Periodic","periodicModeProperties":{"backupIntervalInMinutes":240,"backupRetentionIntervalInHours":8}}}}'
+    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx","name":"k8sinfratestdbhmayhx","location":"West US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2021-01-21T23:45:30.2444381Z"},"properties":{"provisioningState":"Deleting","documentEndpoint":"https://k8sinfratestdbhmayhx.documents.azure.com:443/","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"instanceId":"be52cc07-6378-4a29-a5c8-9d7d7a694291","createMode":"Default","databaseAccountOfferType":"Standard","ipRangeFilter":"","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","failoverPriority":0}],"cors":[],"capabilities":[],"backupPolicy":{"type":"Periodic","periodicModeProperties":{"backupIntervalInMinutes":240,"backupRetentionIntervalInHours":8}}}}'
     headers:
       Cache-Control:
       - no-store, no-cache
       Content-Type:
       - application/json
       Date:
-      - Tue, 19 Jan 2021 22:09:00 GMT
+      - Thu, 21 Jan 2021 23:50:27 GMT
       Pragma:
       - no-cache
       Server:
@@ -2430,14 +2668,14 @@ interactions:
     url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx?api-version=2015-04-08
     method: GET
   response:
-    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx","name":"k8sinfratestdbhmayhx","location":"West US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2021-01-19T22:03:48.2932101Z"},"properties":{"provisioningState":"Deleting","documentEndpoint":"https://k8sinfratestdbhmayhx.documents.azure.com:443/","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"instanceId":"65c2d03c-7a90-4781-ae94-221c028bd8e3","createMode":"Default","databaseAccountOfferType":"Standard","ipRangeFilter":"","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","failoverPriority":0}],"cors":[],"capabilities":[],"backupPolicy":{"type":"Periodic","periodicModeProperties":{"backupIntervalInMinutes":240,"backupRetentionIntervalInHours":8}}}}'
+    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx","name":"k8sinfratestdbhmayhx","location":"West US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2021-01-21T23:45:30.2444381Z"},"properties":{"provisioningState":"Deleting","documentEndpoint":"https://k8sinfratestdbhmayhx.documents.azure.com:443/","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"instanceId":"be52cc07-6378-4a29-a5c8-9d7d7a694291","createMode":"Default","databaseAccountOfferType":"Standard","ipRangeFilter":"","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","failoverPriority":0}],"cors":[],"capabilities":[],"backupPolicy":{"type":"Periodic","periodicModeProperties":{"backupIntervalInMinutes":240,"backupRetentionIntervalInHours":8}}}}'
     headers:
       Cache-Control:
       - no-store, no-cache
       Content-Type:
       - application/json
       Date:
-      - Tue, 19 Jan 2021 22:09:05 GMT
+      - Thu, 21 Jan 2021 23:50:35 GMT
       Pragma:
       - no-cache
       Server:
@@ -2464,14 +2702,14 @@ interactions:
     url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx?api-version=2015-04-08
     method: GET
   response:
-    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx","name":"k8sinfratestdbhmayhx","location":"West US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2021-01-19T22:03:48.2932101Z"},"properties":{"provisioningState":"Deleting","documentEndpoint":"https://k8sinfratestdbhmayhx.documents.azure.com:443/","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"instanceId":"65c2d03c-7a90-4781-ae94-221c028bd8e3","createMode":"Default","databaseAccountOfferType":"Standard","ipRangeFilter":"","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","failoverPriority":0}],"cors":[],"capabilities":[],"backupPolicy":{"type":"Periodic","periodicModeProperties":{"backupIntervalInMinutes":240,"backupRetentionIntervalInHours":8}}}}'
+    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx","name":"k8sinfratestdbhmayhx","location":"West US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2021-01-21T23:45:30.2444381Z"},"properties":{"provisioningState":"Deleting","documentEndpoint":"https://k8sinfratestdbhmayhx.documents.azure.com:443/","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"instanceId":"be52cc07-6378-4a29-a5c8-9d7d7a694291","createMode":"Default","databaseAccountOfferType":"Standard","ipRangeFilter":"","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","failoverPriority":0}],"cors":[],"capabilities":[],"backupPolicy":{"type":"Periodic","periodicModeProperties":{"backupIntervalInMinutes":240,"backupRetentionIntervalInHours":8}}}}'
     headers:
       Cache-Control:
       - no-store, no-cache
       Content-Type:
       - application/json
       Date:
-      - Tue, 19 Jan 2021 22:09:10 GMT
+      - Thu, 21 Jan 2021 23:50:40 GMT
       Pragma:
       - no-cache
       Server:
@@ -2498,14 +2736,14 @@ interactions:
     url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx?api-version=2015-04-08
     method: GET
   response:
-    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx","name":"k8sinfratestdbhmayhx","location":"West US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2021-01-19T22:03:48.2932101Z"},"properties":{"provisioningState":"Deleting","documentEndpoint":"https://k8sinfratestdbhmayhx.documents.azure.com:443/","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"instanceId":"65c2d03c-7a90-4781-ae94-221c028bd8e3","createMode":"Default","databaseAccountOfferType":"Standard","ipRangeFilter":"","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","failoverPriority":0}],"cors":[],"capabilities":[],"backupPolicy":{"type":"Periodic","periodicModeProperties":{"backupIntervalInMinutes":240,"backupRetentionIntervalInHours":8}}}}'
+    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx","name":"k8sinfratestdbhmayhx","location":"West US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2021-01-21T23:45:30.2444381Z"},"properties":{"provisioningState":"Deleting","documentEndpoint":"https://k8sinfratestdbhmayhx.documents.azure.com:443/","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"instanceId":"be52cc07-6378-4a29-a5c8-9d7d7a694291","createMode":"Default","databaseAccountOfferType":"Standard","ipRangeFilter":"","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","failoverPriority":0}],"cors":[],"capabilities":[],"backupPolicy":{"type":"Periodic","periodicModeProperties":{"backupIntervalInMinutes":240,"backupRetentionIntervalInHours":8}}}}'
     headers:
       Cache-Control:
       - no-store, no-cache
       Content-Type:
       - application/json
       Date:
-      - Tue, 19 Jan 2021 22:09:17 GMT
+      - Thu, 21 Jan 2021 23:50:45 GMT
       Pragma:
       - no-cache
       Server:
@@ -2532,14 +2770,14 @@ interactions:
     url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx?api-version=2015-04-08
     method: GET
   response:
-    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx","name":"k8sinfratestdbhmayhx","location":"West US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2021-01-19T22:03:48.2932101Z"},"properties":{"provisioningState":"Deleting","documentEndpoint":"https://k8sinfratestdbhmayhx.documents.azure.com:443/","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"instanceId":"65c2d03c-7a90-4781-ae94-221c028bd8e3","createMode":"Default","databaseAccountOfferType":"Standard","ipRangeFilter":"","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","failoverPriority":0}],"cors":[],"capabilities":[],"backupPolicy":{"type":"Periodic","periodicModeProperties":{"backupIntervalInMinutes":240,"backupRetentionIntervalInHours":8}}}}'
+    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx","name":"k8sinfratestdbhmayhx","location":"West US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2021-01-21T23:45:30.2444381Z"},"properties":{"provisioningState":"Deleting","documentEndpoint":"https://k8sinfratestdbhmayhx.documents.azure.com:443/","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"instanceId":"be52cc07-6378-4a29-a5c8-9d7d7a694291","createMode":"Default","databaseAccountOfferType":"Standard","ipRangeFilter":"","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","failoverPriority":0}],"cors":[],"capabilities":[],"backupPolicy":{"type":"Periodic","periodicModeProperties":{"backupIntervalInMinutes":240,"backupRetentionIntervalInHours":8}}}}'
     headers:
       Cache-Control:
       - no-store, no-cache
       Content-Type:
       - application/json
       Date:
-      - Tue, 19 Jan 2021 22:09:23 GMT
+      - Thu, 21 Jan 2021 23:50:51 GMT
       Pragma:
       - no-cache
       Server:
@@ -2566,14 +2804,14 @@ interactions:
     url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx?api-version=2015-04-08
     method: GET
   response:
-    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx","name":"k8sinfratestdbhmayhx","location":"West US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2021-01-19T22:03:48.2932101Z"},"properties":{"provisioningState":"Deleting","documentEndpoint":"https://k8sinfratestdbhmayhx.documents.azure.com:443/","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"instanceId":"65c2d03c-7a90-4781-ae94-221c028bd8e3","createMode":"Default","databaseAccountOfferType":"Standard","ipRangeFilter":"","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","failoverPriority":0}],"cors":[],"capabilities":[],"backupPolicy":{"type":"Periodic","periodicModeProperties":{"backupIntervalInMinutes":240,"backupRetentionIntervalInHours":8}}}}'
+    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx","name":"k8sinfratestdbhmayhx","location":"West US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2021-01-21T23:45:30.2444381Z"},"properties":{"provisioningState":"Deleting","documentEndpoint":"https://k8sinfratestdbhmayhx.documents.azure.com:443/","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"instanceId":"be52cc07-6378-4a29-a5c8-9d7d7a694291","createMode":"Default","databaseAccountOfferType":"Standard","ipRangeFilter":"","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","failoverPriority":0}],"cors":[],"capabilities":[],"backupPolicy":{"type":"Periodic","periodicModeProperties":{"backupIntervalInMinutes":240,"backupRetentionIntervalInHours":8}}}}'
     headers:
       Cache-Control:
       - no-store, no-cache
       Content-Type:
       - application/json
       Date:
-      - Tue, 19 Jan 2021 22:09:30 GMT
+      - Thu, 21 Jan 2021 23:50:56 GMT
       Pragma:
       - no-cache
       Server:
@@ -2600,14 +2838,14 @@ interactions:
     url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx?api-version=2015-04-08
     method: GET
   response:
-    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx","name":"k8sinfratestdbhmayhx","location":"West US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2021-01-19T22:03:48.2932101Z"},"properties":{"provisioningState":"Deleting","documentEndpoint":"https://k8sinfratestdbhmayhx.documents.azure.com:443/","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"instanceId":"65c2d03c-7a90-4781-ae94-221c028bd8e3","createMode":"Default","databaseAccountOfferType":"Standard","ipRangeFilter":"","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","failoverPriority":0}],"cors":[],"capabilities":[],"backupPolicy":{"type":"Periodic","periodicModeProperties":{"backupIntervalInMinutes":240,"backupRetentionIntervalInHours":8}}}}'
+    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx","name":"k8sinfratestdbhmayhx","location":"West US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2021-01-21T23:45:30.2444381Z"},"properties":{"provisioningState":"Deleting","documentEndpoint":"https://k8sinfratestdbhmayhx.documents.azure.com:443/","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"instanceId":"be52cc07-6378-4a29-a5c8-9d7d7a694291","createMode":"Default","databaseAccountOfferType":"Standard","ipRangeFilter":"","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","failoverPriority":0}],"cors":[],"capabilities":[],"backupPolicy":{"type":"Periodic","periodicModeProperties":{"backupIntervalInMinutes":240,"backupRetentionIntervalInHours":8}}}}'
     headers:
       Cache-Control:
       - no-store, no-cache
       Content-Type:
       - application/json
       Date:
-      - Tue, 19 Jan 2021 22:09:36 GMT
+      - Thu, 21 Jan 2021 23:51:01 GMT
       Pragma:
       - no-cache
       Server:
@@ -2634,14 +2872,14 @@ interactions:
     url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx?api-version=2015-04-08
     method: GET
   response:
-    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx","name":"k8sinfratestdbhmayhx","location":"West US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2021-01-19T22:03:48.2932101Z"},"properties":{"provisioningState":"Deleting","documentEndpoint":"https://k8sinfratestdbhmayhx.documents.azure.com:443/","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"instanceId":"65c2d03c-7a90-4781-ae94-221c028bd8e3","createMode":"Default","databaseAccountOfferType":"Standard","ipRangeFilter":"","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","failoverPriority":0}],"cors":[],"capabilities":[],"backupPolicy":{"type":"Periodic","periodicModeProperties":{"backupIntervalInMinutes":240,"backupRetentionIntervalInHours":8}}}}'
+    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx","name":"k8sinfratestdbhmayhx","location":"West US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2021-01-21T23:45:30.2444381Z"},"properties":{"provisioningState":"Deleting","documentEndpoint":"https://k8sinfratestdbhmayhx.documents.azure.com:443/","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"instanceId":"be52cc07-6378-4a29-a5c8-9d7d7a694291","createMode":"Default","databaseAccountOfferType":"Standard","ipRangeFilter":"","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","failoverPriority":0}],"cors":[],"capabilities":[],"backupPolicy":{"type":"Periodic","periodicModeProperties":{"backupIntervalInMinutes":240,"backupRetentionIntervalInHours":8}}}}'
     headers:
       Cache-Control:
       - no-store, no-cache
       Content-Type:
       - application/json
       Date:
-      - Tue, 19 Jan 2021 22:09:43 GMT
+      - Thu, 21 Jan 2021 23:51:06 GMT
       Pragma:
       - no-cache
       Server:
@@ -2668,14 +2906,14 @@ interactions:
     url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx?api-version=2015-04-08
     method: GET
   response:
-    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx","name":"k8sinfratestdbhmayhx","location":"West US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2021-01-19T22:03:48.2932101Z"},"properties":{"provisioningState":"Deleting","documentEndpoint":"https://k8sinfratestdbhmayhx.documents.azure.com:443/","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"instanceId":"65c2d03c-7a90-4781-ae94-221c028bd8e3","createMode":"Default","databaseAccountOfferType":"Standard","ipRangeFilter":"","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","failoverPriority":0}],"cors":[],"capabilities":[],"backupPolicy":{"type":"Periodic","periodicModeProperties":{"backupIntervalInMinutes":240,"backupRetentionIntervalInHours":8}}}}'
+    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx","name":"k8sinfratestdbhmayhx","location":"West US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2021-01-21T23:45:30.2444381Z"},"properties":{"provisioningState":"Deleting","documentEndpoint":"https://k8sinfratestdbhmayhx.documents.azure.com:443/","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"instanceId":"be52cc07-6378-4a29-a5c8-9d7d7a694291","createMode":"Default","databaseAccountOfferType":"Standard","ipRangeFilter":"","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","failoverPriority":0}],"cors":[],"capabilities":[],"backupPolicy":{"type":"Periodic","periodicModeProperties":{"backupIntervalInMinutes":240,"backupRetentionIntervalInHours":8}}}}'
     headers:
       Cache-Control:
       - no-store, no-cache
       Content-Type:
       - application/json
       Date:
-      - Tue, 19 Jan 2021 22:09:49 GMT
+      - Thu, 21 Jan 2021 23:51:13 GMT
       Pragma:
       - no-cache
       Server:
@@ -2702,14 +2940,14 @@ interactions:
     url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx?api-version=2015-04-08
     method: GET
   response:
-    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx","name":"k8sinfratestdbhmayhx","location":"West US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2021-01-19T22:03:48.2932101Z"},"properties":{"provisioningState":"Deleting","documentEndpoint":"https://k8sinfratestdbhmayhx.documents.azure.com:443/","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"instanceId":"65c2d03c-7a90-4781-ae94-221c028bd8e3","createMode":"Default","databaseAccountOfferType":"Standard","ipRangeFilter":"","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","failoverPriority":0}],"cors":[],"capabilities":[],"backupPolicy":{"type":"Periodic","periodicModeProperties":{"backupIntervalInMinutes":240,"backupRetentionIntervalInHours":8}}}}'
+    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx","name":"k8sinfratestdbhmayhx","location":"West US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2021-01-21T23:45:30.2444381Z"},"properties":{"provisioningState":"Deleting","documentEndpoint":"https://k8sinfratestdbhmayhx.documents.azure.com:443/","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"instanceId":"be52cc07-6378-4a29-a5c8-9d7d7a694291","createMode":"Default","databaseAccountOfferType":"Standard","ipRangeFilter":"","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","failoverPriority":0}],"cors":[],"capabilities":[],"backupPolicy":{"type":"Periodic","periodicModeProperties":{"backupIntervalInMinutes":240,"backupRetentionIntervalInHours":8}}}}'
     headers:
       Cache-Control:
       - no-store, no-cache
       Content-Type:
       - application/json
       Date:
-      - Tue, 19 Jan 2021 22:09:55 GMT
+      - Thu, 21 Jan 2021 23:51:18 GMT
       Pragma:
       - no-cache
       Server:
@@ -2736,14 +2974,14 @@ interactions:
     url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx?api-version=2015-04-08
     method: GET
   response:
-    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx","name":"k8sinfratestdbhmayhx","location":"West US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2021-01-19T22:03:48.2932101Z"},"properties":{"provisioningState":"Deleting","documentEndpoint":"https://k8sinfratestdbhmayhx.documents.azure.com:443/","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"instanceId":"65c2d03c-7a90-4781-ae94-221c028bd8e3","createMode":"Default","databaseAccountOfferType":"Standard","ipRangeFilter":"","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","failoverPriority":0}],"cors":[],"capabilities":[],"backupPolicy":{"type":"Periodic","periodicModeProperties":{"backupIntervalInMinutes":240,"backupRetentionIntervalInHours":8}}}}'
+    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx","name":"k8sinfratestdbhmayhx","location":"West US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2021-01-21T23:45:30.2444381Z"},"properties":{"provisioningState":"Deleting","documentEndpoint":"https://k8sinfratestdbhmayhx.documents.azure.com:443/","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"instanceId":"be52cc07-6378-4a29-a5c8-9d7d7a694291","createMode":"Default","databaseAccountOfferType":"Standard","ipRangeFilter":"","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","failoverPriority":0}],"cors":[],"capabilities":[],"backupPolicy":{"type":"Periodic","periodicModeProperties":{"backupIntervalInMinutes":240,"backupRetentionIntervalInHours":8}}}}'
     headers:
       Cache-Control:
       - no-store, no-cache
       Content-Type:
       - application/json
       Date:
-      - Tue, 19 Jan 2021 22:10:00 GMT
+      - Thu, 21 Jan 2021 23:51:23 GMT
       Pragma:
       - no-cache
       Server:
@@ -2770,14 +3008,14 @@ interactions:
     url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx?api-version=2015-04-08
     method: GET
   response:
-    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx","name":"k8sinfratestdbhmayhx","location":"West US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2021-01-19T22:03:48.2932101Z"},"properties":{"provisioningState":"Deleting","documentEndpoint":"https://k8sinfratestdbhmayhx.documents.azure.com:443/","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"instanceId":"65c2d03c-7a90-4781-ae94-221c028bd8e3","createMode":"Default","databaseAccountOfferType":"Standard","ipRangeFilter":"","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","failoverPriority":0}],"cors":[],"capabilities":[],"backupPolicy":{"type":"Periodic","periodicModeProperties":{"backupIntervalInMinutes":240,"backupRetentionIntervalInHours":8}}}}'
+    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx","name":"k8sinfratestdbhmayhx","location":"West US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2021-01-21T23:45:30.2444381Z"},"properties":{"provisioningState":"Deleting","documentEndpoint":"https://k8sinfratestdbhmayhx.documents.azure.com:443/","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"instanceId":"be52cc07-6378-4a29-a5c8-9d7d7a694291","createMode":"Default","databaseAccountOfferType":"Standard","ipRangeFilter":"","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","failoverPriority":0}],"cors":[],"capabilities":[],"backupPolicy":{"type":"Periodic","periodicModeProperties":{"backupIntervalInMinutes":240,"backupRetentionIntervalInHours":8}}}}'
     headers:
       Cache-Control:
       - no-store, no-cache
       Content-Type:
       - application/json
       Date:
-      - Tue, 19 Jan 2021 22:10:06 GMT
+      - Thu, 21 Jan 2021 23:51:28 GMT
       Pragma:
       - no-cache
       Server:
@@ -2804,14 +3042,14 @@ interactions:
     url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx?api-version=2015-04-08
     method: GET
   response:
-    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx","name":"k8sinfratestdbhmayhx","location":"West US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2021-01-19T22:03:48.2932101Z"},"properties":{"provisioningState":"Deleting","documentEndpoint":"https://k8sinfratestdbhmayhx.documents.azure.com:443/","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"instanceId":"65c2d03c-7a90-4781-ae94-221c028bd8e3","createMode":"Default","databaseAccountOfferType":"Standard","ipRangeFilter":"","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","failoverPriority":0}],"cors":[],"capabilities":[],"backupPolicy":{"type":"Periodic","periodicModeProperties":{"backupIntervalInMinutes":240,"backupRetentionIntervalInHours":8}}}}'
+    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx","name":"k8sinfratestdbhmayhx","location":"West US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2021-01-21T23:45:30.2444381Z"},"properties":{"provisioningState":"Deleting","documentEndpoint":"https://k8sinfratestdbhmayhx.documents.azure.com:443/","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"instanceId":"be52cc07-6378-4a29-a5c8-9d7d7a694291","createMode":"Default","databaseAccountOfferType":"Standard","ipRangeFilter":"","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","failoverPriority":0}],"cors":[],"capabilities":[],"backupPolicy":{"type":"Periodic","periodicModeProperties":{"backupIntervalInMinutes":240,"backupRetentionIntervalInHours":8}}}}'
     headers:
       Cache-Control:
       - no-store, no-cache
       Content-Type:
       - application/json
       Date:
-      - Tue, 19 Jan 2021 22:10:13 GMT
+      - Thu, 21 Jan 2021 23:51:34 GMT
       Pragma:
       - no-cache
       Server:
@@ -2838,14 +3076,14 @@ interactions:
     url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx?api-version=2015-04-08
     method: GET
   response:
-    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx","name":"k8sinfratestdbhmayhx","location":"West US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2021-01-19T22:03:48.2932101Z"},"properties":{"provisioningState":"Deleting","documentEndpoint":"https://k8sinfratestdbhmayhx.documents.azure.com:443/","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"instanceId":"65c2d03c-7a90-4781-ae94-221c028bd8e3","createMode":"Default","databaseAccountOfferType":"Standard","ipRangeFilter":"","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","failoverPriority":0}],"cors":[],"capabilities":[],"backupPolicy":{"type":"Periodic","periodicModeProperties":{"backupIntervalInMinutes":240,"backupRetentionIntervalInHours":8}}}}'
+    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx","name":"k8sinfratestdbhmayhx","location":"West US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2021-01-21T23:45:30.2444381Z"},"properties":{"provisioningState":"Deleting","documentEndpoint":"https://k8sinfratestdbhmayhx.documents.azure.com:443/","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"instanceId":"be52cc07-6378-4a29-a5c8-9d7d7a694291","createMode":"Default","databaseAccountOfferType":"Standard","ipRangeFilter":"","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","failoverPriority":0}],"cors":[],"capabilities":[],"backupPolicy":{"type":"Periodic","periodicModeProperties":{"backupIntervalInMinutes":240,"backupRetentionIntervalInHours":8}}}}'
     headers:
       Cache-Control:
       - no-store, no-cache
       Content-Type:
       - application/json
       Date:
-      - Tue, 19 Jan 2021 22:10:18 GMT
+      - Thu, 21 Jan 2021 23:51:40 GMT
       Pragma:
       - no-cache
       Server:
@@ -2872,14 +3110,14 @@ interactions:
     url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx?api-version=2015-04-08
     method: GET
   response:
-    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx","name":"k8sinfratestdbhmayhx","location":"West US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2021-01-19T22:03:48.2932101Z"},"properties":{"provisioningState":"Deleting","documentEndpoint":"https://k8sinfratestdbhmayhx.documents.azure.com:443/","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"instanceId":"65c2d03c-7a90-4781-ae94-221c028bd8e3","createMode":"Default","databaseAccountOfferType":"Standard","ipRangeFilter":"","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","failoverPriority":0}],"cors":[],"capabilities":[],"backupPolicy":{"type":"Periodic","periodicModeProperties":{"backupIntervalInMinutes":240,"backupRetentionIntervalInHours":8}}}}'
+    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx","name":"k8sinfratestdbhmayhx","location":"West US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2021-01-21T23:45:30.2444381Z"},"properties":{"provisioningState":"Deleting","documentEndpoint":"https://k8sinfratestdbhmayhx.documents.azure.com:443/","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"instanceId":"be52cc07-6378-4a29-a5c8-9d7d7a694291","createMode":"Default","databaseAccountOfferType":"Standard","ipRangeFilter":"","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","failoverPriority":0}],"cors":[],"capabilities":[],"backupPolicy":{"type":"Periodic","periodicModeProperties":{"backupIntervalInMinutes":240,"backupRetentionIntervalInHours":8}}}}'
     headers:
       Cache-Control:
       - no-store, no-cache
       Content-Type:
       - application/json
       Date:
-      - Tue, 19 Jan 2021 22:10:23 GMT
+      - Thu, 21 Jan 2021 23:51:46 GMT
       Pragma:
       - no-cache
       Server:
@@ -2906,14 +3144,14 @@ interactions:
     url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx?api-version=2015-04-08
     method: GET
   response:
-    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx","name":"k8sinfratestdbhmayhx","location":"West US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2021-01-19T22:03:48.2932101Z"},"properties":{"provisioningState":"Deleting","documentEndpoint":"https://k8sinfratestdbhmayhx.documents.azure.com:443/","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"instanceId":"65c2d03c-7a90-4781-ae94-221c028bd8e3","createMode":"Default","databaseAccountOfferType":"Standard","ipRangeFilter":"","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","failoverPriority":0}],"cors":[],"capabilities":[],"backupPolicy":{"type":"Periodic","periodicModeProperties":{"backupIntervalInMinutes":240,"backupRetentionIntervalInHours":8}}}}'
+    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx","name":"k8sinfratestdbhmayhx","location":"West US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2021-01-21T23:45:30.2444381Z"},"properties":{"provisioningState":"Deleting","documentEndpoint":"https://k8sinfratestdbhmayhx.documents.azure.com:443/","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"instanceId":"be52cc07-6378-4a29-a5c8-9d7d7a694291","createMode":"Default","databaseAccountOfferType":"Standard","ipRangeFilter":"","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","failoverPriority":0}],"cors":[],"capabilities":[],"backupPolicy":{"type":"Periodic","periodicModeProperties":{"backupIntervalInMinutes":240,"backupRetentionIntervalInHours":8}}}}'
     headers:
       Cache-Control:
       - no-store, no-cache
       Content-Type:
       - application/json
       Date:
-      - Tue, 19 Jan 2021 22:10:28 GMT
+      - Thu, 21 Jan 2021 23:51:52 GMT
       Pragma:
       - no-cache
       Server:
@@ -2940,14 +3178,14 @@ interactions:
     url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx?api-version=2015-04-08
     method: GET
   response:
-    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx","name":"k8sinfratestdbhmayhx","location":"West US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2021-01-19T22:03:48.2932101Z"},"properties":{"provisioningState":"Deleting","documentEndpoint":"https://k8sinfratestdbhmayhx.documents.azure.com:443/","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"instanceId":"65c2d03c-7a90-4781-ae94-221c028bd8e3","createMode":"Default","databaseAccountOfferType":"Standard","ipRangeFilter":"","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","failoverPriority":0}],"cors":[],"capabilities":[],"backupPolicy":{"type":"Periodic","periodicModeProperties":{"backupIntervalInMinutes":240,"backupRetentionIntervalInHours":8}}}}'
+    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx","name":"k8sinfratestdbhmayhx","location":"West US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2021-01-21T23:45:30.2444381Z"},"properties":{"provisioningState":"Deleting","documentEndpoint":"https://k8sinfratestdbhmayhx.documents.azure.com:443/","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"instanceId":"be52cc07-6378-4a29-a5c8-9d7d7a694291","createMode":"Default","databaseAccountOfferType":"Standard","ipRangeFilter":"","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","failoverPriority":0}],"cors":[],"capabilities":[],"backupPolicy":{"type":"Periodic","periodicModeProperties":{"backupIntervalInMinutes":240,"backupRetentionIntervalInHours":8}}}}'
     headers:
       Cache-Control:
       - no-store, no-cache
       Content-Type:
       - application/json
       Date:
-      - Tue, 19 Jan 2021 22:10:34 GMT
+      - Thu, 21 Jan 2021 23:51:57 GMT
       Pragma:
       - no-cache
       Server:
@@ -2974,14 +3212,14 @@ interactions:
     url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx?api-version=2015-04-08
     method: GET
   response:
-    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx","name":"k8sinfratestdbhmayhx","location":"West US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2021-01-19T22:03:48.2932101Z"},"properties":{"provisioningState":"Deleting","documentEndpoint":"https://k8sinfratestdbhmayhx.documents.azure.com:443/","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"instanceId":"65c2d03c-7a90-4781-ae94-221c028bd8e3","createMode":"Default","databaseAccountOfferType":"Standard","ipRangeFilter":"","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","failoverPriority":0}],"cors":[],"capabilities":[],"backupPolicy":{"type":"Periodic","periodicModeProperties":{"backupIntervalInMinutes":240,"backupRetentionIntervalInHours":8}}}}'
+    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx","name":"k8sinfratestdbhmayhx","location":"West US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2021-01-21T23:45:30.2444381Z"},"properties":{"provisioningState":"Deleting","documentEndpoint":"https://k8sinfratestdbhmayhx.documents.azure.com:443/","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"instanceId":"be52cc07-6378-4a29-a5c8-9d7d7a694291","createMode":"Default","databaseAccountOfferType":"Standard","ipRangeFilter":"","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","failoverPriority":0}],"cors":[],"capabilities":[],"backupPolicy":{"type":"Periodic","periodicModeProperties":{"backupIntervalInMinutes":240,"backupRetentionIntervalInHours":8}}}}'
     headers:
       Cache-Control:
       - no-store, no-cache
       Content-Type:
       - application/json
       Date:
-      - Tue, 19 Jan 2021 22:10:40 GMT
+      - Thu, 21 Jan 2021 23:52:02 GMT
       Pragma:
       - no-cache
       Server:
@@ -3008,14 +3246,14 @@ interactions:
     url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx?api-version=2015-04-08
     method: GET
   response:
-    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx","name":"k8sinfratestdbhmayhx","location":"West US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2021-01-19T22:03:48.2932101Z"},"properties":{"provisioningState":"Deleting","documentEndpoint":"https://k8sinfratestdbhmayhx.documents.azure.com:443/","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"instanceId":"65c2d03c-7a90-4781-ae94-221c028bd8e3","createMode":"Default","databaseAccountOfferType":"Standard","ipRangeFilter":"","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","failoverPriority":0}],"cors":[],"capabilities":[],"backupPolicy":{"type":"Periodic","periodicModeProperties":{"backupIntervalInMinutes":240,"backupRetentionIntervalInHours":8}}}}'
+    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx","name":"k8sinfratestdbhmayhx","location":"West US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2021-01-21T23:45:30.2444381Z"},"properties":{"provisioningState":"Deleting","documentEndpoint":"https://k8sinfratestdbhmayhx.documents.azure.com:443/","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"instanceId":"be52cc07-6378-4a29-a5c8-9d7d7a694291","createMode":"Default","databaseAccountOfferType":"Standard","ipRangeFilter":"","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","failoverPriority":0}],"cors":[],"capabilities":[],"backupPolicy":{"type":"Periodic","periodicModeProperties":{"backupIntervalInMinutes":240,"backupRetentionIntervalInHours":8}}}}'
     headers:
       Cache-Control:
       - no-store, no-cache
       Content-Type:
       - application/json
       Date:
-      - Tue, 19 Jan 2021 22:10:48 GMT
+      - Thu, 21 Jan 2021 23:52:07 GMT
       Pragma:
       - no-cache
       Server:
@@ -3042,14 +3280,14 @@ interactions:
     url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx?api-version=2015-04-08
     method: GET
   response:
-    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx","name":"k8sinfratestdbhmayhx","location":"West US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2021-01-19T22:03:48.2932101Z"},"properties":{"provisioningState":"Deleting","documentEndpoint":"https://k8sinfratestdbhmayhx.documents.azure.com:443/","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"instanceId":"65c2d03c-7a90-4781-ae94-221c028bd8e3","createMode":"Default","databaseAccountOfferType":"Standard","ipRangeFilter":"","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","failoverPriority":0}],"cors":[],"capabilities":[],"backupPolicy":{"type":"Periodic","periodicModeProperties":{"backupIntervalInMinutes":240,"backupRetentionIntervalInHours":8}}}}'
+    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx","name":"k8sinfratestdbhmayhx","location":"West US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2021-01-21T23:45:30.2444381Z"},"properties":{"provisioningState":"Deleting","documentEndpoint":"https://k8sinfratestdbhmayhx.documents.azure.com:443/","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"instanceId":"be52cc07-6378-4a29-a5c8-9d7d7a694291","createMode":"Default","databaseAccountOfferType":"Standard","ipRangeFilter":"","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","failoverPriority":0}],"cors":[],"capabilities":[],"backupPolicy":{"type":"Periodic","periodicModeProperties":{"backupIntervalInMinutes":240,"backupRetentionIntervalInHours":8}}}}'
     headers:
       Cache-Control:
       - no-store, no-cache
       Content-Type:
       - application/json
       Date:
-      - Tue, 19 Jan 2021 22:10:53 GMT
+      - Thu, 21 Jan 2021 23:52:13 GMT
       Pragma:
       - no-cache
       Server:
@@ -3076,14 +3314,14 @@ interactions:
     url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx?api-version=2015-04-08
     method: GET
   response:
-    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx","name":"k8sinfratestdbhmayhx","location":"West US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2021-01-19T22:03:48.2932101Z"},"properties":{"provisioningState":"Deleting","documentEndpoint":"https://k8sinfratestdbhmayhx.documents.azure.com:443/","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"instanceId":"65c2d03c-7a90-4781-ae94-221c028bd8e3","createMode":"Default","databaseAccountOfferType":"Standard","ipRangeFilter":"","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","failoverPriority":0}],"cors":[],"capabilities":[],"backupPolicy":{"type":"Periodic","periodicModeProperties":{"backupIntervalInMinutes":240,"backupRetentionIntervalInHours":8}}}}'
+    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx","name":"k8sinfratestdbhmayhx","location":"West US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2021-01-21T23:45:30.2444381Z"},"properties":{"provisioningState":"Deleting","documentEndpoint":"https://k8sinfratestdbhmayhx.documents.azure.com:443/","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"instanceId":"be52cc07-6378-4a29-a5c8-9d7d7a694291","createMode":"Default","databaseAccountOfferType":"Standard","ipRangeFilter":"","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","failoverPriority":0}],"cors":[],"capabilities":[],"backupPolicy":{"type":"Periodic","periodicModeProperties":{"backupIntervalInMinutes":240,"backupRetentionIntervalInHours":8}}}}'
     headers:
       Cache-Control:
       - no-store, no-cache
       Content-Type:
       - application/json
       Date:
-      - Tue, 19 Jan 2021 22:11:00 GMT
+      - Thu, 21 Jan 2021 23:52:18 GMT
       Pragma:
       - no-cache
       Server:
@@ -3110,14 +3348,14 @@ interactions:
     url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx?api-version=2015-04-08
     method: GET
   response:
-    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx","name":"k8sinfratestdbhmayhx","location":"West US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2021-01-19T22:03:48.2932101Z"},"properties":{"provisioningState":"Deleting","documentEndpoint":"https://k8sinfratestdbhmayhx.documents.azure.com:443/","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"instanceId":"65c2d03c-7a90-4781-ae94-221c028bd8e3","createMode":"Default","databaseAccountOfferType":"Standard","ipRangeFilter":"","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","failoverPriority":0}],"cors":[],"capabilities":[],"backupPolicy":{"type":"Periodic","periodicModeProperties":{"backupIntervalInMinutes":240,"backupRetentionIntervalInHours":8}}}}'
+    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx","name":"k8sinfratestdbhmayhx","location":"West US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2021-01-21T23:45:30.2444381Z"},"properties":{"provisioningState":"Deleting","documentEndpoint":"https://k8sinfratestdbhmayhx.documents.azure.com:443/","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"instanceId":"be52cc07-6378-4a29-a5c8-9d7d7a694291","createMode":"Default","databaseAccountOfferType":"Standard","ipRangeFilter":"","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","failoverPriority":0}],"cors":[],"capabilities":[],"backupPolicy":{"type":"Periodic","periodicModeProperties":{"backupIntervalInMinutes":240,"backupRetentionIntervalInHours":8}}}}'
     headers:
       Cache-Control:
       - no-store, no-cache
       Content-Type:
       - application/json
       Date:
-      - Tue, 19 Jan 2021 22:11:05 GMT
+      - Thu, 21 Jan 2021 23:52:24 GMT
       Pragma:
       - no-cache
       Server:
@@ -3144,14 +3382,14 @@ interactions:
     url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx?api-version=2015-04-08
     method: GET
   response:
-    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx","name":"k8sinfratestdbhmayhx","location":"West US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2021-01-19T22:03:48.2932101Z"},"properties":{"provisioningState":"Deleting","documentEndpoint":"https://k8sinfratestdbhmayhx.documents.azure.com:443/","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"instanceId":"65c2d03c-7a90-4781-ae94-221c028bd8e3","createMode":"Default","databaseAccountOfferType":"Standard","ipRangeFilter":"","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","failoverPriority":0}],"cors":[],"capabilities":[],"backupPolicy":{"type":"Periodic","periodicModeProperties":{"backupIntervalInMinutes":240,"backupRetentionIntervalInHours":8}}}}'
+    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx","name":"k8sinfratestdbhmayhx","location":"West US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2021-01-21T23:45:30.2444381Z"},"properties":{"provisioningState":"Deleting","documentEndpoint":"https://k8sinfratestdbhmayhx.documents.azure.com:443/","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"instanceId":"be52cc07-6378-4a29-a5c8-9d7d7a694291","createMode":"Default","databaseAccountOfferType":"Standard","ipRangeFilter":"","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","failoverPriority":0}],"cors":[],"capabilities":[],"backupPolicy":{"type":"Periodic","periodicModeProperties":{"backupIntervalInMinutes":240,"backupRetentionIntervalInHours":8}}}}'
     headers:
       Cache-Control:
       - no-store, no-cache
       Content-Type:
       - application/json
       Date:
-      - Tue, 19 Jan 2021 22:11:10 GMT
+      - Thu, 21 Jan 2021 23:52:29 GMT
       Pragma:
       - no-cache
       Server:
@@ -3178,14 +3416,14 @@ interactions:
     url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx?api-version=2015-04-08
     method: GET
   response:
-    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx","name":"k8sinfratestdbhmayhx","location":"West US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2021-01-19T22:03:48.2932101Z"},"properties":{"provisioningState":"Deleting","documentEndpoint":"https://k8sinfratestdbhmayhx.documents.azure.com:443/","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"instanceId":"65c2d03c-7a90-4781-ae94-221c028bd8e3","createMode":"Default","databaseAccountOfferType":"Standard","ipRangeFilter":"","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","failoverPriority":0}],"cors":[],"capabilities":[],"backupPolicy":{"type":"Periodic","periodicModeProperties":{"backupIntervalInMinutes":240,"backupRetentionIntervalInHours":8}}}}'
+    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx","name":"k8sinfratestdbhmayhx","location":"West US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2021-01-21T23:45:30.2444381Z"},"properties":{"provisioningState":"Deleting","documentEndpoint":"https://k8sinfratestdbhmayhx.documents.azure.com:443/","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"instanceId":"be52cc07-6378-4a29-a5c8-9d7d7a694291","createMode":"Default","databaseAccountOfferType":"Standard","ipRangeFilter":"","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","failoverPriority":0}],"cors":[],"capabilities":[],"backupPolicy":{"type":"Periodic","periodicModeProperties":{"backupIntervalInMinutes":240,"backupRetentionIntervalInHours":8}}}}'
     headers:
       Cache-Control:
       - no-store, no-cache
       Content-Type:
       - application/json
       Date:
-      - Tue, 19 Jan 2021 22:11:16 GMT
+      - Thu, 21 Jan 2021 23:52:34 GMT
       Pragma:
       - no-cache
       Server:
@@ -3212,14 +3450,14 @@ interactions:
     url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx?api-version=2015-04-08
     method: GET
   response:
-    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx","name":"k8sinfratestdbhmayhx","location":"West US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2021-01-19T22:03:48.2932101Z"},"properties":{"provisioningState":"Deleting","documentEndpoint":"https://k8sinfratestdbhmayhx.documents.azure.com:443/","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"instanceId":"65c2d03c-7a90-4781-ae94-221c028bd8e3","createMode":"Default","databaseAccountOfferType":"Standard","ipRangeFilter":"","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"cors":[],"capabilities":[],"backupPolicy":{"type":"Periodic","periodicModeProperties":{"backupIntervalInMinutes":240,"backupRetentionIntervalInHours":8}}}}'
+    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx","name":"k8sinfratestdbhmayhx","location":"West US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2021-01-21T23:45:30.2444381Z"},"properties":{"provisioningState":"Deleting","documentEndpoint":"https://k8sinfratestdbhmayhx.documents.azure.com:443/","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"instanceId":"be52cc07-6378-4a29-a5c8-9d7d7a694291","createMode":"Default","databaseAccountOfferType":"Standard","ipRangeFilter":"","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","failoverPriority":0}],"cors":[],"capabilities":[],"backupPolicy":{"type":"Periodic","periodicModeProperties":{"backupIntervalInMinutes":240,"backupRetentionIntervalInHours":8}}}}'
     headers:
       Cache-Control:
       - no-store, no-cache
       Content-Type:
       - application/json
       Date:
-      - Tue, 19 Jan 2021 22:11:21 GMT
+      - Thu, 21 Jan 2021 23:52:39 GMT
       Pragma:
       - no-cache
       Server:
@@ -3246,7 +3484,415 @@ interactions:
     url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx?api-version=2015-04-08
     method: GET
   response:
-    body: '{"code":"NotFound","message":"Entity with the specified id does not exist in the system. More info: https://aka.ms/cosmosdb-tsg-not-found\r\nActivityId: 38ffaf48-a385-4968-b0f6-8c606426c81e, Microsoft.Azure.Documents.Common/2.11.0"}'
+    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx","name":"k8sinfratestdbhmayhx","location":"West US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2021-01-21T23:45:30.2444381Z"},"properties":{"provisioningState":"Deleting","documentEndpoint":"https://k8sinfratestdbhmayhx.documents.azure.com:443/","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"instanceId":"be52cc07-6378-4a29-a5c8-9d7d7a694291","createMode":"Default","databaseAccountOfferType":"Standard","ipRangeFilter":"","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","failoverPriority":0}],"cors":[],"capabilities":[],"backupPolicy":{"type":"Periodic","periodicModeProperties":{"backupIntervalInMinutes":240,"backupRetentionIntervalInHours":8}}}}'
+    headers:
+      Cache-Control:
+      - no-store, no-cache
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 21 Jan 2021 23:52:45 GMT
+      Pragma:
+      - no-cache
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Ms-Gatewayversion:
+      - version=2.11.0
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Go/go1.15.6 (amd64-linux) go-autorest/v14.1.1 k8sinfra-generated
+    url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx?api-version=2015-04-08
+    method: GET
+  response:
+    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx","name":"k8sinfratestdbhmayhx","location":"West US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2021-01-21T23:45:30.2444381Z"},"properties":{"provisioningState":"Deleting","documentEndpoint":"https://k8sinfratestdbhmayhx.documents.azure.com:443/","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"instanceId":"be52cc07-6378-4a29-a5c8-9d7d7a694291","createMode":"Default","databaseAccountOfferType":"Standard","ipRangeFilter":"","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","failoverPriority":0}],"cors":[],"capabilities":[],"backupPolicy":{"type":"Periodic","periodicModeProperties":{"backupIntervalInMinutes":240,"backupRetentionIntervalInHours":8}}}}'
+    headers:
+      Cache-Control:
+      - no-store, no-cache
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 21 Jan 2021 23:52:50 GMT
+      Pragma:
+      - no-cache
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Ms-Gatewayversion:
+      - version=2.11.0
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Go/go1.15.6 (amd64-linux) go-autorest/v14.1.1 k8sinfra-generated
+    url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx?api-version=2015-04-08
+    method: GET
+  response:
+    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx","name":"k8sinfratestdbhmayhx","location":"West US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2021-01-21T23:45:30.2444381Z"},"properties":{"provisioningState":"Deleting","documentEndpoint":"https://k8sinfratestdbhmayhx.documents.azure.com:443/","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"instanceId":"be52cc07-6378-4a29-a5c8-9d7d7a694291","createMode":"Default","databaseAccountOfferType":"Standard","ipRangeFilter":"","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","failoverPriority":0}],"cors":[],"capabilities":[],"backupPolicy":{"type":"Periodic","periodicModeProperties":{"backupIntervalInMinutes":240,"backupRetentionIntervalInHours":8}}}}'
+    headers:
+      Cache-Control:
+      - no-store, no-cache
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 21 Jan 2021 23:52:57 GMT
+      Pragma:
+      - no-cache
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Ms-Gatewayversion:
+      - version=2.11.0
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Go/go1.15.6 (amd64-linux) go-autorest/v14.1.1 k8sinfra-generated
+    url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx?api-version=2015-04-08
+    method: GET
+  response:
+    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx","name":"k8sinfratestdbhmayhx","location":"West US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2021-01-21T23:45:30.2444381Z"},"properties":{"provisioningState":"Deleting","documentEndpoint":"https://k8sinfratestdbhmayhx.documents.azure.com:443/","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"instanceId":"be52cc07-6378-4a29-a5c8-9d7d7a694291","createMode":"Default","databaseAccountOfferType":"Standard","ipRangeFilter":"","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","failoverPriority":0}],"cors":[],"capabilities":[],"backupPolicy":{"type":"Periodic","periodicModeProperties":{"backupIntervalInMinutes":240,"backupRetentionIntervalInHours":8}}}}'
+    headers:
+      Cache-Control:
+      - no-store, no-cache
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 21 Jan 2021 23:53:03 GMT
+      Pragma:
+      - no-cache
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Ms-Gatewayversion:
+      - version=2.11.0
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Go/go1.15.6 (amd64-linux) go-autorest/v14.1.1 k8sinfra-generated
+    url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx?api-version=2015-04-08
+    method: GET
+  response:
+    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx","name":"k8sinfratestdbhmayhx","location":"West US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2021-01-21T23:45:30.2444381Z"},"properties":{"provisioningState":"Deleting","documentEndpoint":"https://k8sinfratestdbhmayhx.documents.azure.com:443/","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"instanceId":"be52cc07-6378-4a29-a5c8-9d7d7a694291","createMode":"Default","databaseAccountOfferType":"Standard","ipRangeFilter":"","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","failoverPriority":0}],"cors":[],"capabilities":[],"backupPolicy":{"type":"Periodic","periodicModeProperties":{"backupIntervalInMinutes":240,"backupRetentionIntervalInHours":8}}}}'
+    headers:
+      Cache-Control:
+      - no-store, no-cache
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 21 Jan 2021 23:53:09 GMT
+      Pragma:
+      - no-cache
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Ms-Gatewayversion:
+      - version=2.11.0
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Go/go1.15.6 (amd64-linux) go-autorest/v14.1.1 k8sinfra-generated
+    url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx?api-version=2015-04-08
+    method: GET
+  response:
+    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx","name":"k8sinfratestdbhmayhx","location":"West US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2021-01-21T23:45:30.2444381Z"},"properties":{"provisioningState":"Deleting","documentEndpoint":"https://k8sinfratestdbhmayhx.documents.azure.com:443/","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"instanceId":"be52cc07-6378-4a29-a5c8-9d7d7a694291","createMode":"Default","databaseAccountOfferType":"Standard","ipRangeFilter":"","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","failoverPriority":0}],"cors":[],"capabilities":[],"backupPolicy":{"type":"Periodic","periodicModeProperties":{"backupIntervalInMinutes":240,"backupRetentionIntervalInHours":8}}}}'
+    headers:
+      Cache-Control:
+      - no-store, no-cache
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 21 Jan 2021 23:53:14 GMT
+      Pragma:
+      - no-cache
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Ms-Gatewayversion:
+      - version=2.11.0
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Go/go1.15.6 (amd64-linux) go-autorest/v14.1.1 k8sinfra-generated
+    url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx?api-version=2015-04-08
+    method: GET
+  response:
+    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx","name":"k8sinfratestdbhmayhx","location":"West US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2021-01-21T23:45:30.2444381Z"},"properties":{"provisioningState":"Deleting","documentEndpoint":"https://k8sinfratestdbhmayhx.documents.azure.com:443/","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"instanceId":"be52cc07-6378-4a29-a5c8-9d7d7a694291","createMode":"Default","databaseAccountOfferType":"Standard","ipRangeFilter":"","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","failoverPriority":0}],"cors":[],"capabilities":[],"backupPolicy":{"type":"Periodic","periodicModeProperties":{"backupIntervalInMinutes":240,"backupRetentionIntervalInHours":8}}}}'
+    headers:
+      Cache-Control:
+      - no-store, no-cache
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 21 Jan 2021 23:53:20 GMT
+      Pragma:
+      - no-cache
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Ms-Gatewayversion:
+      - version=2.11.0
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Go/go1.15.6 (amd64-linux) go-autorest/v14.1.1 k8sinfra-generated
+    url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx?api-version=2015-04-08
+    method: GET
+  response:
+    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx","name":"k8sinfratestdbhmayhx","location":"West US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2021-01-21T23:45:30.2444381Z"},"properties":{"provisioningState":"Deleting","documentEndpoint":"https://k8sinfratestdbhmayhx.documents.azure.com:443/","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"instanceId":"be52cc07-6378-4a29-a5c8-9d7d7a694291","createMode":"Default","databaseAccountOfferType":"Standard","ipRangeFilter":"","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","failoverPriority":0}],"cors":[],"capabilities":[],"backupPolicy":{"type":"Periodic","periodicModeProperties":{"backupIntervalInMinutes":240,"backupRetentionIntervalInHours":8}}}}'
+    headers:
+      Cache-Control:
+      - no-store, no-cache
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 21 Jan 2021 23:53:27 GMT
+      Pragma:
+      - no-cache
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Ms-Gatewayversion:
+      - version=2.11.0
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Go/go1.15.6 (amd64-linux) go-autorest/v14.1.1 k8sinfra-generated
+    url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx?api-version=2015-04-08
+    method: GET
+  response:
+    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx","name":"k8sinfratestdbhmayhx","location":"West US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2021-01-21T23:45:30.2444381Z"},"properties":{"provisioningState":"Deleting","documentEndpoint":"https://k8sinfratestdbhmayhx.documents.azure.com:443/","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"instanceId":"be52cc07-6378-4a29-a5c8-9d7d7a694291","createMode":"Default","databaseAccountOfferType":"Standard","ipRangeFilter":"","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","failoverPriority":0}],"cors":[],"capabilities":[],"backupPolicy":{"type":"Periodic","periodicModeProperties":{"backupIntervalInMinutes":240,"backupRetentionIntervalInHours":8}}}}'
+    headers:
+      Cache-Control:
+      - no-store, no-cache
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 21 Jan 2021 23:53:32 GMT
+      Pragma:
+      - no-cache
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Ms-Gatewayversion:
+      - version=2.11.0
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Go/go1.15.6 (amd64-linux) go-autorest/v14.1.1 k8sinfra-generated
+    url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx?api-version=2015-04-08
+    method: GET
+  response:
+    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx","name":"k8sinfratestdbhmayhx","location":"West US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2021-01-21T23:45:30.2444381Z"},"properties":{"provisioningState":"Deleting","documentEndpoint":"https://k8sinfratestdbhmayhx.documents.azure.com:443/","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"instanceId":"be52cc07-6378-4a29-a5c8-9d7d7a694291","createMode":"Default","databaseAccountOfferType":"Standard","ipRangeFilter":"","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","failoverPriority":0}],"cors":[],"capabilities":[],"backupPolicy":{"type":"Periodic","periodicModeProperties":{"backupIntervalInMinutes":240,"backupRetentionIntervalInHours":8}}}}'
+    headers:
+      Cache-Control:
+      - no-store, no-cache
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 21 Jan 2021 23:53:38 GMT
+      Pragma:
+      - no-cache
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Ms-Gatewayversion:
+      - version=2.11.0
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Go/go1.15.6 (amd64-linux) go-autorest/v14.1.1 k8sinfra-generated
+    url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx?api-version=2015-04-08
+    method: GET
+  response:
+    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx","name":"k8sinfratestdbhmayhx","location":"West US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2021-01-21T23:45:30.2444381Z"},"properties":{"provisioningState":"Deleting","documentEndpoint":"https://k8sinfratestdbhmayhx.documents.azure.com:443/","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"instanceId":"be52cc07-6378-4a29-a5c8-9d7d7a694291","createMode":"Default","databaseAccountOfferType":"Standard","ipRangeFilter":"","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","failoverPriority":0}],"cors":[],"capabilities":[],"backupPolicy":{"type":"Periodic","periodicModeProperties":{"backupIntervalInMinutes":240,"backupRetentionIntervalInHours":8}}}}'
+    headers:
+      Cache-Control:
+      - no-store, no-cache
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 21 Jan 2021 23:53:43 GMT
+      Pragma:
+      - no-cache
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Ms-Gatewayversion:
+      - version=2.11.0
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Go/go1.15.6 (amd64-linux) go-autorest/v14.1.1 k8sinfra-generated
+    url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx?api-version=2015-04-08
+    method: GET
+  response:
+    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx","name":"k8sinfratestdbhmayhx","location":"West US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2021-01-21T23:45:30.2444381Z"},"properties":{"provisioningState":"Deleting","documentEndpoint":"https://k8sinfratestdbhmayhx.documents.azure.com:443/","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"instanceId":"be52cc07-6378-4a29-a5c8-9d7d7a694291","createMode":"Default","databaseAccountOfferType":"Standard","ipRangeFilter":"","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"cors":[],"capabilities":[],"backupPolicy":{"type":"Periodic","periodicModeProperties":{"backupIntervalInMinutes":240,"backupRetentionIntervalInHours":8}}}}'
+    headers:
+      Cache-Control:
+      - no-store, no-cache
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 21 Jan 2021 23:53:49 GMT
+      Pragma:
+      - no-cache
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Ms-Gatewayversion:
+      - version=2.11.0
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Go/go1.15.6 (amd64-linux) go-autorest/v14.1.1 k8sinfra-generated
+    url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx?api-version=2015-04-08
+    method: GET
+  response:
+    body: '{"code":"NotFound","message":"Entity with the specified id does not exist in the system. More info: https://aka.ms/cosmosdb-tsg-not-found\r\nActivityId: 85e9dd78-5cfb-48f4-b42f-45b48e070436, Microsoft.Azure.Documents.Common/2.11.0"}'
     headers:
       Cache-Control:
       - no-store, no-cache
@@ -3255,7 +3901,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 19 Jan 2021 22:11:28 GMT
+      - Thu, 21 Jan 2021 23:53:55 GMT
       Pragma:
       - no-cache
       Server:
@@ -3280,26 +3926,26 @@ interactions:
     url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx?api-version=2015-04-08
     method: GET
   response:
-    body: '{"code":"NotFound","message":"Entity with the specified id does not exist in the system. More info: https://aka.ms/cosmosdb-tsg-not-found\r\nActivityId: a35be2bd-ff8b-4333-b4dc-85b677e1275f, Microsoft.Azure.Documents.Common/2.11.0"}'
+    body: '{"error":{"code":"ResourceNotFound","message":"The Resource ''Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx'' under resource group ''k8sinfratest-rg-dnhfns'' was not found. For more details please go to https://aka.ms/ARMResourceNotFoundFix"}}'
     headers:
       Cache-Control:
-      - no-store, no-cache
+      - no-cache
       Content-Length:
-      - "232"
+      - "252"
       Content-Type:
-      - application/json
+      - application/json; charset=utf-8
       Date:
-      - Tue, 19 Jan 2021 22:11:33 GMT
+      - Thu, 21 Jan 2021 23:53:58 GMT
+      Expires:
+      - "-1"
       Pragma:
       - no-cache
-      Server:
-      - Microsoft-HTTPAPI/2.0
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Content-Type-Options:
       - nosniff
-      X-Ms-Gatewayversion:
-      - version=2.11.0
+      X-Ms-Failure-Cause:
+      - gateway
     status: 404 Not Found
     code: 404
     duration: ""

--- a/hack/generated/controllers/recordings/Test_ResourceGroup_CRUD.yaml
+++ b/hack/generated/controllers/recordings/Test_ResourceGroup_CRUD.yaml
@@ -2,28 +2,28 @@
 version: 1
 interactions:
 - request:
-    body: '{"name":"k8s_390d4616-0b35-57d1-93a0-7d00b1542d93","location":"westus","Properties":{"Error":null,"debugSetting":{"detailLevel":"requestContent,responseContent"},"mode":"Incremental","template":{"$schema":"https://schema.management.azure.com/schemas/2018-05-01/subscriptionDeploymentTemplate.json#","contentVersion":"1.0.0.0","resources":[{"apiVersion":"2020-06-01","name":"k8sinfratest-rg-qwiiib","location":"westus","tags":{"CreatedAt":"2020-11-09T23:02:58Z"},"type":"Microsoft.Resources/resourceGroups"}],"outputs":{"resourceId":{"type":"string","value":"[resourceId(''Microsoft.Resources/resourceGroups'', ''k8sinfratest-rg-qwiiib'')]"}}}}}'
+    body: '{"name":"k8s_390d4616-0b35-57d1-93a0-7d00b1542d93","location":"westus","Properties":{"Error":null,"debugSetting":{"detailLevel":"requestContent,responseContent"},"mode":"Incremental","template":{"$schema":"https://schema.management.azure.com/schemas/2018-05-01/subscriptionDeploymentTemplate.json#","contentVersion":"1.0.0.0","resources":[{"apiVersion":"2020-06-01","name":"k8sinfratest-rg-qwiiib","location":"westus","tags":{"CreatedAt":"2021-01-21T23:44:14Z"},"type":"Microsoft.Resources/resourceGroups"}],"outputs":{"resourceId":{"type":"string","value":"[resourceId(''Microsoft.Resources/resourceGroups'', ''k8sinfratest-rg-qwiiib'')]"}}}}}'
     form: {}
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - Go/go1.15.3 (amd64-linux) go-autorest/v14.1.1 k8sinfra-generated
+      - Go/go1.15.6 (amd64-linux) go-autorest/v14.1.1 k8sinfra-generated
     url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Resources/deployments/k8s_390d4616-0b35-57d1-93a0-7d00b1542d93?api-version=2019-10-01
     method: PUT
   response:
-    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Resources/deployments/k8s_390d4616-0b35-57d1-93a0-7d00b1542d93","name":"k8s_390d4616-0b35-57d1-93a0-7d00b1542d93","type":"Microsoft.Resources/deployments","location":"westus","properties":{"templateHash":"12505706662404897757","mode":"Incremental","debugSetting":{"detailLevel":"RequestContent, ResponseContent"},"provisioningState":"Accepted","timestamp":"2020-11-09T23:03:01.6167146Z","duration":"PT3.7120895S","correlationId":"a83c7c07-0b2b-4081-9038-896bc7ed274a","providers":[{"namespace":"Microsoft.Resources","resourceTypes":[{"resourceType":"resourceGroups","locations":["westus"]}]}],"dependencies":[]}}'
+    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Resources/deployments/k8s_390d4616-0b35-57d1-93a0-7d00b1542d93","name":"k8s_390d4616-0b35-57d1-93a0-7d00b1542d93","type":"Microsoft.Resources/deployments","location":"westus","properties":{"templateHash":"5128840256894583251","mode":"Incremental","debugSetting":{"detailLevel":"RequestContent, ResponseContent"},"provisioningState":"Accepted","timestamp":"2021-01-21T23:44:24.7341525Z","duration":"PT4.4302615S","correlationId":"d6b76128-f5ac-4e99-b953-e4bf7572c929","providers":[{"namespace":"Microsoft.Resources","resourceTypes":[{"resourceType":"resourceGroups","locations":["westus"]}]}],"dependencies":[]}}'
     headers:
       Azure-Asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Resources/deployments/k8s_390d4616-0b35-57d1-93a0-7d00b1542d93/operationStatuses/08585966439075729939?api-version=2019-10-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Resources/deployments/k8s_390d4616-0b35-57d1-93a0-7d00b1542d93/operationStatuses/08585903342251737096?api-version=2019-10-01
       Cache-Control:
       - no-cache
       Content-Length:
-      - "691"
+      - "690"
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Mon, 09 Nov 2020 23:03:01 GMT
+      - Thu, 21 Jan 2021 23:44:25 GMT
       Expires:
       - "-1"
       Pragma:
@@ -42,18 +42,18 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - Go/go1.15.3 (amd64-linux) go-autorest/v14.1.1 k8sinfra-generated
+      - Go/go1.15.6 (amd64-linux) go-autorest/v14.1.1 k8sinfra-generated
     url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Resources/deployments/k8s_390d4616-0b35-57d1-93a0-7d00b1542d93?api-version=2019-10-01
     method: GET
   response:
-    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Resources/deployments/k8s_390d4616-0b35-57d1-93a0-7d00b1542d93","name":"k8s_390d4616-0b35-57d1-93a0-7d00b1542d93","type":"Microsoft.Resources/deployments","location":"westus","properties":{"templateHash":"12505706662404897757","mode":"Incremental","debugSetting":{"detailLevel":"RequestContent, ResponseContent"},"provisioningState":"Accepted","timestamp":"2020-11-09T23:03:01.6167146Z","duration":"PT3.7120895S","correlationId":"a83c7c07-0b2b-4081-9038-896bc7ed274a","providers":[{"namespace":"Microsoft.Resources","resourceTypes":[{"resourceType":"resourceGroups","locations":["westus"]}]}],"dependencies":[]}}'
+    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Resources/deployments/k8s_390d4616-0b35-57d1-93a0-7d00b1542d93","name":"k8s_390d4616-0b35-57d1-93a0-7d00b1542d93","type":"Microsoft.Resources/deployments","location":"westus","properties":{"templateHash":"5128840256894583251","mode":"Incremental","debugSetting":{"detailLevel":"RequestContent, ResponseContent"},"provisioningState":"Running","timestamp":"2021-01-21T23:44:25.7461519Z","duration":"PT5.4422609S","correlationId":"d6b76128-f5ac-4e99-b953-e4bf7572c929","providers":[{"namespace":"Microsoft.Resources","resourceTypes":[{"resourceType":"resourceGroups","locations":["westus"]}]}],"dependencies":[]}}'
     headers:
       Cache-Control:
       - no-cache
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Mon, 09 Nov 2020 23:03:02 GMT
+      - Thu, 21 Jan 2021 23:44:25 GMT
       Expires:
       - "-1"
       Pragma:
@@ -76,18 +76,18 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - Go/go1.15.3 (amd64-linux) go-autorest/v14.1.1 k8sinfra-generated
+      - Go/go1.15.6 (amd64-linux) go-autorest/v14.1.1 k8sinfra-generated
     url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Resources/deployments/k8s_390d4616-0b35-57d1-93a0-7d00b1542d93?api-version=2019-10-01
     method: GET
   response:
-    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Resources/deployments/k8s_390d4616-0b35-57d1-93a0-7d00b1542d93","name":"k8s_390d4616-0b35-57d1-93a0-7d00b1542d93","type":"Microsoft.Resources/deployments","location":"westus","properties":{"templateHash":"12505706662404897757","mode":"Incremental","debugSetting":{"detailLevel":"RequestContent, ResponseContent"},"provisioningState":"Running","timestamp":"2020-11-09T23:03:03.0634532Z","duration":"PT5.1588281S","correlationId":"a83c7c07-0b2b-4081-9038-896bc7ed274a","providers":[{"namespace":"Microsoft.Resources","resourceTypes":[{"resourceType":"resourceGroups","locations":["westus"]}]}],"dependencies":[]}}'
+    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Resources/deployments/k8s_390d4616-0b35-57d1-93a0-7d00b1542d93","name":"k8s_390d4616-0b35-57d1-93a0-7d00b1542d93","type":"Microsoft.Resources/deployments","location":"westus","properties":{"templateHash":"5128840256894583251","mode":"Incremental","debugSetting":{"detailLevel":"RequestContent, ResponseContent"},"provisioningState":"Running","timestamp":"2021-01-21T23:44:25.7461519Z","duration":"PT5.4422609S","correlationId":"d6b76128-f5ac-4e99-b953-e4bf7572c929","providers":[{"namespace":"Microsoft.Resources","resourceTypes":[{"resourceType":"resourceGroups","locations":["westus"]}]}],"dependencies":[]}}'
     headers:
       Cache-Control:
       - no-cache
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Mon, 09 Nov 2020 23:03:07 GMT
+      - Thu, 21 Jan 2021 23:44:25 GMT
       Expires:
       - "-1"
       Pragma:
@@ -110,18 +110,18 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - Go/go1.15.3 (amd64-linux) go-autorest/v14.1.1 k8sinfra-generated
+      - Go/go1.15.6 (amd64-linux) go-autorest/v14.1.1 k8sinfra-generated
     url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Resources/deployments/k8s_390d4616-0b35-57d1-93a0-7d00b1542d93?api-version=2019-10-01
     method: GET
   response:
-    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Resources/deployments/k8s_390d4616-0b35-57d1-93a0-7d00b1542d93","name":"k8s_390d4616-0b35-57d1-93a0-7d00b1542d93","type":"Microsoft.Resources/deployments","location":"westus","properties":{"templateHash":"12505706662404897757","mode":"Incremental","debugSetting":{"detailLevel":"RequestContent, ResponseContent"},"provisioningState":"Running","timestamp":"2020-11-09T23:03:03.0634532Z","duration":"PT5.1588281S","correlationId":"a83c7c07-0b2b-4081-9038-896bc7ed274a","providers":[{"namespace":"Microsoft.Resources","resourceTypes":[{"resourceType":"resourceGroups","locations":["westus"]}]}],"dependencies":[]}}'
+    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Resources/deployments/k8s_390d4616-0b35-57d1-93a0-7d00b1542d93","name":"k8s_390d4616-0b35-57d1-93a0-7d00b1542d93","type":"Microsoft.Resources/deployments","location":"westus","properties":{"templateHash":"5128840256894583251","mode":"Incremental","debugSetting":{"detailLevel":"RequestContent, ResponseContent"},"provisioningState":"Running","timestamp":"2021-01-21T23:44:25.7461519Z","duration":"PT5.4422609S","correlationId":"d6b76128-f5ac-4e99-b953-e4bf7572c929","providers":[{"namespace":"Microsoft.Resources","resourceTypes":[{"resourceType":"resourceGroups","locations":["westus"]}]}],"dependencies":[]}}'
     headers:
       Cache-Control:
       - no-cache
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Mon, 09 Nov 2020 23:03:07 GMT
+      - Thu, 21 Jan 2021 23:44:30 GMT
       Expires:
       - "-1"
       Pragma:
@@ -144,18 +144,18 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - Go/go1.15.3 (amd64-linux) go-autorest/v14.1.1 k8sinfra-generated
+      - Go/go1.15.6 (amd64-linux) go-autorest/v14.1.1 k8sinfra-generated
     url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Resources/deployments/k8s_390d4616-0b35-57d1-93a0-7d00b1542d93?api-version=2019-10-01
     method: GET
   response:
-    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Resources/deployments/k8s_390d4616-0b35-57d1-93a0-7d00b1542d93","name":"k8s_390d4616-0b35-57d1-93a0-7d00b1542d93","type":"Microsoft.Resources/deployments","location":"westus","properties":{"templateHash":"12505706662404897757","mode":"Incremental","debugSetting":{"detailLevel":"RequestContent, ResponseContent"},"provisioningState":"Succeeded","timestamp":"2020-11-09T23:03:12.4530468Z","duration":"PT14.5484217S","correlationId":"a83c7c07-0b2b-4081-9038-896bc7ed274a","providers":[{"namespace":"Microsoft.Resources","resourceTypes":[{"resourceType":"resourceGroups","locations":["westus"]}]}],"dependencies":[],"outputs":{"resourceId":{"type":"String","value":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Resources/resourceGroups/k8sinfratest-rg-qwiiib"}},"outputResources":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-qwiiib"}]}}'
+    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Resources/deployments/k8s_390d4616-0b35-57d1-93a0-7d00b1542d93","name":"k8s_390d4616-0b35-57d1-93a0-7d00b1542d93","type":"Microsoft.Resources/deployments","location":"westus","properties":{"templateHash":"5128840256894583251","mode":"Incremental","debugSetting":{"detailLevel":"RequestContent, ResponseContent"},"provisioningState":"Succeeded","timestamp":"2021-01-21T23:44:30.953782Z","duration":"PT10.649891S","correlationId":"d6b76128-f5ac-4e99-b953-e4bf7572c929","providers":[{"namespace":"Microsoft.Resources","resourceTypes":[{"resourceType":"resourceGroups","locations":["westus"]}]}],"dependencies":[],"outputs":{"resourceId":{"type":"String","value":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Resources/resourceGroups/k8sinfratest-rg-qwiiib"}},"outputResources":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-qwiiib"}]}}'
     headers:
       Cache-Control:
       - no-cache
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Mon, 09 Nov 2020 23:03:12 GMT
+      - Thu, 21 Jan 2021 23:44:35 GMT
       Expires:
       - "-1"
       Pragma:
@@ -176,18 +176,18 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - Go/go1.15.3 (amd64-linux) go-autorest/v14.1.1 k8sinfra-generated
+      - Go/go1.15.6 (amd64-linux) go-autorest/v14.1.1 k8sinfra-generated
     url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-qwiiib?api-version=2020-06-01
     method: GET
   response:
-    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-qwiiib","name":"k8sinfratest-rg-qwiiib","type":"Microsoft.Resources/resourceGroups","location":"westus","tags":{"CreatedAt":"2020-11-09T23:02:58Z"},"properties":{"provisioningState":"Succeeded"}}'
+    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-qwiiib","name":"k8sinfratest-rg-qwiiib","type":"Microsoft.Resources/resourceGroups","location":"westus","tags":{"CreatedAt":"2021-01-21T23:44:14Z"},"properties":{"provisioningState":"Succeeded"}}'
     headers:
       Cache-Control:
       - no-cache
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Mon, 09 Nov 2020 23:03:12 GMT
+      - Thu, 21 Jan 2021 23:44:35 GMT
       Expires:
       - "-1"
       Pragma:
@@ -208,7 +208,7 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - Go/go1.15.3 (amd64-linux) go-autorest/v14.1.1 k8sinfra-generated
+      - Go/go1.15.6 (amd64-linux) go-autorest/v14.1.1 k8sinfra-generated
     url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Resources/deployments/k8s_390d4616-0b35-57d1-93a0-7d00b1542d93?api-version=2019-10-01
     method: DELETE
   response:
@@ -219,11 +219,47 @@ interactions:
       Content-Length:
       - "0"
       Date:
-      - Mon, 09 Nov 2020 23:03:14 GMT
+      - Thu, 21 Jan 2021 23:44:37 GMT
       Expires:
       - "-1"
       Location:
       - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/operationresults/eyJqb2JJZCI6IkRlcGxveW1lbnREZWxldGlvbkpvYi1HTlMtLUs4Uzo1RjM5MEQ0NjE2OjJEMEIzNToyRDU3RDE6MkQ5M0EwOjJEN0QwMEIxNTQyRDkzLSIsImpvYkxvY2F0aW9uIjoid2VzdHVzIn0?api-version=2019-10-01
+      Pragma:
+      - no-cache
+      Retry-After:
+      - "15"
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      X-Ms-Ratelimit-Remaining-Subscription-Deletes:
+      - "14997"
+    status: 202 Accepted
+    code: 202
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Go/go1.15.6 (amd64-linux) go-autorest/v14.1.1 k8sinfra-generated
+    url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-qwiiib?api-version=2020-06-01
+    method: DELETE
+  response:
+    body: ""
+    headers:
+      Cache-Control:
+      - no-cache
+      Content-Length:
+      - "0"
+      Date:
+      - Thu, 21 Jan 2021 23:44:40 GMT
+      Expires:
+      - "-1"
+      Location:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/operationresults/eyJqb2JJZCI6IlJFU09VUkNFR1JPVVBERUxFVElPTkpPQi1LOFNJTkZSQVRFU1Q6MkRSRzoyRFFXSUlJQi1XRVNUVVMiLCJqb2JMb2NhdGlvbiI6Indlc3R1cyJ9?api-version=2020-06-01
       Pragma:
       - no-cache
       Retry-After:
@@ -244,54 +280,18 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - Go/go1.15.3 (amd64-linux) go-autorest/v14.1.1 k8sinfra-generated
-    url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-qwiiib?api-version=2020-06-01
-    method: DELETE
-  response:
-    body: ""
-    headers:
-      Cache-Control:
-      - no-cache
-      Content-Length:
-      - "0"
-      Date:
-      - Mon, 09 Nov 2020 23:03:18 GMT
-      Expires:
-      - "-1"
-      Location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/operationresults/eyJqb2JJZCI6IlJFU09VUkNFR1JPVVBERUxFVElPTkpPQi1LOFNJTkZSQVRFU1Q6MkRSRzoyRFFXSUlJQi1XRVNUVVMiLCJqb2JMb2NhdGlvbiI6Indlc3R1cyJ9?api-version=2020-06-01
-      Pragma:
-      - no-cache
-      Retry-After:
-      - "15"
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Content-Type-Options:
-      - nosniff
-      X-Ms-Ratelimit-Remaining-Subscription-Deletes:
-      - "14995"
-    status: 202 Accepted
-    code: 202
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - Go/go1.15.3 (amd64-linux) go-autorest/v14.1.1 k8sinfra-generated
+      - Go/go1.15.6 (amd64-linux) go-autorest/v14.1.1 k8sinfra-generated
     url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-qwiiib?api-version=2020-06-01
     method: GET
   response:
-    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-qwiiib","name":"k8sinfratest-rg-qwiiib","type":"Microsoft.Resources/resourceGroups","location":"westus","tags":{"CreatedAt":"2020-11-09T23:02:58Z"},"properties":{"provisioningState":"Deleting"}}'
+    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-qwiiib","name":"k8sinfratest-rg-qwiiib","type":"Microsoft.Resources/resourceGroups","location":"westus","tags":{"CreatedAt":"2021-01-21T23:44:14Z"},"properties":{"provisioningState":"Deleting"}}'
     headers:
       Cache-Control:
       - no-cache
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Mon, 09 Nov 2020 23:03:18 GMT
+      - Thu, 21 Jan 2021 23:44:40 GMT
       Expires:
       - "-1"
       Pragma:
@@ -312,18 +312,18 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - Go/go1.15.3 (amd64-linux) go-autorest/v14.1.1 k8sinfra-generated
+      - Go/go1.15.6 (amd64-linux) go-autorest/v14.1.1 k8sinfra-generated
     url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-qwiiib?api-version=2020-06-01
     method: GET
   response:
-    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-qwiiib","name":"k8sinfratest-rg-qwiiib","type":"Microsoft.Resources/resourceGroups","location":"westus","tags":{"CreatedAt":"2020-11-09T23:02:58Z"},"properties":{"provisioningState":"Deleting"}}'
+    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-qwiiib","name":"k8sinfratest-rg-qwiiib","type":"Microsoft.Resources/resourceGroups","location":"westus","tags":{"CreatedAt":"2021-01-21T23:44:14Z"},"properties":{"provisioningState":"Deleting"}}'
     headers:
       Cache-Control:
       - no-cache
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Mon, 09 Nov 2020 23:03:23 GMT
+      - Thu, 21 Jan 2021 23:44:45 GMT
       Expires:
       - "-1"
       Pragma:
@@ -344,18 +344,18 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - Go/go1.15.3 (amd64-linux) go-autorest/v14.1.1 k8sinfra-generated
+      - Go/go1.15.6 (amd64-linux) go-autorest/v14.1.1 k8sinfra-generated
     url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-qwiiib?api-version=2020-06-01
     method: GET
   response:
-    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-qwiiib","name":"k8sinfratest-rg-qwiiib","type":"Microsoft.Resources/resourceGroups","location":"westus","tags":{"CreatedAt":"2020-11-09T23:02:58Z"},"properties":{"provisioningState":"Deleting"}}'
+    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-qwiiib","name":"k8sinfratest-rg-qwiiib","type":"Microsoft.Resources/resourceGroups","location":"westus","tags":{"CreatedAt":"2021-01-21T23:44:14Z"},"properties":{"provisioningState":"Deleting"}}'
     headers:
       Cache-Control:
       - no-cache
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Mon, 09 Nov 2020 23:03:28 GMT
+      - Thu, 21 Jan 2021 23:44:50 GMT
       Expires:
       - "-1"
       Pragma:
@@ -376,18 +376,18 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - Go/go1.15.3 (amd64-linux) go-autorest/v14.1.1 k8sinfra-generated
+      - Go/go1.15.6 (amd64-linux) go-autorest/v14.1.1 k8sinfra-generated
     url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-qwiiib?api-version=2020-06-01
     method: GET
   response:
-    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-qwiiib","name":"k8sinfratest-rg-qwiiib","type":"Microsoft.Resources/resourceGroups","location":"westus","tags":{"CreatedAt":"2020-11-09T23:02:58Z"},"properties":{"provisioningState":"Deleting"}}'
+    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-qwiiib","name":"k8sinfratest-rg-qwiiib","type":"Microsoft.Resources/resourceGroups","location":"westus","tags":{"CreatedAt":"2021-01-21T23:44:14Z"},"properties":{"provisioningState":"Deleting"}}'
     headers:
       Cache-Control:
       - no-cache
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Mon, 09 Nov 2020 23:03:33 GMT
+      - Thu, 21 Jan 2021 23:44:55 GMT
       Expires:
       - "-1"
       Pragma:
@@ -408,18 +408,18 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - Go/go1.15.3 (amd64-linux) go-autorest/v14.1.1 k8sinfra-generated
+      - Go/go1.15.6 (amd64-linux) go-autorest/v14.1.1 k8sinfra-generated
     url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-qwiiib?api-version=2020-06-01
     method: GET
   response:
-    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-qwiiib","name":"k8sinfratest-rg-qwiiib","type":"Microsoft.Resources/resourceGroups","location":"westus","tags":{"CreatedAt":"2020-11-09T23:02:58Z"},"properties":{"provisioningState":"Deleting"}}'
+    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-qwiiib","name":"k8sinfratest-rg-qwiiib","type":"Microsoft.Resources/resourceGroups","location":"westus","tags":{"CreatedAt":"2021-01-21T23:44:14Z"},"properties":{"provisioningState":"Deleting"}}'
     headers:
       Cache-Control:
       - no-cache
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Mon, 09 Nov 2020 23:03:38 GMT
+      - Thu, 21 Jan 2021 23:45:00 GMT
       Expires:
       - "-1"
       Pragma:
@@ -440,18 +440,18 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - Go/go1.15.3 (amd64-linux) go-autorest/v14.1.1 k8sinfra-generated
+      - Go/go1.15.6 (amd64-linux) go-autorest/v14.1.1 k8sinfra-generated
     url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-qwiiib?api-version=2020-06-01
     method: GET
   response:
-    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-qwiiib","name":"k8sinfratest-rg-qwiiib","type":"Microsoft.Resources/resourceGroups","location":"westus","tags":{"CreatedAt":"2020-11-09T23:02:58Z"},"properties":{"provisioningState":"Deleting"}}'
+    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-qwiiib","name":"k8sinfratest-rg-qwiiib","type":"Microsoft.Resources/resourceGroups","location":"westus","tags":{"CreatedAt":"2021-01-21T23:44:14Z"},"properties":{"provisioningState":"Deleting"}}'
     headers:
       Cache-Control:
       - no-cache
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Mon, 09 Nov 2020 23:03:43 GMT
+      - Thu, 21 Jan 2021 23:45:05 GMT
       Expires:
       - "-1"
       Pragma:
@@ -472,18 +472,18 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - Go/go1.15.3 (amd64-linux) go-autorest/v14.1.1 k8sinfra-generated
+      - Go/go1.15.6 (amd64-linux) go-autorest/v14.1.1 k8sinfra-generated
     url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-qwiiib?api-version=2020-06-01
     method: GET
   response:
-    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-qwiiib","name":"k8sinfratest-rg-qwiiib","type":"Microsoft.Resources/resourceGroups","location":"westus","tags":{"CreatedAt":"2020-11-09T23:02:58Z"},"properties":{"provisioningState":"Deleting"}}'
+    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-qwiiib","name":"k8sinfratest-rg-qwiiib","type":"Microsoft.Resources/resourceGroups","location":"westus","tags":{"CreatedAt":"2021-01-21T23:44:14Z"},"properties":{"provisioningState":"Deleting"}}'
     headers:
       Cache-Control:
       - no-cache
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Mon, 09 Nov 2020 23:03:49 GMT
+      - Thu, 21 Jan 2021 23:45:10 GMT
       Expires:
       - "-1"
       Pragma:
@@ -504,7 +504,7 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - Go/go1.15.3 (amd64-linux) go-autorest/v14.1.1 k8sinfra-generated
+      - Go/go1.15.6 (amd64-linux) go-autorest/v14.1.1 k8sinfra-generated
     url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-qwiiib?api-version=2020-06-01
     method: GET
   response:
@@ -517,7 +517,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Mon, 09 Nov 2020 23:03:54 GMT
+      - Thu, 21 Jan 2021 23:45:15 GMT
       Expires:
       - "-1"
       Pragma:
@@ -538,7 +538,7 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - Go/go1.15.3 (amd64-linux) go-autorest/v14.1.1 k8sinfra-generated
+      - Go/go1.15.6 (amd64-linux) go-autorest/v14.1.1 k8sinfra-generated
     url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-qwiiib?api-version=2020-06-01
     method: GET
   response:
@@ -551,7 +551,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Mon, 09 Nov 2020 23:03:57 GMT
+      - Thu, 21 Jan 2021 23:45:18 GMT
       Expires:
       - "-1"
       Pragma:

--- a/hack/generated/controllers/recordings/Test_StorageAccount_CRUD.yaml
+++ b/hack/generated/controllers/recordings/Test_StorageAccount_CRUD.yaml
@@ -2,28 +2,28 @@
 version: 1
 interactions:
 - request:
-    body: '{"name":"k8s_1e2aa8d6-8708-5041-983c-bf90493b733e","location":"westus","Properties":{"Error":null,"debugSetting":{"detailLevel":"requestContent,responseContent"},"mode":"Incremental","template":{"$schema":"https://schema.management.azure.com/schemas/2018-05-01/subscriptionDeploymentTemplate.json#","contentVersion":"1.0.0.0","resources":[{"apiVersion":"2020-06-01","name":"k8sinfratest-rg-ewlqsf","location":"westus","tags":{"CreatedAt":"2020-11-23T23:02:01Z"},"type":"Microsoft.Resources/resourceGroups"}],"outputs":{"resourceId":{"type":"string","value":"[resourceId(''Microsoft.Resources/resourceGroups'', ''k8sinfratest-rg-ewlqsf'')]"}}}}}'
+    body: '{"name":"k8s_1e2aa8d6-8708-5041-983c-bf90493b733e","location":"westus","Properties":{"Error":null,"debugSetting":{"detailLevel":"requestContent,responseContent"},"mode":"Incremental","template":{"$schema":"https://schema.management.azure.com/schemas/2018-05-01/subscriptionDeploymentTemplate.json#","contentVersion":"1.0.0.0","resources":[{"apiVersion":"2020-06-01","name":"k8sinfratest-rg-ewlqsf","location":"westus","tags":{"CreatedAt":"2021-01-21T23:44:14Z"},"type":"Microsoft.Resources/resourceGroups"}],"outputs":{"resourceId":{"type":"string","value":"[resourceId(''Microsoft.Resources/resourceGroups'', ''k8sinfratest-rg-ewlqsf'')]"}}}}}'
     form: {}
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - Go/go1.15.5 (amd64-linux) go-autorest/v14.1.1 k8sinfra-generated
+      - Go/go1.15.6 (amd64-linux) go-autorest/v14.1.1 k8sinfra-generated
     url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Resources/deployments/k8s_1e2aa8d6-8708-5041-983c-bf90493b733e?api-version=2019-10-01
     method: PUT
   response:
-    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Resources/deployments/k8s_1e2aa8d6-8708-5041-983c-bf90493b733e","name":"k8s_1e2aa8d6-8708-5041-983c-bf90493b733e","type":"Microsoft.Resources/deployments","location":"westus","properties":{"templateHash":"1502682588162038360","mode":"Incremental","debugSetting":{"detailLevel":"RequestContent, ResponseContent"},"provisioningState":"Accepted","timestamp":"2020-11-23T23:02:09.747369Z","duration":"PT3.7278781S","correlationId":"66f602ac-1001-47c5-9e49-afbc6a9bae19","providers":[{"namespace":"Microsoft.Resources","resourceTypes":[{"resourceType":"resourceGroups","locations":["westus"]}]}],"dependencies":[]}}'
+    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Resources/deployments/k8s_1e2aa8d6-8708-5041-983c-bf90493b733e","name":"k8s_1e2aa8d6-8708-5041-983c-bf90493b733e","type":"Microsoft.Resources/deployments","location":"westus","properties":{"templateHash":"13595365891663933550","mode":"Incremental","debugSetting":{"detailLevel":"RequestContent, ResponseContent"},"provisioningState":"Accepted","timestamp":"2021-01-21T23:44:24.6184114Z","duration":"PT4.3147732S","correlationId":"488e77fc-cef6-42ab-b42e-e88c3134da33","providers":[{"namespace":"Microsoft.Resources","resourceTypes":[{"resourceType":"resourceGroups","locations":["westus"]}]}],"dependencies":[]}}'
     headers:
       Azure-Asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Resources/deployments/k8s_1e2aa8d6-8708-5041-983c-bf90493b733e/operationStatuses/08585954343594581152?api-version=2019-10-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Resources/deployments/k8s_1e2aa8d6-8708-5041-983c-bf90493b733e/operationStatuses/08585903342251739651?api-version=2019-10-01
       Cache-Control:
       - no-cache
       Content-Length:
-      - "689"
+      - "691"
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Mon, 23 Nov 2020 23:02:10 GMT
+      - Thu, 21 Jan 2021 23:44:25 GMT
       Expires:
       - "-1"
       Pragma:
@@ -42,18 +42,18 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - Go/go1.15.5 (amd64-linux) go-autorest/v14.1.1 k8sinfra-generated
+      - Go/go1.15.6 (amd64-linux) go-autorest/v14.1.1 k8sinfra-generated
     url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Resources/deployments/k8s_1e2aa8d6-8708-5041-983c-bf90493b733e?api-version=2019-10-01
     method: GET
   response:
-    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Resources/deployments/k8s_1e2aa8d6-8708-5041-983c-bf90493b733e","name":"k8s_1e2aa8d6-8708-5041-983c-bf90493b733e","type":"Microsoft.Resources/deployments","location":"westus","properties":{"templateHash":"1502682588162038360","mode":"Incremental","debugSetting":{"detailLevel":"RequestContent, ResponseContent"},"provisioningState":"Accepted","timestamp":"2020-11-23T23:02:09.747369Z","duration":"PT3.7278781S","correlationId":"66f602ac-1001-47c5-9e49-afbc6a9bae19","providers":[{"namespace":"Microsoft.Resources","resourceTypes":[{"resourceType":"resourceGroups","locations":["westus"]}]}],"dependencies":[]}}'
+    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Resources/deployments/k8s_1e2aa8d6-8708-5041-983c-bf90493b733e","name":"k8s_1e2aa8d6-8708-5041-983c-bf90493b733e","type":"Microsoft.Resources/deployments","location":"westus","properties":{"templateHash":"13595365891663933550","mode":"Incremental","debugSetting":{"detailLevel":"RequestContent, ResponseContent"},"provisioningState":"Accepted","timestamp":"2021-01-21T23:44:24.6184114Z","duration":"PT4.3147732S","correlationId":"488e77fc-cef6-42ab-b42e-e88c3134da33","providers":[{"namespace":"Microsoft.Resources","resourceTypes":[{"resourceType":"resourceGroups","locations":["westus"]}]}],"dependencies":[]}}'
     headers:
       Cache-Control:
       - no-cache
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Mon, 23 Nov 2020 23:02:10 GMT
+      - Thu, 21 Jan 2021 23:44:25 GMT
       Expires:
       - "-1"
       Pragma:
@@ -76,18 +76,18 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - Go/go1.15.5 (amd64-linux) go-autorest/v14.1.1 k8sinfra-generated
+      - Go/go1.15.6 (amd64-linux) go-autorest/v14.1.1 k8sinfra-generated
     url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Resources/deployments/k8s_1e2aa8d6-8708-5041-983c-bf90493b733e?api-version=2019-10-01
     method: GET
   response:
-    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Resources/deployments/k8s_1e2aa8d6-8708-5041-983c-bf90493b733e","name":"k8s_1e2aa8d6-8708-5041-983c-bf90493b733e","type":"Microsoft.Resources/deployments","location":"westus","properties":{"templateHash":"1502682588162038360","mode":"Incremental","debugSetting":{"detailLevel":"RequestContent, ResponseContent"},"provisioningState":"Running","timestamp":"2020-11-23T23:02:10.897269Z","duration":"PT4.8777781S","correlationId":"66f602ac-1001-47c5-9e49-afbc6a9bae19","providers":[{"namespace":"Microsoft.Resources","resourceTypes":[{"resourceType":"resourceGroups","locations":["westus"]}]}],"dependencies":[]}}'
+    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Resources/deployments/k8s_1e2aa8d6-8708-5041-983c-bf90493b733e","name":"k8s_1e2aa8d6-8708-5041-983c-bf90493b733e","type":"Microsoft.Resources/deployments","location":"westus","properties":{"templateHash":"13595365891663933550","mode":"Incremental","debugSetting":{"detailLevel":"RequestContent, ResponseContent"},"provisioningState":"Running","timestamp":"2021-01-21T23:44:25.9167545Z","duration":"PT5.6131163S","correlationId":"488e77fc-cef6-42ab-b42e-e88c3134da33","providers":[{"namespace":"Microsoft.Resources","resourceTypes":[{"resourceType":"resourceGroups","locations":["westus"]}]}],"dependencies":[]}}'
     headers:
       Cache-Control:
       - no-cache
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Mon, 23 Nov 2020 23:02:15 GMT
+      - Thu, 21 Jan 2021 23:44:30 GMT
       Expires:
       - "-1"
       Pragma:
@@ -110,18 +110,18 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - Go/go1.15.5 (amd64-linux) go-autorest/v14.1.1 k8sinfra-generated
+      - Go/go1.15.6 (amd64-linux) go-autorest/v14.1.1 k8sinfra-generated
     url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Resources/deployments/k8s_1e2aa8d6-8708-5041-983c-bf90493b733e?api-version=2019-10-01
     method: GET
   response:
-    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Resources/deployments/k8s_1e2aa8d6-8708-5041-983c-bf90493b733e","name":"k8s_1e2aa8d6-8708-5041-983c-bf90493b733e","type":"Microsoft.Resources/deployments","location":"westus","properties":{"templateHash":"1502682588162038360","mode":"Incremental","debugSetting":{"detailLevel":"RequestContent, ResponseContent"},"provisioningState":"Running","timestamp":"2020-11-23T23:02:10.897269Z","duration":"PT4.8777781S","correlationId":"66f602ac-1001-47c5-9e49-afbc6a9bae19","providers":[{"namespace":"Microsoft.Resources","resourceTypes":[{"resourceType":"resourceGroups","locations":["westus"]}]}],"dependencies":[]}}'
+    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Resources/deployments/k8s_1e2aa8d6-8708-5041-983c-bf90493b733e","name":"k8s_1e2aa8d6-8708-5041-983c-bf90493b733e","type":"Microsoft.Resources/deployments","location":"westus","properties":{"templateHash":"13595365891663933550","mode":"Incremental","debugSetting":{"detailLevel":"RequestContent, ResponseContent"},"provisioningState":"Running","timestamp":"2021-01-21T23:44:25.9167545Z","duration":"PT5.6131163S","correlationId":"488e77fc-cef6-42ab-b42e-e88c3134da33","providers":[{"namespace":"Microsoft.Resources","resourceTypes":[{"resourceType":"resourceGroups","locations":["westus"]}]}],"dependencies":[]}}'
     headers:
       Cache-Control:
       - no-cache
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Mon, 23 Nov 2020 23:02:15 GMT
+      - Thu, 21 Jan 2021 23:44:30 GMT
       Expires:
       - "-1"
       Pragma:
@@ -144,18 +144,18 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - Go/go1.15.5 (amd64-linux) go-autorest/v14.1.1 k8sinfra-generated
+      - Go/go1.15.6 (amd64-linux) go-autorest/v14.1.1 k8sinfra-generated
     url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Resources/deployments/k8s_1e2aa8d6-8708-5041-983c-bf90493b733e?api-version=2019-10-01
     method: GET
   response:
-    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Resources/deployments/k8s_1e2aa8d6-8708-5041-983c-bf90493b733e","name":"k8s_1e2aa8d6-8708-5041-983c-bf90493b733e","type":"Microsoft.Resources/deployments","location":"westus","properties":{"templateHash":"1502682588162038360","mode":"Incremental","debugSetting":{"detailLevel":"RequestContent, ResponseContent"},"provisioningState":"Succeeded","timestamp":"2020-11-23T23:02:16.9294794Z","duration":"PT10.9099885S","correlationId":"66f602ac-1001-47c5-9e49-afbc6a9bae19","providers":[{"namespace":"Microsoft.Resources","resourceTypes":[{"resourceType":"resourceGroups","locations":["westus"]}]}],"dependencies":[],"outputs":{"resourceId":{"type":"String","value":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Resources/resourceGroups/k8sinfratest-rg-ewlqsf"}},"outputResources":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-ewlqsf"}]}}'
+    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Resources/deployments/k8s_1e2aa8d6-8708-5041-983c-bf90493b733e","name":"k8s_1e2aa8d6-8708-5041-983c-bf90493b733e","type":"Microsoft.Resources/deployments","location":"westus","properties":{"templateHash":"13595365891663933550","mode":"Incremental","debugSetting":{"detailLevel":"RequestContent, ResponseContent"},"provisioningState":"Succeeded","timestamp":"2021-01-21T23:44:35.3534202Z","duration":"PT15.049782S","correlationId":"488e77fc-cef6-42ab-b42e-e88c3134da33","providers":[{"namespace":"Microsoft.Resources","resourceTypes":[{"resourceType":"resourceGroups","locations":["westus"]}]}],"dependencies":[],"outputs":{"resourceId":{"type":"String","value":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Resources/resourceGroups/k8sinfratest-rg-ewlqsf"}},"outputResources":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-ewlqsf"}]}}'
     headers:
       Cache-Control:
       - no-cache
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Mon, 23 Nov 2020 23:02:20 GMT
+      - Thu, 21 Jan 2021 23:44:35 GMT
       Expires:
       - "-1"
       Pragma:
@@ -176,18 +176,18 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - Go/go1.15.5 (amd64-linux) go-autorest/v14.1.1 k8sinfra-generated
+      - Go/go1.15.6 (amd64-linux) go-autorest/v14.1.1 k8sinfra-generated
     url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-ewlqsf?api-version=2020-06-01
     method: GET
   response:
-    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-ewlqsf","name":"k8sinfratest-rg-ewlqsf","type":"Microsoft.Resources/resourceGroups","location":"westus","tags":{"CreatedAt":"2020-11-23T23:02:01Z"},"properties":{"provisioningState":"Succeeded"}}'
+    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-ewlqsf","name":"k8sinfratest-rg-ewlqsf","type":"Microsoft.Resources/resourceGroups","location":"westus","tags":{"CreatedAt":"2021-01-21T23:44:14Z"},"properties":{"provisioningState":"Succeeded"}}'
     headers:
       Cache-Control:
       - no-cache
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Mon, 23 Nov 2020 23:02:20 GMT
+      - Thu, 21 Jan 2021 23:44:35 GMT
       Expires:
       - "-1"
       Pragma:
@@ -208,7 +208,7 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - Go/go1.15.5 (amd64-linux) go-autorest/v14.1.1 k8sinfra-generated
+      - Go/go1.15.6 (amd64-linux) go-autorest/v14.1.1 k8sinfra-generated
     url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Resources/deployments/k8s_1e2aa8d6-8708-5041-983c-bf90493b733e?api-version=2019-10-01
     method: DELETE
   response:
@@ -219,589 +219,11 @@ interactions:
       Content-Length:
       - "0"
       Date:
-      - Mon, 23 Nov 2020 23:02:22 GMT
+      - Thu, 21 Jan 2021 23:44:37 GMT
       Expires:
       - "-1"
       Location:
       - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/operationresults/eyJqb2JJZCI6IkRlcGxveW1lbnREZWxldGlvbkpvYi1HTlMtLUs4Uzo1RjFFMkFBOEQ2OjJEODcwODoyRDUwNDE6MkQ5ODNDOjJEQkY5MDQ5M0I3MzNFLSIsImpvYkxvY2F0aW9uIjoid2VzdHVzIn0?api-version=2019-10-01
-      Pragma:
-      - no-cache
-      Retry-After:
-      - "15"
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Content-Type-Options:
-      - nosniff
-      X-Ms-Ratelimit-Remaining-Subscription-Deletes:
-      - "14999"
-    status: 202 Accepted
-    code: 202
-    duration: ""
-- request:
-    body: '{"name":"k8s_7b4d934c-9181-52e6-912c-67c108a32c3e","Properties":{"Error":null,"debugSetting":{"detailLevel":"requestContent,responseContent"},"mode":"Incremental","template":{"$schema":"https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#","contentVersion":"1.0.0.0","resources":[{"apiVersion":"2019-04-01","kind":"BlobStorage","location":"westus","name":"k8sinfrateststorgiatzw","properties":{"accessTier":"Hot"},"sku":{"name":"Standard_LRS"},"type":"Microsoft.Storage/storageAccounts"}],"outputs":{"resourceId":{"type":"string","value":"[resourceId(''Microsoft.Storage/storageAccounts'', ''k8sinfrateststorgiatzw'')]"}}}}}'
-    form: {}
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - Go/go1.15.5 (amd64-linux) go-autorest/v14.1.1 k8sinfra-generated
-    url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/k8sinfratest-rg-ewlqsf/providers/Microsoft.Resources/deployments/k8s_7b4d934c-9181-52e6-912c-67c108a32c3e?api-version=2019-10-01
-    method: PUT
-  response:
-    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-ewlqsf/providers/Microsoft.Resources/deployments/k8s_7b4d934c-9181-52e6-912c-67c108a32c3e","name":"k8s_7b4d934c-9181-52e6-912c-67c108a32c3e","type":"Microsoft.Resources/deployments","properties":{"templateHash":"10656703011749167364","mode":"Incremental","debugSetting":{"detailLevel":"RequestContent, ResponseContent"},"provisioningState":"Accepted","timestamp":"2020-11-23T23:02:28.2348415Z","duration":"PT0.8462419S","correlationId":"a0d42b0f-8ca1-44d0-a222-d3fdb380bec1","providers":[{"namespace":"Microsoft.Storage","resourceTypes":[{"resourceType":"storageAccounts","locations":["westus"]}]}],"dependencies":[]}}'
-    headers:
-      Azure-Asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/k8sinfratest-rg-ewlqsf/providers/Microsoft.Resources/deployments/k8s_7b4d934c-9181-52e6-912c-67c108a32c3e/operationStatuses/08585954343380890097?api-version=2019-10-01
-      Cache-Control:
-      - no-cache
-      Content-Length:
-      - "708"
-      Content-Type:
-      - application/json; charset=utf-8
-      Date:
-      - Mon, 23 Nov 2020 23:02:28 GMT
-      Expires:
-      - "-1"
-      Pragma:
-      - no-cache
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Content-Type-Options:
-      - nosniff
-    status: 201 Created
-    code: 201
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - Go/go1.15.5 (amd64-linux) go-autorest/v14.1.1 k8sinfra-generated
-    url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-ewlqsf/providers/Microsoft.Resources/deployments/k8s_7b4d934c-9181-52e6-912c-67c108a32c3e?api-version=2019-10-01
-    method: GET
-  response:
-    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-ewlqsf/providers/Microsoft.Resources/deployments/k8s_7b4d934c-9181-52e6-912c-67c108a32c3e","name":"k8s_7b4d934c-9181-52e6-912c-67c108a32c3e","type":"Microsoft.Resources/deployments","properties":{"templateHash":"10656703011749167364","mode":"Incremental","debugSetting":{"detailLevel":"RequestContent, ResponseContent"},"provisioningState":"Accepted","timestamp":"2020-11-23T23:02:28.2348415Z","duration":"PT0.8462419S","correlationId":"a0d42b0f-8ca1-44d0-a222-d3fdb380bec1","providers":[{"namespace":"Microsoft.Storage","resourceTypes":[{"resourceType":"storageAccounts","locations":["westus"]}]}],"dependencies":[]}}'
-    headers:
-      Cache-Control:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Date:
-      - Mon, 23 Nov 2020 23:02:28 GMT
-      Expires:
-      - "-1"
-      Pragma:
-      - no-cache
-      Retry-After:
-      - "5"
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Content-Type-Options:
-      - nosniff
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - Go/go1.15.5 (amd64-linux) go-autorest/v14.1.1 k8sinfra-generated
-    url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-ewlqsf/providers/Microsoft.Resources/deployments/k8s_7b4d934c-9181-52e6-912c-67c108a32c3e?api-version=2019-10-01
-    method: GET
-  response:
-    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-ewlqsf/providers/Microsoft.Resources/deployments/k8s_7b4d934c-9181-52e6-912c-67c108a32c3e","name":"k8s_7b4d934c-9181-52e6-912c-67c108a32c3e","type":"Microsoft.Resources/deployments","properties":{"templateHash":"10656703011749167364","mode":"Incremental","debugSetting":{"detailLevel":"RequestContent, ResponseContent"},"provisioningState":"Running","timestamp":"2020-11-23T23:02:29.3461825Z","duration":"PT1.9575829S","correlationId":"a0d42b0f-8ca1-44d0-a222-d3fdb380bec1","providers":[{"namespace":"Microsoft.Storage","resourceTypes":[{"resourceType":"storageAccounts","locations":["westus"]}]}],"dependencies":[]}}'
-    headers:
-      Cache-Control:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Date:
-      - Mon, 23 Nov 2020 23:02:33 GMT
-      Expires:
-      - "-1"
-      Pragma:
-      - no-cache
-      Retry-After:
-      - "5"
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Content-Type-Options:
-      - nosniff
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - Go/go1.15.5 (amd64-linux) go-autorest/v14.1.1 k8sinfra-generated
-    url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-ewlqsf/providers/Microsoft.Resources/deployments/k8s_7b4d934c-9181-52e6-912c-67c108a32c3e?api-version=2019-10-01
-    method: GET
-  response:
-    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-ewlqsf/providers/Microsoft.Resources/deployments/k8s_7b4d934c-9181-52e6-912c-67c108a32c3e","name":"k8s_7b4d934c-9181-52e6-912c-67c108a32c3e","type":"Microsoft.Resources/deployments","properties":{"templateHash":"10656703011749167364","mode":"Incremental","debugSetting":{"detailLevel":"RequestContent, ResponseContent"},"provisioningState":"Running","timestamp":"2020-11-23T23:02:29.3461825Z","duration":"PT1.9575829S","correlationId":"a0d42b0f-8ca1-44d0-a222-d3fdb380bec1","providers":[{"namespace":"Microsoft.Storage","resourceTypes":[{"resourceType":"storageAccounts","locations":["westus"]}]}],"dependencies":[]}}'
-    headers:
-      Cache-Control:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Date:
-      - Mon, 23 Nov 2020 23:02:34 GMT
-      Expires:
-      - "-1"
-      Pragma:
-      - no-cache
-      Retry-After:
-      - "5"
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Content-Type-Options:
-      - nosniff
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - Go/go1.15.5 (amd64-linux) go-autorest/v14.1.1 k8sinfra-generated
-    url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-ewlqsf/providers/Microsoft.Resources/deployments/k8s_7b4d934c-9181-52e6-912c-67c108a32c3e?api-version=2019-10-01
-    method: GET
-  response:
-    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-ewlqsf/providers/Microsoft.Resources/deployments/k8s_7b4d934c-9181-52e6-912c-67c108a32c3e","name":"k8s_7b4d934c-9181-52e6-912c-67c108a32c3e","type":"Microsoft.Resources/deployments","properties":{"templateHash":"10656703011749167364","mode":"Incremental","debugSetting":{"detailLevel":"RequestContent, ResponseContent"},"provisioningState":"Running","timestamp":"2020-11-23T23:02:38.0358003Z","duration":"PT10.6472007S","correlationId":"a0d42b0f-8ca1-44d0-a222-d3fdb380bec1","providers":[{"namespace":"Microsoft.Storage","resourceTypes":[{"resourceType":"storageAccounts","locations":["westus"]}]}],"dependencies":[]}}'
-    headers:
-      Cache-Control:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Date:
-      - Mon, 23 Nov 2020 23:02:39 GMT
-      Expires:
-      - "-1"
-      Pragma:
-      - no-cache
-      Retry-After:
-      - "17"
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Content-Type-Options:
-      - nosniff
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - Go/go1.15.5 (amd64-linux) go-autorest/v14.1.1 k8sinfra-generated
-    url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-ewlqsf/providers/Microsoft.Resources/deployments/k8s_7b4d934c-9181-52e6-912c-67c108a32c3e?api-version=2019-10-01
-    method: GET
-  response:
-    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-ewlqsf/providers/Microsoft.Resources/deployments/k8s_7b4d934c-9181-52e6-912c-67c108a32c3e","name":"k8s_7b4d934c-9181-52e6-912c-67c108a32c3e","type":"Microsoft.Resources/deployments","properties":{"templateHash":"10656703011749167364","mode":"Incremental","debugSetting":{"detailLevel":"RequestContent, ResponseContent"},"provisioningState":"Running","timestamp":"2020-11-23T23:02:38.0358003Z","duration":"PT10.6472007S","correlationId":"a0d42b0f-8ca1-44d0-a222-d3fdb380bec1","providers":[{"namespace":"Microsoft.Storage","resourceTypes":[{"resourceType":"storageAccounts","locations":["westus"]}]}],"dependencies":[]}}'
-    headers:
-      Cache-Control:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Date:
-      - Mon, 23 Nov 2020 23:02:44 GMT
-      Expires:
-      - "-1"
-      Pragma:
-      - no-cache
-      Retry-After:
-      - "11"
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Content-Type-Options:
-      - nosniff
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - Go/go1.15.5 (amd64-linux) go-autorest/v14.1.1 k8sinfra-generated
-    url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-ewlqsf/providers/Microsoft.Resources/deployments/k8s_7b4d934c-9181-52e6-912c-67c108a32c3e?api-version=2019-10-01
-    method: GET
-  response:
-    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-ewlqsf/providers/Microsoft.Resources/deployments/k8s_7b4d934c-9181-52e6-912c-67c108a32c3e","name":"k8s_7b4d934c-9181-52e6-912c-67c108a32c3e","type":"Microsoft.Resources/deployments","properties":{"templateHash":"10656703011749167364","mode":"Incremental","debugSetting":{"detailLevel":"RequestContent, ResponseContent"},"provisioningState":"Running","timestamp":"2020-11-23T23:02:38.0358003Z","duration":"PT10.6472007S","correlationId":"a0d42b0f-8ca1-44d0-a222-d3fdb380bec1","providers":[{"namespace":"Microsoft.Storage","resourceTypes":[{"resourceType":"storageAccounts","locations":["westus"]}]}],"dependencies":[]}}'
-    headers:
-      Cache-Control:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Date:
-      - Mon, 23 Nov 2020 23:02:49 GMT
-      Expires:
-      - "-1"
-      Pragma:
-      - no-cache
-      Retry-After:
-      - "6"
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Content-Type-Options:
-      - nosniff
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - Go/go1.15.5 (amd64-linux) go-autorest/v14.1.1 k8sinfra-generated
-    url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-ewlqsf/providers/Microsoft.Resources/deployments/k8s_7b4d934c-9181-52e6-912c-67c108a32c3e?api-version=2019-10-01
-    method: GET
-  response:
-    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-ewlqsf/providers/Microsoft.Resources/deployments/k8s_7b4d934c-9181-52e6-912c-67c108a32c3e","name":"k8s_7b4d934c-9181-52e6-912c-67c108a32c3e","type":"Microsoft.Resources/deployments","properties":{"templateHash":"10656703011749167364","mode":"Incremental","debugSetting":{"detailLevel":"RequestContent, ResponseContent"},"provisioningState":"Running","timestamp":"2020-11-23T23:02:38.0358003Z","duration":"PT10.6472007S","correlationId":"a0d42b0f-8ca1-44d0-a222-d3fdb380bec1","providers":[{"namespace":"Microsoft.Storage","resourceTypes":[{"resourceType":"storageAccounts","locations":["westus"]}]}],"dependencies":[]}}'
-    headers:
-      Cache-Control:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Date:
-      - Mon, 23 Nov 2020 23:02:55 GMT
-      Expires:
-      - "-1"
-      Pragma:
-      - no-cache
-      Retry-After:
-      - "5"
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Content-Type-Options:
-      - nosniff
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - Go/go1.15.5 (amd64-linux) go-autorest/v14.1.1 k8sinfra-generated
-    url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-ewlqsf/providers/Microsoft.Resources/deployments/k8s_7b4d934c-9181-52e6-912c-67c108a32c3e?api-version=2019-10-01
-    method: GET
-  response:
-    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-ewlqsf/providers/Microsoft.Resources/deployments/k8s_7b4d934c-9181-52e6-912c-67c108a32c3e","name":"k8s_7b4d934c-9181-52e6-912c-67c108a32c3e","type":"Microsoft.Resources/deployments","properties":{"templateHash":"10656703011749167364","mode":"Incremental","debugSetting":{"detailLevel":"RequestContent, ResponseContent"},"provisioningState":"Running","timestamp":"2020-11-23T23:02:38.0358003Z","duration":"PT10.6472007S","correlationId":"a0d42b0f-8ca1-44d0-a222-d3fdb380bec1","providers":[{"namespace":"Microsoft.Storage","resourceTypes":[{"resourceType":"storageAccounts","locations":["westus"]}]}],"dependencies":[]}}'
-    headers:
-      Cache-Control:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Date:
-      - Mon, 23 Nov 2020 23:03:00 GMT
-      Expires:
-      - "-1"
-      Pragma:
-      - no-cache
-      Retry-After:
-      - "5"
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Content-Type-Options:
-      - nosniff
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - Go/go1.15.5 (amd64-linux) go-autorest/v14.1.1 k8sinfra-generated
-    url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-ewlqsf/providers/Microsoft.Resources/deployments/k8s_7b4d934c-9181-52e6-912c-67c108a32c3e?api-version=2019-10-01
-    method: GET
-  response:
-    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-ewlqsf/providers/Microsoft.Resources/deployments/k8s_7b4d934c-9181-52e6-912c-67c108a32c3e","name":"k8s_7b4d934c-9181-52e6-912c-67c108a32c3e","type":"Microsoft.Resources/deployments","properties":{"templateHash":"10656703011749167364","mode":"Incremental","debugSetting":{"detailLevel":"RequestContent, ResponseContent"},"provisioningState":"Succeeded","timestamp":"2020-11-23T23:03:03.0422947Z","duration":"PT35.6536951S","correlationId":"a0d42b0f-8ca1-44d0-a222-d3fdb380bec1","providers":[{"namespace":"Microsoft.Storage","resourceTypes":[{"resourceType":"storageAccounts","locations":["westus"]}]}],"dependencies":[],"outputs":{"resourceId":{"type":"String","value":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-ewlqsf/providers/Microsoft.Storage/storageAccounts/k8sinfrateststorgiatzw"}},"outputResources":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-ewlqsf/providers/Microsoft.Storage/storageAccounts/k8sinfrateststorgiatzw"}]}}'
-    headers:
-      Cache-Control:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Date:
-      - Mon, 23 Nov 2020 23:03:05 GMT
-      Expires:
-      - "-1"
-      Pragma:
-      - no-cache
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Content-Type-Options:
-      - nosniff
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - Go/go1.15.5 (amd64-linux) go-autorest/v14.1.1 k8sinfra-generated
-    url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-ewlqsf/providers/Microsoft.Storage/storageAccounts/k8sinfrateststorgiatzw?api-version=2019-04-01
-    method: GET
-  response:
-    body: '{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"BlobStorage","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-ewlqsf/providers/Microsoft.Storage/storageAccounts/k8sinfrateststorgiatzw","name":"k8sinfrateststorgiatzw","type":"Microsoft.Storage/storageAccounts","location":"westus","tags":{},"properties":{"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"enabled":true,"lastEnabledTime":"2020-11-23T23:02:36.6194938Z"},"blob":{"enabled":true,"lastEnabledTime":"2020-11-23T23:02:36.6194938Z"}},"keySource":"Microsoft.Storage"},"accessTier":"Hot","provisioningState":"Succeeded","creationTime":"2020-11-23T23:02:36.5257352Z","primaryEndpoints":{"dfs":"https://k8sinfrateststorgiatzw.dfs.core.windows.net/","blob":"https://k8sinfrateststorgiatzw.blob.core.windows.net/","table":"https://k8sinfrateststorgiatzw.table.core.windows.net/"},"primaryLocation":"westus","statusOfPrimary":"available"}}'
-    headers:
-      Cache-Control:
-      - no-cache
-      Content-Type:
-      - application/json
-      Date:
-      - Mon, 23 Nov 2020 23:03:06 GMT
-      Expires:
-      - "-1"
-      Pragma:
-      - no-cache
-      Server:
-      - Microsoft-Azure-Storage-Resource-Provider/1.0,Microsoft-HTTPAPI/2.0 Microsoft-HTTPAPI/2.0
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Content-Type-Options:
-      - nosniff
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - Go/go1.15.5 (amd64-linux) go-autorest/v14.1.1 k8sinfra-generated
-    url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-ewlqsf/providers/Microsoft.Resources/deployments/k8s_7b4d934c-9181-52e6-912c-67c108a32c3e?api-version=2019-10-01
-    method: DELETE
-  response:
-    body: ""
-    headers:
-      Cache-Control:
-      - no-cache
-      Content-Length:
-      - "0"
-      Date:
-      - Mon, 23 Nov 2020 23:03:08 GMT
-      Expires:
-      - "-1"
-      Location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/operationresults/eyJqb2JJZCI6IkRlcGxveW1lbnREZWxldGlvbkpvYi1HTlMtSzhTSU5GUkFURVNUOjJEUkc6MkRFV0xRU0YtSzhTOjVGN0I0RDkzNEM6MkQ5MTgxOjJENTJFNjoyRDkxMkM6MkQ2N0MxMDhBMzJDM0UtIiwiam9iTG9jYXRpb24iOiJ3ZXN0dXMifQ?api-version=2019-10-01
-      Pragma:
-      - no-cache
-      Retry-After:
-      - "15"
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Content-Type-Options:
-      - nosniff
-      X-Ms-Ratelimit-Remaining-Subscription-Deletes:
-      - "14998"
-    status: 202 Accepted
-    code: 202
-    duration: ""
-- request:
-    body: '{"name":"k8s_38cdf7b5-24aa-54c3-87df-f7da086033ef","Properties":{"Error":null,"debugSetting":{"detailLevel":"requestContent,responseContent"},"mode":"Incremental","template":{"$schema":"https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#","contentVersion":"1.0.0.0","resources":[{"apiVersion":"2019-04-01","name":"k8sinfrateststorgiatzw/default","type":"Microsoft.Storage/storageAccounts/blobServices"}],"outputs":{"resourceId":{"type":"string","value":"[resourceId(''Microsoft.Storage/storageAccounts/blobServices'', ''k8sinfrateststorgiatzw'', ''default'')]"}}}}}'
-    form: {}
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - Go/go1.15.5 (amd64-linux) go-autorest/v14.1.1 k8sinfra-generated
-    url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/k8sinfratest-rg-ewlqsf/providers/Microsoft.Resources/deployments/k8s_38cdf7b5-24aa-54c3-87df-f7da086033ef?api-version=2019-10-01
-    method: PUT
-  response:
-    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-ewlqsf/providers/Microsoft.Resources/deployments/k8s_38cdf7b5-24aa-54c3-87df-f7da086033ef","name":"k8s_38cdf7b5-24aa-54c3-87df-f7da086033ef","type":"Microsoft.Resources/deployments","properties":{"templateHash":"14644625414381836457","mode":"Incremental","debugSetting":{"detailLevel":"RequestContent, ResponseContent"},"provisioningState":"Accepted","timestamp":"2020-11-23T23:03:12.1739928Z","duration":"PT0.909065S","correlationId":"50de489d-4027-4df8-9a90-bd3ddfba545b","providers":[{"namespace":"Microsoft.Storage","resourceTypes":[{"resourceType":"storageAccounts/blobServices","locations":[null]}]}],"dependencies":[]}}'
-    headers:
-      Azure-Asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/k8sinfratest-rg-ewlqsf/providers/Microsoft.Resources/deployments/k8s_38cdf7b5-24aa-54c3-87df-f7da086033ef/operationStatuses/08585954342942126813?api-version=2019-10-01
-      Cache-Control:
-      - no-cache
-      Content-Length:
-      - "716"
-      Content-Type:
-      - application/json; charset=utf-8
-      Date:
-      - Mon, 23 Nov 2020 23:03:12 GMT
-      Expires:
-      - "-1"
-      Pragma:
-      - no-cache
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Content-Type-Options:
-      - nosniff
-    status: 201 Created
-    code: 201
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - Go/go1.15.5 (amd64-linux) go-autorest/v14.1.1 k8sinfra-generated
-    url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-ewlqsf/providers/Microsoft.Resources/deployments/k8s_38cdf7b5-24aa-54c3-87df-f7da086033ef?api-version=2019-10-01
-    method: GET
-  response:
-    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-ewlqsf/providers/Microsoft.Resources/deployments/k8s_38cdf7b5-24aa-54c3-87df-f7da086033ef","name":"k8s_38cdf7b5-24aa-54c3-87df-f7da086033ef","type":"Microsoft.Resources/deployments","properties":{"templateHash":"14644625414381836457","mode":"Incremental","debugSetting":{"detailLevel":"RequestContent, ResponseContent"},"provisioningState":"Accepted","timestamp":"2020-11-23T23:03:12.1739928Z","duration":"PT0.909065S","correlationId":"50de489d-4027-4df8-9a90-bd3ddfba545b","providers":[{"namespace":"Microsoft.Storage","resourceTypes":[{"resourceType":"storageAccounts/blobServices","locations":[null]}]}],"dependencies":[]}}'
-    headers:
-      Cache-Control:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Date:
-      - Mon, 23 Nov 2020 23:03:12 GMT
-      Expires:
-      - "-1"
-      Pragma:
-      - no-cache
-      Retry-After:
-      - "5"
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Content-Type-Options:
-      - nosniff
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - Go/go1.15.5 (amd64-linux) go-autorest/v14.1.1 k8sinfra-generated
-    url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-ewlqsf/providers/Microsoft.Resources/deployments/k8s_38cdf7b5-24aa-54c3-87df-f7da086033ef?api-version=2019-10-01
-    method: GET
-  response:
-    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-ewlqsf/providers/Microsoft.Resources/deployments/k8s_38cdf7b5-24aa-54c3-87df-f7da086033ef","name":"k8s_38cdf7b5-24aa-54c3-87df-f7da086033ef","type":"Microsoft.Resources/deployments","properties":{"templateHash":"14644625414381836457","mode":"Incremental","debugSetting":{"detailLevel":"RequestContent, ResponseContent"},"provisioningState":"Succeeded","timestamp":"2020-11-23T23:03:16.9072072Z","duration":"PT5.6422794S","correlationId":"50de489d-4027-4df8-9a90-bd3ddfba545b","providers":[{"namespace":"Microsoft.Storage","resourceTypes":[{"resourceType":"storageAccounts/blobServices","locations":[null]}]}],"dependencies":[],"outputs":{"resourceId":{"type":"String","value":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-ewlqsf/providers/Microsoft.Storage/storageAccounts/k8sinfrateststorgiatzw/blobServices/default"}},"outputResources":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-ewlqsf/providers/Microsoft.Storage/storageAccounts/k8sinfrateststorgiatzw/blobServices/default"}]}}'
-    headers:
-      Cache-Control:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Date:
-      - Mon, 23 Nov 2020 23:03:18 GMT
-      Expires:
-      - "-1"
-      Pragma:
-      - no-cache
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Content-Type-Options:
-      - nosniff
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - Go/go1.15.5 (amd64-linux) go-autorest/v14.1.1 k8sinfra-generated
-    url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-ewlqsf/providers/Microsoft.Storage/storageAccounts/k8sinfrateststorgiatzw/blobServices/default?api-version=2019-04-01
-    method: GET
-  response:
-    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-ewlqsf/providers/Microsoft.Storage/storageAccounts/k8sinfrateststorgiatzw/blobServices/default","name":"default","type":"Microsoft.Storage/storageAccounts/blobServices","properties":{"cors":{"corsRules":[]},"deleteRetentionPolicy":{"enabled":false}}}'
-    headers:
-      Cache-Control:
-      - no-cache
-      Content-Type:
-      - application/json
-      Date:
-      - Mon, 23 Nov 2020 23:03:18 GMT
-      Expires:
-      - "-1"
-      Pragma:
-      - no-cache
-      Server:
-      - Microsoft-Azure-Storage-Resource-Provider/1.0,Microsoft-HTTPAPI/2.0 Microsoft-HTTPAPI/2.0
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Content-Type-Options:
-      - nosniff
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - Go/go1.15.5 (amd64-linux) go-autorest/v14.1.1 k8sinfra-generated
-    url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-ewlqsf/providers/Microsoft.Resources/deployments/k8s_38cdf7b5-24aa-54c3-87df-f7da086033ef?api-version=2019-10-01
-    method: DELETE
-  response:
-    body: ""
-    headers:
-      Cache-Control:
-      - no-cache
-      Content-Length:
-      - "0"
-      Date:
-      - Mon, 23 Nov 2020 23:03:20 GMT
-      Expires:
-      - "-1"
-      Location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/operationresults/eyJqb2JJZCI6IkRlcGxveW1lbnREZWxldGlvbkpvYi1HTlMtSzhTSU5GUkFURVNUOjJEUkc6MkRFV0xRU0YtSzhTOjVGMzhDREY3QjU6MkQyNEFBOjJENTRDMzoyRDg3REY6MkRGN0RBMDg2MDMzRUYtIiwiam9iTG9jYXRpb24iOiJ3ZXN0dXMifQ?api-version=2019-10-01
       Pragma:
       - no-cache
       Retry-After:
@@ -816,20 +238,496 @@ interactions:
     code: 202
     duration: ""
 - request:
+    body: '{"name":"k8s_7b4d934c-9181-52e6-912c-67c108a32c3e","Properties":{"Error":null,"debugSetting":{"detailLevel":"requestContent,responseContent"},"mode":"Incremental","template":{"$schema":"https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#","contentVersion":"1.0.0.0","resources":[{"apiVersion":"2019-04-01","kind":"BlobStorage","location":"westus","name":"k8sinfrateststorgiatzw","properties":{"accessTier":"Hot"},"sku":{"name":"Standard_LRS"},"type":"Microsoft.Storage/storageAccounts"}],"outputs":{"resourceId":{"type":"string","value":"[resourceId(''Microsoft.Storage/storageAccounts'', ''k8sinfrateststorgiatzw'')]"}}}}}'
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Go/go1.15.6 (amd64-linux) go-autorest/v14.1.1 k8sinfra-generated
+    url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/k8sinfratest-rg-ewlqsf/providers/Microsoft.Resources/deployments/k8s_7b4d934c-9181-52e6-912c-67c108a32c3e?api-version=2019-10-01
+    method: PUT
+  response:
+    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-ewlqsf/providers/Microsoft.Resources/deployments/k8s_7b4d934c-9181-52e6-912c-67c108a32c3e","name":"k8s_7b4d934c-9181-52e6-912c-67c108a32c3e","type":"Microsoft.Resources/deployments","properties":{"templateHash":"10656703011749167364","mode":"Incremental","debugSetting":{"detailLevel":"RequestContent, ResponseContent"},"provisioningState":"Accepted","timestamp":"2021-01-21T23:44:40.722357Z","duration":"PT0.8355482S","correlationId":"31881e74-c7db-4e37-95fb-f4eb46b75ba2","providers":[{"namespace":"Microsoft.Storage","resourceTypes":[{"resourceType":"storageAccounts","locations":["westus"]}]}],"dependencies":[]}}'
+    headers:
+      Azure-Asyncoperation:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/k8sinfratest-rg-ewlqsf/providers/Microsoft.Resources/deployments/k8s_7b4d934c-9181-52e6-912c-67c108a32c3e/operationStatuses/08585903342055908086?api-version=2019-10-01
+      Cache-Control:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 21 Jan 2021 23:44:40 GMT
+      Expires:
+      - "-1"
+      Pragma:
+      - no-cache
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Go/go1.15.6 (amd64-linux) go-autorest/v14.1.1 k8sinfra-generated
+    url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-ewlqsf/providers/Microsoft.Resources/deployments/k8s_7b4d934c-9181-52e6-912c-67c108a32c3e?api-version=2019-10-01
+    method: GET
+  response:
+    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-ewlqsf/providers/Microsoft.Resources/deployments/k8s_7b4d934c-9181-52e6-912c-67c108a32c3e","name":"k8s_7b4d934c-9181-52e6-912c-67c108a32c3e","type":"Microsoft.Resources/deployments","properties":{"templateHash":"10656703011749167364","mode":"Incremental","debugSetting":{"detailLevel":"RequestContent, ResponseContent"},"provisioningState":"Running","timestamp":"2021-01-21T23:44:41.7145561Z","duration":"PT1.8277473S","correlationId":"31881e74-c7db-4e37-95fb-f4eb46b75ba2","providers":[{"namespace":"Microsoft.Storage","resourceTypes":[{"resourceType":"storageAccounts","locations":["westus"]}]}],"dependencies":[]}}'
+    headers:
+      Cache-Control:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 21 Jan 2021 23:44:41 GMT
+      Expires:
+      - "-1"
+      Pragma:
+      - no-cache
+      Retry-After:
+      - "5"
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Go/go1.15.6 (amd64-linux) go-autorest/v14.1.1 k8sinfra-generated
+    url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-ewlqsf/providers/Microsoft.Resources/deployments/k8s_7b4d934c-9181-52e6-912c-67c108a32c3e?api-version=2019-10-01
+    method: GET
+  response:
+    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-ewlqsf/providers/Microsoft.Resources/deployments/k8s_7b4d934c-9181-52e6-912c-67c108a32c3e","name":"k8s_7b4d934c-9181-52e6-912c-67c108a32c3e","type":"Microsoft.Resources/deployments","properties":{"templateHash":"10656703011749167364","mode":"Incremental","debugSetting":{"detailLevel":"RequestContent, ResponseContent"},"provisioningState":"Running","timestamp":"2021-01-21T23:44:41.7145561Z","duration":"PT1.8277473S","correlationId":"31881e74-c7db-4e37-95fb-f4eb46b75ba2","providers":[{"namespace":"Microsoft.Storage","resourceTypes":[{"resourceType":"storageAccounts","locations":["westus"]}]}],"dependencies":[]}}'
+    headers:
+      Cache-Control:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 21 Jan 2021 23:44:41 GMT
+      Expires:
+      - "-1"
+      Pragma:
+      - no-cache
+      Retry-After:
+      - "5"
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Go/go1.15.6 (amd64-linux) go-autorest/v14.1.1 k8sinfra-generated
+    url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-ewlqsf/providers/Microsoft.Resources/deployments/k8s_7b4d934c-9181-52e6-912c-67c108a32c3e?api-version=2019-10-01
+    method: GET
+  response:
+    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-ewlqsf/providers/Microsoft.Resources/deployments/k8s_7b4d934c-9181-52e6-912c-67c108a32c3e","name":"k8s_7b4d934c-9181-52e6-912c-67c108a32c3e","type":"Microsoft.Resources/deployments","properties":{"templateHash":"10656703011749167364","mode":"Incremental","debugSetting":{"detailLevel":"RequestContent, ResponseContent"},"provisioningState":"Running","timestamp":"2021-01-21T23:44:41.7145561Z","duration":"PT1.8277473S","correlationId":"31881e74-c7db-4e37-95fb-f4eb46b75ba2","providers":[{"namespace":"Microsoft.Storage","resourceTypes":[{"resourceType":"storageAccounts","locations":["westus"]}]}],"dependencies":[]}}'
+    headers:
+      Cache-Control:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 21 Jan 2021 23:44:46 GMT
+      Expires:
+      - "-1"
+      Pragma:
+      - no-cache
+      Retry-After:
+      - "5"
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Go/go1.15.6 (amd64-linux) go-autorest/v14.1.1 k8sinfra-generated
+    url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-ewlqsf/providers/Microsoft.Resources/deployments/k8s_7b4d934c-9181-52e6-912c-67c108a32c3e?api-version=2019-10-01
+    method: GET
+  response:
+    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-ewlqsf/providers/Microsoft.Resources/deployments/k8s_7b4d934c-9181-52e6-912c-67c108a32c3e","name":"k8s_7b4d934c-9181-52e6-912c-67c108a32c3e","type":"Microsoft.Resources/deployments","properties":{"templateHash":"10656703011749167364","mode":"Incremental","debugSetting":{"detailLevel":"RequestContent, ResponseContent"},"provisioningState":"Succeeded","timestamp":"2021-01-21T23:44:48.2432957Z","duration":"PT8.3564869S","correlationId":"31881e74-c7db-4e37-95fb-f4eb46b75ba2","providers":[{"namespace":"Microsoft.Storage","resourceTypes":[{"resourceType":"storageAccounts","locations":["westus"]}]}],"dependencies":[],"outputs":{"resourceId":{"type":"String","value":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-ewlqsf/providers/Microsoft.Storage/storageAccounts/k8sinfrateststorgiatzw"}},"outputResources":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-ewlqsf/providers/Microsoft.Storage/storageAccounts/k8sinfrateststorgiatzw"}]}}'
+    headers:
+      Cache-Control:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 21 Jan 2021 23:44:51 GMT
+      Expires:
+      - "-1"
+      Pragma:
+      - no-cache
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Go/go1.15.6 (amd64-linux) go-autorest/v14.1.1 k8sinfra-generated
+    url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-ewlqsf/providers/Microsoft.Storage/storageAccounts/k8sinfrateststorgiatzw?api-version=2019-04-01
+    method: GET
+  response:
+    body: '{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"BlobStorage","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-ewlqsf/providers/Microsoft.Storage/storageAccounts/k8sinfrateststorgiatzw","name":"k8sinfrateststorgiatzw","type":"Microsoft.Storage/storageAccounts","location":"westus","tags":{},"properties":{"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"enabled":true,"lastEnabledTime":"2021-01-21T23:40:47.7757946Z"},"blob":{"enabled":true,"lastEnabledTime":"2021-01-21T23:40:47.7757946Z"}},"keySource":"Microsoft.Storage"},"accessTier":"Hot","provisioningState":"Succeeded","creationTime":"2021-01-21T23:40:47.6820376Z","primaryEndpoints":{"dfs":"https://k8sinfrateststorgiatzw.dfs.core.windows.net/","blob":"https://k8sinfrateststorgiatzw.blob.core.windows.net/","table":"https://k8sinfrateststorgiatzw.table.core.windows.net/"},"primaryLocation":"westus","statusOfPrimary":"available"}}'
+    headers:
+      Cache-Control:
+      - no-cache
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 21 Jan 2021 23:44:51 GMT
+      Expires:
+      - "-1"
+      Pragma:
+      - no-cache
+      Server:
+      - Microsoft-Azure-Storage-Resource-Provider/1.0,Microsoft-HTTPAPI/2.0 Microsoft-HTTPAPI/2.0
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Go/go1.15.6 (amd64-linux) go-autorest/v14.1.1 k8sinfra-generated
+    url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-ewlqsf/providers/Microsoft.Resources/deployments/k8s_7b4d934c-9181-52e6-912c-67c108a32c3e?api-version=2019-10-01
+    method: DELETE
+  response:
+    body: ""
+    headers:
+      Cache-Control:
+      - no-cache
+      Content-Length:
+      - "0"
+      Date:
+      - Thu, 21 Jan 2021 23:44:53 GMT
+      Expires:
+      - "-1"
+      Location:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/operationresults/eyJqb2JJZCI6IkRlcGxveW1lbnREZWxldGlvbkpvYi1HTlMtSzhTSU5GUkFURVNUOjJEUkc6MkRFV0xRU0YtSzhTOjVGN0I0RDkzNEM6MkQ5MTgxOjJENTJFNjoyRDkxMkM6MkQ2N0MxMDhBMzJDM0UtIiwiam9iTG9jYXRpb24iOiJ3ZXN0dXMifQ?api-version=2019-10-01
+      Pragma:
+      - no-cache
+      Retry-After:
+      - "15"
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      X-Ms-Ratelimit-Remaining-Subscription-Deletes:
+      - "14995"
+    status: 202 Accepted
+    code: 202
+    duration: ""
+- request:
+    body: '{"name":"k8s_38cdf7b5-24aa-54c3-87df-f7da086033ef","Properties":{"Error":null,"debugSetting":{"detailLevel":"requestContent,responseContent"},"mode":"Incremental","template":{"$schema":"https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#","contentVersion":"1.0.0.0","resources":[{"apiVersion":"2019-04-01","name":"k8sinfrateststorgiatzw/default","type":"Microsoft.Storage/storageAccounts/blobServices"}],"outputs":{"resourceId":{"type":"string","value":"[resourceId(''Microsoft.Storage/storageAccounts/blobServices'', ''k8sinfrateststorgiatzw'', ''default'')]"}}}}}'
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Go/go1.15.6 (amd64-linux) go-autorest/v14.1.1 k8sinfra-generated
+    url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/k8sinfratest-rg-ewlqsf/providers/Microsoft.Resources/deployments/k8s_38cdf7b5-24aa-54c3-87df-f7da086033ef?api-version=2019-10-01
+    method: PUT
+  response:
+    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-ewlqsf/providers/Microsoft.Resources/deployments/k8s_38cdf7b5-24aa-54c3-87df-f7da086033ef","name":"k8s_38cdf7b5-24aa-54c3-87df-f7da086033ef","type":"Microsoft.Resources/deployments","properties":{"templateHash":"14644625414381836457","mode":"Incremental","debugSetting":{"detailLevel":"RequestContent, ResponseContent"},"provisioningState":"Accepted","timestamp":"2021-01-21T23:44:55.2354202Z","duration":"PT0.7424773S","correlationId":"9d183ed2-dae4-40a4-bf43-910f1dd071c9","providers":[{"namespace":"Microsoft.Storage","resourceTypes":[{"resourceType":"storageAccounts/blobServices","locations":[null]}]}],"dependencies":[]}}'
+    headers:
+      Azure-Asyncoperation:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/k8sinfratest-rg-ewlqsf/providers/Microsoft.Resources/deployments/k8s_38cdf7b5-24aa-54c3-87df-f7da086033ef/operationStatuses/08585903341909846619?api-version=2019-10-01
+      Cache-Control:
+      - no-cache
+      Content-Length:
+      - "717"
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 21 Jan 2021 23:44:55 GMT
+      Expires:
+      - "-1"
+      Pragma:
+      - no-cache
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+    status: 201 Created
+    code: 201
+    duration: ""
+- request:
+    body: '{"name":"k8s_38cdf7b5-24aa-54c3-87df-f7da086033ef","Properties":{"Error":null,"debugSetting":{"detailLevel":"requestContent,responseContent"},"mode":"Incremental","template":{"$schema":"https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#","contentVersion":"1.0.0.0","resources":[{"apiVersion":"2019-04-01","name":"k8sinfrateststorgiatzw/default","type":"Microsoft.Storage/storageAccounts/blobServices"}],"outputs":{"resourceId":{"type":"string","value":"[resourceId(''Microsoft.Storage/storageAccounts/blobServices'', ''k8sinfrateststorgiatzw'', ''default'')]"}}}}}'
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Go/go1.15.6 (amd64-linux) go-autorest/v14.1.1 k8sinfra-generated
+    url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/k8sinfratest-rg-ewlqsf/providers/Microsoft.Resources/deployments/k8s_38cdf7b5-24aa-54c3-87df-f7da086033ef?api-version=2019-10-01
+    method: PUT
+  response:
+    body: '{"error":{"code":"DeploymentActive","message":"Unable to edit or replace deployment ''k8s_38cdf7b5-24aa-54c3-87df-f7da086033ef'': previous deployment from ''1/21/2021 11:44:55 PM'' is still active (expiration time is ''1/28/2021 11:44:54 PM''). Please see https://aka.ms/arm-deploy for usage details."}}'
+    headers:
+      Cache-Control:
+      - no-cache
+      Content-Length:
+      - "297"
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 21 Jan 2021 23:44:55 GMT
+      Expires:
+      - "-1"
+      Pragma:
+      - no-cache
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      X-Ms-Failure-Cause:
+      - gateway
+    status: 409 Conflict
+    code: 409
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Go/go1.15.6 (amd64-linux) go-autorest/v14.1.1 k8sinfra-generated
+    url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-ewlqsf/providers/Microsoft.Resources/deployments/k8s_38cdf7b5-24aa-54c3-87df-f7da086033ef?api-version=2019-10-01
+    method: GET
+  response:
+    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-ewlqsf/providers/Microsoft.Resources/deployments/k8s_38cdf7b5-24aa-54c3-87df-f7da086033ef","name":"k8s_38cdf7b5-24aa-54c3-87df-f7da086033ef","type":"Microsoft.Resources/deployments","properties":{"templateHash":"14644625414381836457","mode":"Incremental","debugSetting":{"detailLevel":"RequestContent, ResponseContent"},"provisioningState":"Running","timestamp":"2021-01-21T23:44:55.9586818Z","duration":"PT1.4657389S","correlationId":"9d183ed2-dae4-40a4-bf43-910f1dd071c9","providers":[{"namespace":"Microsoft.Storage","resourceTypes":[{"resourceType":"storageAccounts/blobServices","locations":[null]}]}],"dependencies":[]}}'
+    headers:
+      Cache-Control:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 21 Jan 2021 23:44:56 GMT
+      Expires:
+      - "-1"
+      Pragma:
+      - no-cache
+      Retry-After:
+      - "5"
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Go/go1.15.6 (amd64-linux) go-autorest/v14.1.1 k8sinfra-generated
+    url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-ewlqsf/providers/Microsoft.Resources/deployments/k8s_38cdf7b5-24aa-54c3-87df-f7da086033ef?api-version=2019-10-01
+    method: GET
+  response:
+    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-ewlqsf/providers/Microsoft.Resources/deployments/k8s_38cdf7b5-24aa-54c3-87df-f7da086033ef","name":"k8s_38cdf7b5-24aa-54c3-87df-f7da086033ef","type":"Microsoft.Resources/deployments","properties":{"templateHash":"14644625414381836457","mode":"Incremental","debugSetting":{"detailLevel":"RequestContent, ResponseContent"},"provisioningState":"Running","timestamp":"2021-01-21T23:44:55.9586818Z","duration":"PT1.4657389S","correlationId":"9d183ed2-dae4-40a4-bf43-910f1dd071c9","providers":[{"namespace":"Microsoft.Storage","resourceTypes":[{"resourceType":"storageAccounts/blobServices","locations":[null]}]}],"dependencies":[]}}'
+    headers:
+      Cache-Control:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 21 Jan 2021 23:44:56 GMT
+      Expires:
+      - "-1"
+      Pragma:
+      - no-cache
+      Retry-After:
+      - "5"
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Go/go1.15.6 (amd64-linux) go-autorest/v14.1.1 k8sinfra-generated
+    url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-ewlqsf/providers/Microsoft.Resources/deployments/k8s_38cdf7b5-24aa-54c3-87df-f7da086033ef?api-version=2019-10-01
+    method: GET
+  response:
+    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-ewlqsf/providers/Microsoft.Resources/deployments/k8s_38cdf7b5-24aa-54c3-87df-f7da086033ef","name":"k8s_38cdf7b5-24aa-54c3-87df-f7da086033ef","type":"Microsoft.Resources/deployments","properties":{"templateHash":"14644625414381836457","mode":"Incremental","debugSetting":{"detailLevel":"RequestContent, ResponseContent"},"provisioningState":"Succeeded","timestamp":"2021-01-21T23:44:59.2547469Z","duration":"PT4.761804S","correlationId":"9d183ed2-dae4-40a4-bf43-910f1dd071c9","providers":[{"namespace":"Microsoft.Storage","resourceTypes":[{"resourceType":"storageAccounts/blobServices","locations":[null]}]}],"dependencies":[],"outputs":{"resourceId":{"type":"String","value":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-ewlqsf/providers/Microsoft.Storage/storageAccounts/k8sinfrateststorgiatzw/blobServices/default"}},"outputResources":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-ewlqsf/providers/Microsoft.Storage/storageAccounts/k8sinfrateststorgiatzw/blobServices/default"}]}}'
+    headers:
+      Cache-Control:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 21 Jan 2021 23:45:00 GMT
+      Expires:
+      - "-1"
+      Pragma:
+      - no-cache
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Go/go1.15.6 (amd64-linux) go-autorest/v14.1.1 k8sinfra-generated
+    url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-ewlqsf/providers/Microsoft.Storage/storageAccounts/k8sinfrateststorgiatzw/blobServices/default?api-version=2019-04-01
+    method: GET
+  response:
+    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-ewlqsf/providers/Microsoft.Storage/storageAccounts/k8sinfrateststorgiatzw/blobServices/default","name":"default","type":"Microsoft.Storage/storageAccounts/blobServices","properties":{"cors":{"corsRules":[]},"deleteRetentionPolicy":{"enabled":false}}}'
+    headers:
+      Cache-Control:
+      - no-cache
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 21 Jan 2021 23:45:01 GMT
+      Expires:
+      - "-1"
+      Pragma:
+      - no-cache
+      Server:
+      - Microsoft-Azure-Storage-Resource-Provider/1.0,Microsoft-HTTPAPI/2.0 Microsoft-HTTPAPI/2.0
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Go/go1.15.6 (amd64-linux) go-autorest/v14.1.1 k8sinfra-generated
+    url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-ewlqsf/providers/Microsoft.Resources/deployments/k8s_38cdf7b5-24aa-54c3-87df-f7da086033ef?api-version=2019-10-01
+    method: DELETE
+  response:
+    body: ""
+    headers:
+      Cache-Control:
+      - no-cache
+      Content-Length:
+      - "0"
+      Date:
+      - Thu, 21 Jan 2021 23:45:03 GMT
+      Expires:
+      - "-1"
+      Location:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/operationresults/eyJqb2JJZCI6IkRlcGxveW1lbnREZWxldGlvbkpvYi1HTlMtSzhTSU5GUkFURVNUOjJEUkc6MkRFV0xRU0YtSzhTOjVGMzhDREY3QjU6MkQyNEFBOjJENTRDMzoyRDg3REY6MkRGN0RBMDg2MDMzRUYtIiwiam9iTG9jYXRpb24iOiJ3ZXN0dXMifQ?api-version=2019-10-01
+      Pragma:
+      - no-cache
+      Retry-After:
+      - "15"
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      X-Ms-Ratelimit-Remaining-Subscription-Deletes:
+      - "14994"
+    status: 202 Accepted
+    code: 202
+    duration: ""
+- request:
     body: '{"name":"k8s_854dcd17-12e8-5b6c-b7a6-25298d2f652a","Properties":{"Error":null,"debugSetting":{"detailLevel":"requestContent,responseContent"},"mode":"Incremental","template":{"$schema":"https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#","contentVersion":"1.0.0.0","resources":[{"apiVersion":"2019-04-01","name":"k8sinfrateststorgiatzw/default/k8sinfratest-container-ntusgr","type":"Microsoft.Storage/storageAccounts/blobServices/containers"}],"outputs":{"resourceId":{"type":"string","value":"[resourceId(''Microsoft.Storage/storageAccounts/blobServices/containers'', ''k8sinfrateststorgiatzw'', ''default'', ''k8sinfratest-container-ntusgr'')]"}}}}}'
     form: {}
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - Go/go1.15.5 (amd64-linux) go-autorest/v14.1.1 k8sinfra-generated
+      - Go/go1.15.6 (amd64-linux) go-autorest/v14.1.1 k8sinfra-generated
     url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/k8sinfratest-rg-ewlqsf/providers/Microsoft.Resources/deployments/k8s_854dcd17-12e8-5b6c-b7a6-25298d2f652a?api-version=2019-10-01
     method: PUT
   response:
-    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-ewlqsf/providers/Microsoft.Resources/deployments/k8s_854dcd17-12e8-5b6c-b7a6-25298d2f652a","name":"k8s_854dcd17-12e8-5b6c-b7a6-25298d2f652a","type":"Microsoft.Resources/deployments","properties":{"templateHash":"8405540082520381987","mode":"Incremental","debugSetting":{"detailLevel":"RequestContent, ResponseContent"},"provisioningState":"Accepted","timestamp":"2020-11-23T23:03:22.1289463Z","duration":"PT0.8507192S","correlationId":"dd4301c8-da56-4e66-8e34-8c461718d3c0","providers":[{"namespace":"Microsoft.Storage","resourceTypes":[{"resourceType":"storageAccounts/blobServices/containers","locations":[null]}]}],"dependencies":[]}}'
+    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-ewlqsf/providers/Microsoft.Resources/deployments/k8s_854dcd17-12e8-5b6c-b7a6-25298d2f652a","name":"k8s_854dcd17-12e8-5b6c-b7a6-25298d2f652a","type":"Microsoft.Resources/deployments","properties":{"templateHash":"8405540082520381987","mode":"Incremental","debugSetting":{"detailLevel":"RequestContent, ResponseContent"},"provisioningState":"Accepted","timestamp":"2021-01-21T23:45:05.2236792Z","duration":"PT0.7133481S","correlationId":"a2699b98-bb66-4032-a1c8-985a7a70c346","providers":[{"namespace":"Microsoft.Storage","resourceTypes":[{"resourceType":"storageAccounts/blobServices/containers","locations":[null]}]}],"dependencies":[]}}'
     headers:
       Azure-Asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/k8sinfratest-rg-ewlqsf/providers/Microsoft.Resources/deployments/k8s_854dcd17-12e8-5b6c-b7a6-25298d2f652a/operationStatuses/08585954342841993794?api-version=2019-10-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/k8sinfratest-rg-ewlqsf/providers/Microsoft.Resources/deployments/k8s_854dcd17-12e8-5b6c-b7a6-25298d2f652a/operationStatuses/08585903341809672774?api-version=2019-10-01
       Cache-Control:
       - no-cache
       Content-Length:
@@ -837,7 +735,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Mon, 23 Nov 2020 23:03:22 GMT
+      - Thu, 21 Jan 2021 23:45:05 GMT
       Expires:
       - "-1"
       Pragma:
@@ -856,18 +754,18 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - Go/go1.15.5 (amd64-linux) go-autorest/v14.1.1 k8sinfra-generated
+      - Go/go1.15.6 (amd64-linux) go-autorest/v14.1.1 k8sinfra-generated
     url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-ewlqsf/providers/Microsoft.Resources/deployments/k8s_854dcd17-12e8-5b6c-b7a6-25298d2f652a?api-version=2019-10-01
     method: GET
   response:
-    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-ewlqsf/providers/Microsoft.Resources/deployments/k8s_854dcd17-12e8-5b6c-b7a6-25298d2f652a","name":"k8s_854dcd17-12e8-5b6c-b7a6-25298d2f652a","type":"Microsoft.Resources/deployments","properties":{"templateHash":"8405540082520381987","mode":"Incremental","debugSetting":{"detailLevel":"RequestContent, ResponseContent"},"provisioningState":"Accepted","timestamp":"2020-11-23T23:03:22.1289463Z","duration":"PT0.8507192S","correlationId":"dd4301c8-da56-4e66-8e34-8c461718d3c0","providers":[{"namespace":"Microsoft.Storage","resourceTypes":[{"resourceType":"storageAccounts/blobServices/containers","locations":[null]}]}],"dependencies":[]}}'
+    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-ewlqsf/providers/Microsoft.Resources/deployments/k8s_854dcd17-12e8-5b6c-b7a6-25298d2f652a","name":"k8s_854dcd17-12e8-5b6c-b7a6-25298d2f652a","type":"Microsoft.Resources/deployments","properties":{"templateHash":"8405540082520381987","mode":"Incremental","debugSetting":{"detailLevel":"RequestContent, ResponseContent"},"provisioningState":"Running","timestamp":"2021-01-21T23:45:05.8898399Z","duration":"PT1.3795088S","correlationId":"a2699b98-bb66-4032-a1c8-985a7a70c346","providers":[{"namespace":"Microsoft.Storage","resourceTypes":[{"resourceType":"storageAccounts/blobServices/containers","locations":[null]}]}],"dependencies":[]}}'
     headers:
       Cache-Control:
       - no-cache
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Mon, 23 Nov 2020 23:03:23 GMT
+      - Thu, 21 Jan 2021 23:45:05 GMT
       Expires:
       - "-1"
       Pragma:
@@ -890,18 +788,18 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - Go/go1.15.5 (amd64-linux) go-autorest/v14.1.1 k8sinfra-generated
+      - Go/go1.15.6 (amd64-linux) go-autorest/v14.1.1 k8sinfra-generated
     url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-ewlqsf/providers/Microsoft.Resources/deployments/k8s_854dcd17-12e8-5b6c-b7a6-25298d2f652a?api-version=2019-10-01
     method: GET
   response:
-    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-ewlqsf/providers/Microsoft.Resources/deployments/k8s_854dcd17-12e8-5b6c-b7a6-25298d2f652a","name":"k8s_854dcd17-12e8-5b6c-b7a6-25298d2f652a","type":"Microsoft.Resources/deployments","properties":{"templateHash":"8405540082520381987","mode":"Incremental","debugSetting":{"detailLevel":"RequestContent, ResponseContent"},"provisioningState":"Running","timestamp":"2020-11-23T23:03:23.3589903Z","duration":"PT2.0807632S","correlationId":"dd4301c8-da56-4e66-8e34-8c461718d3c0","providers":[{"namespace":"Microsoft.Storage","resourceTypes":[{"resourceType":"storageAccounts/blobServices/containers","locations":[null]}]}],"dependencies":[]}}'
+    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-ewlqsf/providers/Microsoft.Resources/deployments/k8s_854dcd17-12e8-5b6c-b7a6-25298d2f652a","name":"k8s_854dcd17-12e8-5b6c-b7a6-25298d2f652a","type":"Microsoft.Resources/deployments","properties":{"templateHash":"8405540082520381987","mode":"Incremental","debugSetting":{"detailLevel":"RequestContent, ResponseContent"},"provisioningState":"Running","timestamp":"2021-01-21T23:45:05.8898399Z","duration":"PT1.3795088S","correlationId":"a2699b98-bb66-4032-a1c8-985a7a70c346","providers":[{"namespace":"Microsoft.Storage","resourceTypes":[{"resourceType":"storageAccounts/blobServices/containers","locations":[null]}]}],"dependencies":[]}}'
     headers:
       Cache-Control:
       - no-cache
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Mon, 23 Nov 2020 23:03:28 GMT
+      - Thu, 21 Jan 2021 23:45:05 GMT
       Expires:
       - "-1"
       Pragma:
@@ -924,120 +822,18 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - Go/go1.15.5 (amd64-linux) go-autorest/v14.1.1 k8sinfra-generated
+      - Go/go1.15.6 (amd64-linux) go-autorest/v14.1.1 k8sinfra-generated
     url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-ewlqsf/providers/Microsoft.Resources/deployments/k8s_854dcd17-12e8-5b6c-b7a6-25298d2f652a?api-version=2019-10-01
     method: GET
   response:
-    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-ewlqsf/providers/Microsoft.Resources/deployments/k8s_854dcd17-12e8-5b6c-b7a6-25298d2f652a","name":"k8s_854dcd17-12e8-5b6c-b7a6-25298d2f652a","type":"Microsoft.Resources/deployments","properties":{"templateHash":"8405540082520381987","mode":"Incremental","debugSetting":{"detailLevel":"RequestContent, ResponseContent"},"provisioningState":"Running","timestamp":"2020-11-23T23:03:23.3589903Z","duration":"PT2.0807632S","correlationId":"dd4301c8-da56-4e66-8e34-8c461718d3c0","providers":[{"namespace":"Microsoft.Storage","resourceTypes":[{"resourceType":"storageAccounts/blobServices/containers","locations":[null]}]}],"dependencies":[]}}'
+    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-ewlqsf/providers/Microsoft.Resources/deployments/k8s_854dcd17-12e8-5b6c-b7a6-25298d2f652a","name":"k8s_854dcd17-12e8-5b6c-b7a6-25298d2f652a","type":"Microsoft.Resources/deployments","properties":{"templateHash":"8405540082520381987","mode":"Incremental","debugSetting":{"detailLevel":"RequestContent, ResponseContent"},"provisioningState":"Succeeded","timestamp":"2021-01-21T23:45:06.8927877Z","duration":"PT2.3824566S","correlationId":"a2699b98-bb66-4032-a1c8-985a7a70c346","providers":[{"namespace":"Microsoft.Storage","resourceTypes":[{"resourceType":"storageAccounts/blobServices/containers","locations":[null]}]}],"dependencies":[],"outputs":{"resourceId":{"type":"String","value":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-ewlqsf/providers/Microsoft.Storage/storageAccounts/k8sinfrateststorgiatzw/blobServices/default/containers/k8sinfratest-container-ntusgr"}},"outputResources":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-ewlqsf/providers/Microsoft.Storage/storageAccounts/k8sinfrateststorgiatzw/blobServices/default/containers/k8sinfratest-container-ntusgr"}]}}'
     headers:
       Cache-Control:
       - no-cache
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Mon, 23 Nov 2020 23:03:28 GMT
-      Expires:
-      - "-1"
-      Pragma:
-      - no-cache
-      Retry-After:
-      - "5"
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Content-Type-Options:
-      - nosniff
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - Go/go1.15.5 (amd64-linux) go-autorest/v14.1.1 k8sinfra-generated
-    url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-ewlqsf/providers/Microsoft.Resources/deployments/k8s_854dcd17-12e8-5b6c-b7a6-25298d2f652a?api-version=2019-10-01
-    method: GET
-  response:
-    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-ewlqsf/providers/Microsoft.Resources/deployments/k8s_854dcd17-12e8-5b6c-b7a6-25298d2f652a","name":"k8s_854dcd17-12e8-5b6c-b7a6-25298d2f652a","type":"Microsoft.Resources/deployments","properties":{"templateHash":"8405540082520381987","mode":"Incremental","debugSetting":{"detailLevel":"RequestContent, ResponseContent"},"provisioningState":"Running","timestamp":"2020-11-23T23:03:23.3589903Z","duration":"PT2.0807632S","correlationId":"dd4301c8-da56-4e66-8e34-8c461718d3c0","providers":[{"namespace":"Microsoft.Storage","resourceTypes":[{"resourceType":"storageAccounts/blobServices/containers","locations":[null]}]}],"dependencies":[]}}'
-    headers:
-      Cache-Control:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Date:
-      - Mon, 23 Nov 2020 23:03:33 GMT
-      Expires:
-      - "-1"
-      Pragma:
-      - no-cache
-      Retry-After:
-      - "5"
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Content-Type-Options:
-      - nosniff
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - Go/go1.15.5 (amd64-linux) go-autorest/v14.1.1 k8sinfra-generated
-    url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-ewlqsf/providers/Microsoft.Resources/deployments/k8s_854dcd17-12e8-5b6c-b7a6-25298d2f652a?api-version=2019-10-01
-    method: GET
-  response:
-    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-ewlqsf/providers/Microsoft.Resources/deployments/k8s_854dcd17-12e8-5b6c-b7a6-25298d2f652a","name":"k8s_854dcd17-12e8-5b6c-b7a6-25298d2f652a","type":"Microsoft.Resources/deployments","properties":{"templateHash":"8405540082520381987","mode":"Incremental","debugSetting":{"detailLevel":"RequestContent, ResponseContent"},"provisioningState":"Running","timestamp":"2020-11-23T23:03:23.3589903Z","duration":"PT2.0807632S","correlationId":"dd4301c8-da56-4e66-8e34-8c461718d3c0","providers":[{"namespace":"Microsoft.Storage","resourceTypes":[{"resourceType":"storageAccounts/blobServices/containers","locations":[null]}]}],"dependencies":[]}}'
-    headers:
-      Cache-Control:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Date:
-      - Mon, 23 Nov 2020 23:03:38 GMT
-      Expires:
-      - "-1"
-      Pragma:
-      - no-cache
-      Retry-After:
-      - "5"
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Content-Type-Options:
-      - nosniff
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - Go/go1.15.5 (amd64-linux) go-autorest/v14.1.1 k8sinfra-generated
-    url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-ewlqsf/providers/Microsoft.Resources/deployments/k8s_854dcd17-12e8-5b6c-b7a6-25298d2f652a?api-version=2019-10-01
-    method: GET
-  response:
-    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-ewlqsf/providers/Microsoft.Resources/deployments/k8s_854dcd17-12e8-5b6c-b7a6-25298d2f652a","name":"k8s_854dcd17-12e8-5b6c-b7a6-25298d2f652a","type":"Microsoft.Resources/deployments","properties":{"templateHash":"8405540082520381987","mode":"Incremental","debugSetting":{"detailLevel":"RequestContent, ResponseContent"},"provisioningState":"Succeeded","timestamp":"2020-11-23T23:03:41.0019832Z","duration":"PT19.7237561S","correlationId":"dd4301c8-da56-4e66-8e34-8c461718d3c0","providers":[{"namespace":"Microsoft.Storage","resourceTypes":[{"resourceType":"storageAccounts/blobServices/containers","locations":[null]}]}],"dependencies":[],"outputs":{"resourceId":{"type":"String","value":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-ewlqsf/providers/Microsoft.Storage/storageAccounts/k8sinfrateststorgiatzw/blobServices/default/containers/k8sinfratest-container-ntusgr"}},"outputResources":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-ewlqsf/providers/Microsoft.Storage/storageAccounts/k8sinfrateststorgiatzw/blobServices/default/containers/k8sinfratest-container-ntusgr"}]}}'
-    headers:
-      Cache-Control:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Date:
-      - Mon, 23 Nov 2020 23:03:44 GMT
+      - Thu, 21 Jan 2021 23:45:10 GMT
       Expires:
       - "-1"
       Pragma:
@@ -1058,20 +854,20 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - Go/go1.15.5 (amd64-linux) go-autorest/v14.1.1 k8sinfra-generated
+      - Go/go1.15.6 (amd64-linux) go-autorest/v14.1.1 k8sinfra-generated
     url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-ewlqsf/providers/Microsoft.Storage/storageAccounts/k8sinfrateststorgiatzw/blobServices/default/containers/k8sinfratest-container-ntusgr?api-version=2019-04-01
     method: GET
   response:
-    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-ewlqsf/providers/Microsoft.Storage/storageAccounts/k8sinfrateststorgiatzw/blobServices/default/containers/k8sinfratest-container-ntusgr","name":"k8sinfratest-container-ntusgr","type":"Microsoft.Storage/storageAccounts/blobServices/containers","etag":"\"0x8D89003FCA06E78\"","properties":{"publicAccess":"None","leaseStatus":"Unlocked","leaseState":"Available","lastModifiedTime":"2020-11-23T23:03:27.0000000Z","legalHold":{"hasLegalHold":false,"tags":[]},"hasImmutabilityPolicy":false,"hasLegalHold":false}}'
+    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-ewlqsf/providers/Microsoft.Storage/storageAccounts/k8sinfrateststorgiatzw/blobServices/default/containers/k8sinfratest-container-ntusgr","name":"k8sinfratest-container-ntusgr","type":"Microsoft.Storage/storageAccounts/blobServices/containers","etag":"\"0x8D8BE6694CC917A\"","properties":{"publicAccess":"None","leaseStatus":"Unlocked","leaseState":"Available","lastModifiedTime":"2021-01-21T23:45:06.0000000Z","legalHold":{"hasLegalHold":false,"tags":[]},"hasImmutabilityPolicy":false,"hasLegalHold":false}}'
     headers:
       Cache-Control:
       - no-cache
       Content-Type:
       - application/json
       Date:
-      - Mon, 23 Nov 2020 23:03:45 GMT
+      - Thu, 21 Jan 2021 23:45:10 GMT
       Etag:
-      - '"0x8D89003FCA06E78"'
+      - '"0x8D8BE6694CC917A"'
       Expires:
       - "-1"
       Pragma:
@@ -1094,7 +890,7 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - Go/go1.15.5 (amd64-linux) go-autorest/v14.1.1 k8sinfra-generated
+      - Go/go1.15.6 (amd64-linux) go-autorest/v14.1.1 k8sinfra-generated
     url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-ewlqsf/providers/Microsoft.Resources/deployments/k8s_854dcd17-12e8-5b6c-b7a6-25298d2f652a?api-version=2019-10-01
     method: DELETE
   response:
@@ -1105,7 +901,7 @@ interactions:
       Content-Length:
       - "0"
       Date:
-      - Mon, 23 Nov 2020 23:03:47 GMT
+      - Thu, 21 Jan 2021 23:45:12 GMT
       Expires:
       - "-1"
       Location:
@@ -1119,7 +915,7 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Ms-Ratelimit-Remaining-Subscription-Deletes:
-      - "14996"
+      - "14993"
     status: 202 Accepted
     code: 202
     duration: ""
@@ -1130,7 +926,7 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - Go/go1.15.5 (amd64-linux) go-autorest/v14.1.1 k8sinfra-generated
+      - Go/go1.15.6 (amd64-linux) go-autorest/v14.1.1 k8sinfra-generated
     url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-ewlqsf/providers/Microsoft.Storage/storageAccounts/k8sinfrateststorgiatzw/blobServices/default/containers/k8sinfratest-container-ntusgr?api-version=2019-04-01
     method: DELETE
   response:
@@ -1143,7 +939,7 @@ interactions:
       Content-Type:
       - text/plain; charset=utf-8
       Date:
-      - Mon, 23 Nov 2020 23:03:47 GMT
+      - Thu, 21 Jan 2021 23:45:13 GMT
       Expires:
       - "-1"
       Pragma:
@@ -1155,7 +951,7 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Ms-Ratelimit-Remaining-Subscription-Deletes:
-      - "14995"
+      - "14992"
     status: 200 OK
     code: 200
     duration: ""
@@ -1166,20 +962,20 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - Go/go1.15.5 (amd64-linux) go-autorest/v14.1.1 k8sinfra-generated
+      - Go/go1.15.6 (amd64-linux) go-autorest/v14.1.1 k8sinfra-generated
     url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-ewlqsf/providers/Microsoft.Storage/storageAccounts/k8sinfrateststorgiatzw/blobServices/default/containers/k8sinfratest-container-ntusgr?api-version=2019-04-01
     method: GET
   response:
-    body: '{"error":{"code":"ContainerOperationFailure","message":"The specified container does not exist.\nRequestId:4e03df2d-601e-0006-27ec-c1e8e7000000\nTime:2020-11-23T23:03:48.7226465Z"}}'
+    body: '{"error":{"code":"ContainerNotFound","message":"The specified container does not exist.\nRequestId:eaa0d743-a01e-0025-4f4f-f0f0b4000000\nTime:2021-01-21T23:45:15.3623348Z"}}'
     headers:
       Cache-Control:
       - no-cache
       Content-Length:
-      - "181"
+      - "173"
       Content-Type:
       - application/json
       Date:
-      - Mon, 23 Nov 2020 23:03:48 GMT
+      - Thu, 21 Jan 2021 23:45:14 GMT
       Expires:
       - "-1"
       Pragma:
@@ -1200,7 +996,7 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - Go/go1.15.5 (amd64-linux) go-autorest/v14.1.1 k8sinfra-generated
+      - Go/go1.15.6 (amd64-linux) go-autorest/v14.1.1 k8sinfra-generated
     url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-ewlqsf/providers/Microsoft.Storage/storageAccounts/k8sinfrateststorgiatzw?api-version=2019-04-01
     method: DELETE
   response:
@@ -1213,7 +1009,7 @@ interactions:
       Content-Type:
       - text/plain; charset=utf-8
       Date:
-      - Mon, 23 Nov 2020 23:03:56 GMT
+      - Thu, 21 Jan 2021 23:45:24 GMT
       Expires:
       - "-1"
       Pragma:
@@ -1225,7 +1021,7 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Ms-Ratelimit-Remaining-Subscription-Deletes:
-      - "14994"
+      - "14991"
     status: 200 OK
     code: 200
     duration: ""
@@ -1236,7 +1032,7 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - Go/go1.15.5 (amd64-linux) go-autorest/v14.1.1 k8sinfra-generated
+      - Go/go1.15.6 (amd64-linux) go-autorest/v14.1.1 k8sinfra-generated
     url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-ewlqsf/providers/Microsoft.Storage/storageAccounts/k8sinfrateststorgiatzw?api-version=2019-04-01
     method: GET
   response:
@@ -1249,7 +1045,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Mon, 23 Nov 2020 23:03:56 GMT
+      - Thu, 21 Jan 2021 23:45:24 GMT
       Expires:
       - "-1"
       Pragma:
@@ -1270,7 +1066,7 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - Go/go1.15.5 (amd64-linux) go-autorest/v14.1.1 k8sinfra-generated
+      - Go/go1.15.6 (amd64-linux) go-autorest/v14.1.1 k8sinfra-generated
     url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-ewlqsf/providers/Microsoft.Storage/storageAccounts/k8sinfrateststorgiatzw?api-version=2019-04-01
     method: GET
   response:
@@ -1283,7 +1079,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Mon, 23 Nov 2020 23:04:00 GMT
+      - Thu, 21 Jan 2021 23:45:29 GMT
       Expires:
       - "-1"
       Pragma:

--- a/hack/generated/go.mod
+++ b/hack/generated/go.mod
@@ -18,7 +18,6 @@ require (
 	github.com/onsi/gomega v1.10.1
 	github.com/pkg/errors v0.9.1
 	k8s.io/api v0.18.6
-	k8s.io/apiextensions-apiserver v0.18.6
 	k8s.io/apimachinery v0.18.6
 	k8s.io/client-go v0.18.6
 	k8s.io/klog/v2 v2.0.0

--- a/hack/generated/go.sum
+++ b/hack/generated/go.sum
@@ -581,6 +581,7 @@ sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.0.7/go.mod h1:PHgbrJT
 sigs.k8s.io/controller-runtime v0.5.0/go.mod h1:REiJzC7Y00U+2YkMbT8wxgrsX5USpXKGhb2sCtAXiT8=
 sigs.k8s.io/controller-runtime v0.6.2 h1:jkAnfdTYBpFwlmBn3pS5HFO06SfxvnTZ1p5PeEF/zAA=
 sigs.k8s.io/controller-runtime v0.6.2/go.mod h1:vhcq/rlnENJ09SIRp3EveTaZ0yqH526hjf9iJdbUJ/E=
+sigs.k8s.io/controller-runtime v0.8.0 h1:s0dYdo7lQgJiAf+alP82PRwbz+oAqL3oSyMQ18XRDOc=
 sigs.k8s.io/structured-merge-diff v0.0.0-20190525122527-15d366b2352e/go.mod h1:wWxsB5ozmmv/SG7nM11ayaAW51xMvak/t1r0CSlcokI=
 sigs.k8s.io/structured-merge-diff v1.0.1-0.20191108220359-b1b620dd3f06 h1:zD2IemQ4LmOcAumeiyDWXKUI2SO0NYDe3H6QGvPOVgU=
 sigs.k8s.io/structured-merge-diff v1.0.1-0.20191108220359-b1b620dd3f06/go.mod h1:/ULNhyfzRopfcjskuui0cTITekDduZ7ycKN3oUT9R18=

--- a/hack/generated/pkg/armclient/raw_client.go
+++ b/hack/generated/pkg/armclient/raw_client.go
@@ -111,7 +111,7 @@ func (c *Client) PutDeployment(ctx context.Context, deployment *Deployment) erro
 	return nil
 }
 
-var noDuration time.Duration = 0
+var zeroDuration time.Duration = 0
 
 func (c *Client) GetResource(ctx context.Context, resourceID string, resource interface{}) (time.Duration, error) {
 
@@ -120,13 +120,13 @@ func (c *Client) GetResource(ctx context.Context, resourceID string, resource in
 
 	req, err := c.newRequest(ctx, http.MethodGet, resourceID)
 	if err != nil {
-		return noDuration, err
+		return zeroDuration, err
 	}
 
 	req, err = preparer.Prepare(req)
 	if err != nil {
 		tab.For(ctx).Error(err)
-		return noDuration, err
+		return zeroDuration, err
 	}
 
 	// The linter below doesn't realize that the response is closed in the course of
@@ -135,7 +135,7 @@ func (c *Client) GetResource(ctx context.Context, resourceID string, resource in
 	resp, err := c.Send(req)
 	if err != nil {
 		tab.For(ctx).Error(err)
-		return noDuration, err
+		return zeroDuration, err
 	}
 
 	err = autorest.Respond(

--- a/hack/generated/pkg/armclient/raw_client.go
+++ b/hack/generated/pkg/armclient/raw_client.go
@@ -111,20 +111,22 @@ func (c *Client) PutDeployment(ctx context.Context, deployment *Deployment) erro
 	return nil
 }
 
-func (c *Client) GetResource(ctx context.Context, resourceID string, resource interface{}) (error, time.Duration) {
+var noDuration time.Duration = 0
+
+func (c *Client) GetResource(ctx context.Context, resourceID string, resource interface{}) (time.Duration, error) {
 
 	preparer := autorest.CreatePreparer(
 		autorest.AsContentType("application/json"))
 
 	req, err := c.newRequest(ctx, http.MethodGet, resourceID)
 	if err != nil {
-		return err, 0
+		return noDuration, err
 	}
 
 	req, err = preparer.Prepare(req)
 	if err != nil {
 		tab.For(ctx).Error(err)
-		return err, 0
+		return noDuration, err
 	}
 
 	// The linter below doesn't realize that the response is closed in the course of
@@ -133,7 +135,7 @@ func (c *Client) GetResource(ctx context.Context, resourceID string, resource in
 	resp, err := c.Send(req)
 	if err != nil {
 		tab.For(ctx).Error(err)
-		return err, 0
+		return noDuration, err
 	}
 
 	err = autorest.Respond(
@@ -146,10 +148,10 @@ func (c *Client) GetResource(ctx context.Context, resourceID string, resource in
 
 	if err != nil {
 		tab.For(ctx).Error(err)
-		return err, retryAfter
+		return retryAfter, err
 	}
 
-	return nil, retryAfter
+	return retryAfter, nil
 }
 
 func getRetryAfter(resp *http.Response) time.Duration {

--- a/hack/generated/pkg/armclient/raw_client.go
+++ b/hack/generated/pkg/armclient/raw_client.go
@@ -185,19 +185,19 @@ func parseHttpDate(s string) (time.Time, error) {
 
 // DeleteResource will make an HTTP DELETE call to the resourceId and attempt to fill the resource with the response.
 // If the body of the response is empty, the resource will be nil.
-func (c *Client) DeleteResource(ctx context.Context, resourceID string, resource interface{}) (error, time.Duration) {
+func (c *Client) DeleteResource(ctx context.Context, resourceID string, resource interface{}) (time.Duration, error) {
 	preparer := autorest.CreatePreparer(
 		autorest.AsContentType("application/json"))
 
 	req, err := c.newRequest(ctx, http.MethodDelete, resourceID)
 	if err != nil {
-		return err, 0
+		return zeroDuration, err
 	}
 
 	req, err = preparer.Prepare(req)
 	if err != nil {
 		tab.For(ctx).Error(err)
-		return err, 0
+		return zeroDuration, err
 	}
 
 	// The linter below doesn't realize that the response is closed in the course of
@@ -207,7 +207,7 @@ func (c *Client) DeleteResource(ctx context.Context, resourceID string, resource
 
 	if err != nil {
 		tab.For(ctx).Error(err)
-		return err, 0
+		return zeroDuration, err
 	}
 
 	err = autorest.Respond(
@@ -221,14 +221,14 @@ func (c *Client) DeleteResource(ctx context.Context, resourceID string, resource
 	if err != nil {
 		if IsNotFound(err) {
 			// you asked it to be gone, well, it is.
-			return nil, 0 /* no need to retry */
+			return zeroDuration, nil /* no need to retry */
 		}
 
 		tab.For(ctx).Error(err)
-		return err, retryAfter
+		return retryAfter, err
 	}
 
-	return nil, retryAfter
+	return retryAfter, nil
 }
 
 func (c *Client) newRequest(ctx context.Context, method string, entityPath string) (*http.Request, error) {

--- a/hack/generated/pkg/armclient/raw_client.go
+++ b/hack/generated/pkg/armclient/raw_client.go
@@ -159,9 +159,28 @@ func getRetryAfter(resp *http.Response) time.Duration {
 		if retryAfterVal, parseErr := strconv.ParseInt(retryAfterStr, 10, 64); parseErr == nil {
 			return time.Duration(retryAfterVal) * time.Second
 		}
+
+		if retryAfterTime, parseErr := parseHttpDate(retryAfterStr); parseErr == nil {
+			result := time.Until(retryAfterTime)
+			if result > 0 {
+				return result
+			}
+		}
 	}
 
 	return 0
+}
+
+func parseHttpDate(s string) (time.Time, error) {
+	if t, err := time.Parse("Mon, 02 Jan 2006 15:04:05 MST", s); err == nil {
+		return t, nil
+	} else if t, err = time.Parse("Monday, 02-Jan-06 15:04:05 MST", s); err == nil {
+		return t, nil
+	} else if t, err = time.Parse("Mon Jan  2 15:04:05 2006", s); err == nil {
+		return t, nil
+	}
+
+	return time.Time{}, errors.New("unable to parse date")
 }
 
 // DeleteResource will make an HTTP DELETE call to the resourceId and attempt to fill the resource with the response.

--- a/hack/generated/pkg/armclient/raw_client_test.go
+++ b/hack/generated/pkg/armclient/raw_client_test.go
@@ -1,0 +1,38 @@
+/*
+Copyright (c) Microsoft Corporation.
+Licensed under the MIT license.
+*/
+
+package armclient
+
+import (
+	"testing"
+	"time"
+
+	. "github.com/onsi/gomega"
+)
+
+func TestParseHttpDate(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	gmt, err := time.LoadLocation("GMT")
+	if err != nil {
+		panic(err)
+	}
+
+	expected := time.Date(1994, time.November, 6, 8, 49, 37, 0, gmt)
+
+	// date format examples yanked from: https://www.w3.org/Protocols/rfc2616/rfc2616-sec3.html#sec3.3
+	// see also: https://tools.ietf.org/html/rfc7231#section-7.1.1.1
+	for _, dateFormat := range []string{
+		"Sun, 06 Nov 1994 08:49:37 GMT",  // IMF-fixdate
+		"Sunday, 06-Nov-94 08:49:37 GMT", // obs-date (rfc850-date)
+		"Sun Nov  6 08:49:37 1994",       // obs-date (asctime-date)
+		"Sun Nov 06 08:49:37 1994",       // modified version of last to have 2 digits
+	} {
+		parsed, err := parseHttpDate(dateFormat)
+		g.Expect(err).ToNot(HaveOccurred())
+		// can't use gomega assertion here as .Equal must be called
+		g.Expect(parsed.Equal(expected)).To(BeTrue())
+	}
+}

--- a/hack/generated/pkg/armclient/template_client.go
+++ b/hack/generated/pkg/armclient/template_client.go
@@ -203,7 +203,7 @@ func (atc *AzureTemplateClient) GetResource(
 	status genruntime.ArmResourceStatus) (time.Duration, error) {
 
 	if id == "" {
-		return noDuration, errors.Errorf("resource ID cannot be empty")
+		return zeroDuration, errors.Errorf("resource ID cannot be empty")
 	}
 
 	path := fmt.Sprintf("%s?api-version=%s", id, apiVersion)
@@ -276,7 +276,7 @@ func (atc *AzureTemplateClient) BeginDeleteResource(
 	status genruntime.ArmResourceStatus) (time.Duration, error) {
 
 	if id == "" {
-		return noDuration, errors.Errorf("resource ID cannot be empty")
+		return zeroDuration, errors.Errorf("resource ID cannot be empty")
 	}
 
 	path := fmt.Sprintf("%s?api-version=%s", id, apiVersion)
@@ -295,7 +295,7 @@ func (atc *AzureTemplateClient) BeginDeleteResource(
 // Provider does not implement HEAD. For these reasons, we use an HTTP GET
 func (atc *AzureTemplateClient) HeadResource(ctx context.Context, id string, apiVersion string) (bool, time.Duration, error) {
 	if id == "" {
-		return false, noDuration, fmt.Errorf("resource ID cannot be empty")
+		return false, zeroDuration, fmt.Errorf("resource ID cannot be empty")
 	}
 
 	idAndAPIVersion := id + fmt.Sprintf("?api-version=%s", apiVersion)

--- a/hack/generated/pkg/armclient/template_client.go
+++ b/hack/generated/pkg/armclient/template_client.go
@@ -24,8 +24,8 @@ import (
 // TODO: Naming?
 type Applier interface {
 	CreateDeployment(ctx context.Context, deployment *Deployment) error
-	DeleteDeployment(ctx context.Context, deploymentId string) error
-	GetDeployment(ctx context.Context, deploymentId string) (*Deployment, error)
+	DeleteDeployment(ctx context.Context, deploymentId string) (error, time.Duration)
+	GetDeployment(ctx context.Context, deploymentId string) (*Deployment, error, time.Duration)
 	NewResourceGroupDeployment(resourceGroup string, deploymentName string, resourceSpec genruntime.ArmResourceSpec) *Deployment
 	NewSubscriptionDeployment(location string, deploymentName string, resourceSpec genruntime.ArmResourceSpec) *Deployment
 
@@ -33,9 +33,9 @@ type Applier interface {
 
 	// TODO: These functions take an empty status and fill it out with the response from Azure (rather than as
 	// TODO: the return type. I don't love that pattern but don't have a better one either.
-	BeginDeleteResource(ctx context.Context, id string, apiVersion string, status genruntime.ArmResourceStatus) error
-	GetResource(ctx context.Context, id string, apiVersion string, status genruntime.ArmResourceStatus) error
-	HeadResource(ctx context.Context, id string, apiVersion string) (bool, error)
+	BeginDeleteResource(ctx context.Context, id string, apiVersion string, status genruntime.ArmResourceStatus) (error, time.Duration)
+	GetResource(ctx context.Context, id string, apiVersion string, status genruntime.ArmResourceStatus) (error, time.Duration)
+	HeadResource(ctx context.Context, id string, apiVersion string) (bool, error, time.Duration)
 }
 
 type AzureTemplateClient struct {
@@ -196,14 +196,18 @@ func (atc *AzureTemplateClient) SubscriptionID() string {
 	return atc.subscriptionID
 }
 
-func (atc *AzureTemplateClient) GetResource(ctx context.Context, id string, apiVersion string, status genruntime.ArmResourceStatus) error {
+func (atc *AzureTemplateClient) GetResource(
+	ctx context.Context,
+	id string,
+	apiVersion string,
+	status genruntime.ArmResourceStatus) (error, time.Duration) {
+
 	if id == "" {
-		return errors.Errorf("resource ID cannot be empty")
+		return errors.Errorf("resource ID cannot be empty"), 0
 	}
 
 	path := fmt.Sprintf("%s?api-version=%s", id, apiVersion)
-	err := atc.RawClient.GetResource(ctx, path, &status) // TODO: is this right?
-	return err
+	return atc.RawClient.GetResource(ctx, path, &status) // TODO: is this right?
 }
 
 // CreateDeployment deploys a resource to Azure via a deployment template,
@@ -213,25 +217,25 @@ func (atc *AzureTemplateClient) CreateDeployment(ctx context.Context, deployment
 }
 
 // DeleteDeployment deletes a deployment. If the deployment doesn't exist it does not return an error
-func (atc *AzureTemplateClient) DeleteDeployment(ctx context.Context, deploymentId string) error {
-	err := atc.RawClient.DeleteResource(ctx, idWithAPIVersion(deploymentId), nil)
+func (atc *AzureTemplateClient) DeleteDeployment(ctx context.Context, deploymentId string) (error, time.Duration) {
+	err, retryAfter := atc.RawClient.DeleteResource(ctx, idWithAPIVersion(deploymentId), nil)
 
 	// NotFound is a success
 	if IsNotFound(err) {
-		return nil
+		return nil, retryAfter
 	}
 
-	return err
+	return err, retryAfter
 }
 
-func (atc *AzureTemplateClient) GetDeployment(ctx context.Context, deploymentId string) (*Deployment, error) {
+func (atc *AzureTemplateClient) GetDeployment(ctx context.Context, deploymentId string) (*Deployment, error, time.Duration) {
 	var deployment Deployment
-	err := atc.RawClient.GetResource(ctx, idWithAPIVersion(deploymentId), &deployment)
+	err, retryAfter := atc.RawClient.GetResource(ctx, idWithAPIVersion(deploymentId), &deployment)
 	if err != nil {
-		return nil, err
+		return nil, err, retryAfter
 	}
 
-	return &deployment, nil
+	return &deployment, nil, retryAfter
 }
 
 func createResourceIdTemplate(resourceSpec genruntime.ArmResourceSpec) map[string]Output {
@@ -269,18 +273,19 @@ func (atc *AzureTemplateClient) BeginDeleteResource(
 	ctx context.Context,
 	id string,
 	apiVersion string,
-	status genruntime.ArmResourceStatus) error {
+	status genruntime.ArmResourceStatus) (error, time.Duration) {
 
 	if id == "" {
-		return errors.Errorf("resource ID cannot be empty")
+		return errors.Errorf("resource ID cannot be empty"), 0
 	}
 
 	path := fmt.Sprintf("%s?api-version=%s", id, apiVersion)
-	if err := atc.RawClient.DeleteResource(ctx, path, &status); err != nil {
-		return errors.Wrapf(err, "failed deleting %s", id)
+	err, retryAfter := atc.RawClient.DeleteResource(ctx, path, &status)
+	if err != nil {
+		return errors.Wrapf(err, "failed deleting %s", id), retryAfter
 	}
 
-	return nil
+	return nil, retryAfter /* retry-after here indicates how long to wait before polling */
 }
 
 // HeadResource checks to see if the resource exists
@@ -288,21 +293,21 @@ func (atc *AzureTemplateClient) BeginDeleteResource(
 // Note: this doesn't actually use HTTP HEAD as Azure Resource Manager does not uniformly implement HEAD for all
 // all resources. Also, ARM returns a 400 rather than 405 when requesting HEAD for a resource which the Resource
 // Provider does not implement HEAD. For these reasons, we use an HTTP GET
-func (atc *AzureTemplateClient) HeadResource(ctx context.Context, id string, apiVersion string) (bool, error) {
+func (atc *AzureTemplateClient) HeadResource(ctx context.Context, id string, apiVersion string) (bool, error, time.Duration) {
 	if id == "" {
-		return false, fmt.Errorf("resource ID cannot be empty")
+		return false, fmt.Errorf("resource ID cannot be empty"), 0
 	}
 
 	idAndAPIVersion := id + fmt.Sprintf("?api-version=%s", apiVersion)
 	ignored := struct{}{}
-	err := atc.RawClient.GetResource(ctx, idAndAPIVersion, &ignored)
+	err, retryAfter := atc.RawClient.GetResource(ctx, idAndAPIVersion, &ignored)
 	switch {
 	case IsNotFound(err):
-		return false, nil
+		return false, nil, retryAfter
 	case err != nil:
-		return false, err
+		return false, err, retryAfter
 	default:
-		return true, nil
+		return true, nil, retryAfter
 	}
 }
 

--- a/hack/generated/pkg/armclient/template_client.go
+++ b/hack/generated/pkg/armclient/template_client.go
@@ -285,7 +285,7 @@ func (atc *AzureTemplateClient) BeginDeleteResource(
 		return errors.Wrapf(err, "failed deleting %s", id), retryAfter
 	}
 
-	return nil, retryAfter /* retry-after here indicates how long to wait before polling */
+	return nil, retryAfter /* retry-after here indicates how long to wait before polling for progress */
 }
 
 // HeadResource checks to see if the resource exists

--- a/hack/generated/pkg/armclient/template_client.go
+++ b/hack/generated/pkg/armclient/template_client.go
@@ -218,7 +218,7 @@ func (atc *AzureTemplateClient) CreateDeployment(ctx context.Context, deployment
 
 // DeleteDeployment deletes a deployment. If the deployment doesn't exist it does not return an error
 func (atc *AzureTemplateClient) DeleteDeployment(ctx context.Context, deploymentId string) (time.Duration, error) {
-	err, retryAfter := atc.RawClient.DeleteResource(ctx, idWithAPIVersion(deploymentId), nil)
+	retryAfter, err := atc.RawClient.DeleteResource(ctx, idWithAPIVersion(deploymentId), nil)
 
 	// NotFound is a success
 	if IsNotFound(err) {
@@ -280,7 +280,7 @@ func (atc *AzureTemplateClient) BeginDeleteResource(
 	}
 
 	path := fmt.Sprintf("%s?api-version=%s", id, apiVersion)
-	err, retryAfter := atc.RawClient.DeleteResource(ctx, path, &status)
+	retryAfter, err := atc.RawClient.DeleteResource(ctx, path, &status)
 	if err != nil {
 		return retryAfter, errors.Wrapf(err, "failed deleting %s", id)
 	}

--- a/hack/generated/pkg/armclient/template_client.go
+++ b/hack/generated/pkg/armclient/template_client.go
@@ -24,8 +24,8 @@ import (
 // TODO: Naming?
 type Applier interface {
 	CreateDeployment(ctx context.Context, deployment *Deployment) error
-	DeleteDeployment(ctx context.Context, deploymentId string) (error, time.Duration)
-	GetDeployment(ctx context.Context, deploymentId string) (*Deployment, error, time.Duration)
+	DeleteDeployment(ctx context.Context, deploymentId string) (time.Duration, error)
+	GetDeployment(ctx context.Context, deploymentId string) (*Deployment, time.Duration, error)
 	NewResourceGroupDeployment(resourceGroup string, deploymentName string, resourceSpec genruntime.ArmResourceSpec) *Deployment
 	NewSubscriptionDeployment(location string, deploymentName string, resourceSpec genruntime.ArmResourceSpec) *Deployment
 
@@ -33,9 +33,9 @@ type Applier interface {
 
 	// TODO: These functions take an empty status and fill it out with the response from Azure (rather than as
 	// TODO: the return type. I don't love that pattern but don't have a better one either.
-	BeginDeleteResource(ctx context.Context, id string, apiVersion string, status genruntime.ArmResourceStatus) (error, time.Duration)
-	GetResource(ctx context.Context, id string, apiVersion string, status genruntime.ArmResourceStatus) (error, time.Duration)
-	HeadResource(ctx context.Context, id string, apiVersion string) (bool, error, time.Duration)
+	BeginDeleteResource(ctx context.Context, id string, apiVersion string, status genruntime.ArmResourceStatus) (time.Duration, error)
+	GetResource(ctx context.Context, id string, apiVersion string, status genruntime.ArmResourceStatus) (time.Duration, error)
+	HeadResource(ctx context.Context, id string, apiVersion string) (bool, time.Duration, error)
 }
 
 type AzureTemplateClient struct {
@@ -200,10 +200,10 @@ func (atc *AzureTemplateClient) GetResource(
 	ctx context.Context,
 	id string,
 	apiVersion string,
-	status genruntime.ArmResourceStatus) (error, time.Duration) {
+	status genruntime.ArmResourceStatus) (time.Duration, error) {
 
 	if id == "" {
-		return errors.Errorf("resource ID cannot be empty"), 0
+		return noDuration, errors.Errorf("resource ID cannot be empty")
 	}
 
 	path := fmt.Sprintf("%s?api-version=%s", id, apiVersion)
@@ -217,25 +217,25 @@ func (atc *AzureTemplateClient) CreateDeployment(ctx context.Context, deployment
 }
 
 // DeleteDeployment deletes a deployment. If the deployment doesn't exist it does not return an error
-func (atc *AzureTemplateClient) DeleteDeployment(ctx context.Context, deploymentId string) (error, time.Duration) {
+func (atc *AzureTemplateClient) DeleteDeployment(ctx context.Context, deploymentId string) (time.Duration, error) {
 	err, retryAfter := atc.RawClient.DeleteResource(ctx, idWithAPIVersion(deploymentId), nil)
 
 	// NotFound is a success
 	if IsNotFound(err) {
-		return nil, retryAfter
+		return retryAfter, nil
 	}
 
-	return err, retryAfter
+	return retryAfter, err
 }
 
-func (atc *AzureTemplateClient) GetDeployment(ctx context.Context, deploymentId string) (*Deployment, error, time.Duration) {
+func (atc *AzureTemplateClient) GetDeployment(ctx context.Context, deploymentId string) (*Deployment, time.Duration, error) {
 	var deployment Deployment
-	err, retryAfter := atc.RawClient.GetResource(ctx, idWithAPIVersion(deploymentId), &deployment)
+	retryAfter, err := atc.RawClient.GetResource(ctx, idWithAPIVersion(deploymentId), &deployment)
 	if err != nil {
-		return nil, err, retryAfter
+		return nil, retryAfter, err
 	}
 
-	return &deployment, nil, retryAfter
+	return &deployment, retryAfter, nil
 }
 
 func createResourceIdTemplate(resourceSpec genruntime.ArmResourceSpec) map[string]Output {
@@ -273,19 +273,19 @@ func (atc *AzureTemplateClient) BeginDeleteResource(
 	ctx context.Context,
 	id string,
 	apiVersion string,
-	status genruntime.ArmResourceStatus) (error, time.Duration) {
+	status genruntime.ArmResourceStatus) (time.Duration, error) {
 
 	if id == "" {
-		return errors.Errorf("resource ID cannot be empty"), 0
+		return noDuration, errors.Errorf("resource ID cannot be empty")
 	}
 
 	path := fmt.Sprintf("%s?api-version=%s", id, apiVersion)
 	err, retryAfter := atc.RawClient.DeleteResource(ctx, path, &status)
 	if err != nil {
-		return errors.Wrapf(err, "failed deleting %s", id), retryAfter
+		return retryAfter, errors.Wrapf(err, "failed deleting %s", id)
 	}
 
-	return nil, retryAfter /* retry-after here indicates how long to wait before polling for progress */
+	return retryAfter, nil /* retry-after here indicates how long to wait before polling for progress */
 }
 
 // HeadResource checks to see if the resource exists
@@ -293,21 +293,21 @@ func (atc *AzureTemplateClient) BeginDeleteResource(
 // Note: this doesn't actually use HTTP HEAD as Azure Resource Manager does not uniformly implement HEAD for all
 // all resources. Also, ARM returns a 400 rather than 405 when requesting HEAD for a resource which the Resource
 // Provider does not implement HEAD. For these reasons, we use an HTTP GET
-func (atc *AzureTemplateClient) HeadResource(ctx context.Context, id string, apiVersion string) (bool, error, time.Duration) {
+func (atc *AzureTemplateClient) HeadResource(ctx context.Context, id string, apiVersion string) (bool, time.Duration, error) {
 	if id == "" {
-		return false, fmt.Errorf("resource ID cannot be empty"), 0
+		return false, noDuration, fmt.Errorf("resource ID cannot be empty")
 	}
 
 	idAndAPIVersion := id + fmt.Sprintf("?api-version=%s", apiVersion)
 	ignored := struct{}{}
-	err, retryAfter := atc.RawClient.GetResource(ctx, idAndAPIVersion, &ignored)
+	retryAfter, err := atc.RawClient.GetResource(ctx, idAndAPIVersion, &ignored)
 	switch {
 	case IsNotFound(err):
-		return false, nil, retryAfter
+		return false, retryAfter, nil
 	case err != nil:
-		return false, err, retryAfter
+		return false, retryAfter, err
 	default:
-		return true, nil, retryAfter
+		return true, retryAfter, nil
 	}
 }
 

--- a/hack/generated/pkg/armclient/template_client_test.go
+++ b/hack/generated/pkg/armclient/template_client_test.go
@@ -59,7 +59,7 @@ func Test_NewResourceGroupDeployment(t *testing.T) {
 	log.Printf("Created resource: %s\n", id)
 
 	// Delete the RG
-	err = testContext.AzureClient.BeginDeleteResource(ctx, id, typedResourceGroupSpec.ApiVersion, nil)
+	err, _ = testContext.AzureClient.BeginDeleteResource(ctx, id, typedResourceGroupSpec.ApiVersion, nil)
 	g.Expect(err).ToNot(HaveOccurred())
 
 	// Ensure that the resource group is deleted

--- a/hack/generated/pkg/armclient/template_client_test.go
+++ b/hack/generated/pkg/armclient/template_client_test.go
@@ -59,7 +59,7 @@ func Test_NewResourceGroupDeployment(t *testing.T) {
 	log.Printf("Created resource: %s\n", id)
 
 	// Delete the RG
-	err, _ = testContext.AzureClient.BeginDeleteResource(ctx, id, typedResourceGroupSpec.ApiVersion, nil)
+	_, err = testContext.AzureClient.BeginDeleteResource(ctx, id, typedResourceGroupSpec.ApiVersion, nil)
 	g.Expect(err).ToNot(HaveOccurred())
 
 	// Ensure that the resource group is deleted

--- a/hack/generated/pkg/testcommon/azure_be_deleted_matcher.go
+++ b/hack/generated/pkg/testcommon/azure_be_deleted_matcher.go
@@ -47,7 +47,7 @@ func (m *AzureBeDeletedMatcher) Match(actual interface{}) (bool, error) {
 		return false, err
 	}
 
-	exists, err := m.azureClient.HeadResource(m.ctx, args[0], args[1])
+	exists, err, _ := m.azureClient.HeadResource(m.ctx, args[0], args[1])
 	if err != nil {
 		return false, err
 	}

--- a/hack/generated/pkg/testcommon/azure_be_deleted_matcher.go
+++ b/hack/generated/pkg/testcommon/azure_be_deleted_matcher.go
@@ -47,7 +47,7 @@ func (m *AzureBeDeletedMatcher) Match(actual interface{}) (bool, error) {
 		return false, err
 	}
 
-	exists, err, _ := m.azureClient.HeadResource(m.ctx, args[0], args[1])
+	exists, _, err := m.azureClient.HeadResource(m.ctx, args[0], args[1])
 	if err != nil {
 		return false, err
 	}

--- a/hack/generated/pkg/testcommon/azure_be_provisioned_matcher.go
+++ b/hack/generated/pkg/testcommon/azure_be_provisioned_matcher.go
@@ -44,7 +44,7 @@ func (m *AzureBeProvisionedMatcher) Match(actual interface{}) (bool, error) {
 		return false, err
 	}
 
-	updatedDeployment, err, _ := m.azureClient.GetDeployment(m.ctx, deployment.Id)
+	updatedDeployment, _, err := m.azureClient.GetDeployment(m.ctx, deployment.Id)
 	if err != nil {
 		return false, err
 	}

--- a/hack/generated/pkg/testcommon/azure_be_provisioned_matcher.go
+++ b/hack/generated/pkg/testcommon/azure_be_provisioned_matcher.go
@@ -44,10 +44,11 @@ func (m *AzureBeProvisionedMatcher) Match(actual interface{}) (bool, error) {
 		return false, err
 	}
 
-	updatedDeployment, err := m.azureClient.GetDeployment(m.ctx, deployment.Id)
+	updatedDeployment, err, _ := m.azureClient.GetDeployment(m.ctx, deployment.Id)
 	if err != nil {
 		return false, err
 	}
+
 	*deployment = *updatedDeployment
 
 	log.Printf(

--- a/hack/generated/pkg/testcommon/kube_test_context_envtest.go
+++ b/hack/generated/pkg/testcommon/kube_test_context_envtest.go
@@ -14,7 +14,6 @@ import (
 	"time"
 
 	"github.com/Azure/k8s-infra/hack/generated/controllers"
-	"github.com/dnaeon/go-vcr/recorder"
 	"github.com/google/uuid"
 	"github.com/pkg/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -65,13 +64,6 @@ func createEnvtestContext(perTestContext PerTestContext) (*KubeBaseTestContext, 
 		return nil, errors.Wrapf(err, "creating controller-runtime manager")
 	}
 
-	var requeueDelay time.Duration // defaults to 5s when zero is passed
-	if perTestContext.AzureClientRecorder.Mode() == recorder.ModeReplaying {
-		log.Print("Minimizing requeue delay")
-		// skip requeue delays when replaying
-		requeueDelay = 100 * time.Millisecond
-	}
-
 	log.Print("Registering custom controllers")
 	errs := controllers.RegisterAll(
 		mgr,
@@ -84,7 +76,6 @@ func createEnvtestContext(perTestContext PerTestContext) (*KubeBaseTestContext, 
 				result := uuid.NewSHA1(uuid.Nil, []byte(perTestContext.TestName+"/"+obj.GetNamespace()+"/"+obj.GetName()))
 				return fmt.Sprintf("k8s_%s", result.String()), nil
 			},
-			RequeueDelay: requeueDelay,
 		})
 
 	if errs != nil {


### PR DESCRIPTION
I feel like this is rather messy. Unsure how to improve it at the moment.

The `Applier` now always returns the value of the `Retry-After` header (or a zero duration). It is up to the caller to interpret that, as `Retry-After` can be used in both success (202 Accepted) and error (non-200) situations. 

Also removed the default requeue delay we were using, now relying on the automatic backoff that controller-runtime gives us.