### PR TITLE
Performance improvements during generation

### DIFF
--- a/hack/generator/pkg/astmodel/allof_type.go
+++ b/hack/generator/pkg/astmodel/allof_type.go
@@ -29,10 +29,10 @@ type AllOfType struct {
 
 var _ Type = &AllOfType{}
 
-// MakeAllOfType is a smart constructor for AllOfType,
+// BuildAllOfType is a smart constructor for AllOfType,
 // maintaining the invariants. If only one unique type
 // is passed, then the result will be that type, not an AllOf.
-func MakeAllOfType(types ...Type) Type {
+func BuildAllOfType(types ...Type) Type {
 	uniqueTypes := MakeTypeSet()
 	for _, t := range types {
 		if allOf, ok := t.(*AllOfType); ok {
@@ -75,10 +75,10 @@ func MakeAllOfType(types ...Type) Type {
 
 		var ts []Type
 		oneOfs[0].types.ForEach(func(t Type, _ int) {
-			ts = append(ts, MakeAllOfType(append(notOneOfs, t)...))
+			ts = append(ts, BuildAllOfType(append(notOneOfs, t)...))
 		})
 
-		return MakeOneOfType(ts...)
+		return BuildOneOfType(ts...)
 	} else if len(oneOfs) > 1 {
 		// emit a warning if this ever comes up
 		// (it doesn't at the moment)

--- a/hack/generator/pkg/astmodel/allof_type.go
+++ b/hack/generator/pkg/astmodel/allof_type.go
@@ -89,7 +89,6 @@ func MakeAllOfType(types ...Type) Type {
 	return &AllOfType{uniqueTypes}
 }
 
-
 // Types returns what types the AllOf can be.
 // Exposed as ReadonlyTypeSet so caller can't break invariants.
 func (allOf *AllOfType) Types() ReadonlyTypeSet {

--- a/hack/generator/pkg/astmodel/allof_type.go
+++ b/hack/generator/pkg/astmodel/allof_type.go
@@ -27,13 +27,15 @@ type AllOfType struct {
 	types TypeSet
 }
 
+var _ Type = &AllOfType{}
+
 // MakeAllOfType is a smart constructor for AllOfType,
 // maintaining the invariants. If only one unique type
 // is passed, then the result will be that type, not an AllOf.
 func MakeAllOfType(types ...Type) Type {
 	uniqueTypes := MakeTypeSet()
 	for _, t := range types {
-		if allOf, ok := t.(AllOfType); ok {
+		if allOf, ok := t.(*AllOfType); ok {
 			allOf.types.ForEach(func(t Type, _ int) {
 				uniqueTypes.Add(t)
 			})
@@ -52,10 +54,10 @@ func MakeAllOfType(types ...Type) Type {
 	}
 
 	// see if there are any OneOfs inside
-	var oneOfs []OneOfType
+	var oneOfs []*OneOfType
 	var notOneOfs []Type
 	uniqueTypes.ForEach(func(t Type, _ int) {
-		if oneOf, ok := t.(OneOfType); ok {
+		if oneOf, ok := t.(*OneOfType); ok {
 			oneOfs = append(oneOfs, oneOf)
 		} else {
 			notOneOfs = append(notOneOfs, t)
@@ -84,19 +86,18 @@ func MakeAllOfType(types ...Type) Type {
 	}
 
 	// 0 oneOf (nothing to do) or >1 oneOf (too hard)
-	return AllOfType{uniqueTypes}
+	return &AllOfType{uniqueTypes}
 }
 
-var _ Type = AllOfType{}
 
 // Types returns what types the AllOf can be.
 // Exposed as ReadonlyTypeSet so caller can't break invariants.
-func (allOf AllOfType) Types() ReadonlyTypeSet {
+func (allOf *AllOfType) Types() ReadonlyTypeSet {
 	return allOf.types
 }
 
 // References returns any type referenced by the AllOf types
-func (allOf AllOfType) References() TypeNameSet {
+func (allOf *AllOfType) References() TypeNameSet {
 	var result TypeNameSet
 	allOf.types.ForEach(func(t Type, _ int) {
 		result = SetUnion(result, t.References())
@@ -127,17 +128,21 @@ func (allOf AllOfType) RequiredPackageReferences() *PackageReferenceSet {
 
 // Equals returns true if the other Type is a AllOf that contains
 // the same set of types
-func (allOf AllOfType) Equals(t Type) bool {
-	other, ok := t.(AllOfType)
+func (allOf *AllOfType) Equals(t Type) bool {
+	other, ok := t.(*AllOfType)
 	if !ok {
 		return false
+	}
+
+	if allOf == other {
+		return true // short-circuit
 	}
 
 	return allOf.types.Equals(other.types)
 }
 
 // String implements fmt.Stringer
-func (allOf AllOfType) String() string {
+func (allOf *AllOfType) String() string {
 	var subStrings []string
 	allOf.types.ForEach(func(t Type, _ int) {
 		subStrings = append(subStrings, t.String())

--- a/hack/generator/pkg/astmodel/allof_type_test.go
+++ b/hack/generator/pkg/astmodel/allof_type_test.go
@@ -15,7 +15,7 @@ func TestAllOfOneTypeReturnsThatType(t *testing.T) {
 	g := NewGomegaWithT(t)
 
 	oneType := StringType
-	result := MakeAllOfType(oneType)
+	result := BuildAllOfType(oneType)
 
 	g.Expect(result).To(BeIdenticalTo(oneType))
 }
@@ -24,7 +24,7 @@ func TestAllOfIdenticalTypesReturnsThatType(t *testing.T) {
 	g := NewGomegaWithT(t)
 
 	oneType := StringType
-	result := MakeAllOfType(oneType, oneType)
+	result := BuildAllOfType(oneType, oneType)
 
 	g.Expect(result).To(BeIdenticalTo(oneType))
 }
@@ -32,9 +32,9 @@ func TestAllOfIdenticalTypesReturnsThatType(t *testing.T) {
 func TestAllOfFlattensNestedAllOfs(t *testing.T) {
 	g := NewGomegaWithT(t)
 
-	result := MakeAllOfType(BoolType, MakeAllOfType(StringType, IntType))
+	result := BuildAllOfType(BoolType, BuildAllOfType(StringType, IntType))
 
-	expected := MakeAllOfType(BoolType, StringType, IntType)
+	expected := BuildAllOfType(BoolType, StringType, IntType)
 
 	g.Expect(result).To(Equal(expected))
 }
@@ -42,12 +42,12 @@ func TestAllOfFlattensNestedAllOfs(t *testing.T) {
 func TestAllOfOneOfBecomesOneOfAllOf(t *testing.T) {
 	g := NewGomegaWithT(t)
 
-	oneOf := MakeOneOfType(StringType, FloatType)
-	result := MakeAllOfType(BoolType, IntType, oneOf)
+	oneOf := BuildOneOfType(StringType, FloatType)
+	result := BuildAllOfType(BoolType, IntType, oneOf)
 
-	expected := MakeOneOfType(
-		MakeAllOfType(BoolType, IntType, StringType),
-		MakeAllOfType(BoolType, IntType, FloatType),
+	expected := BuildOneOfType(
+		BuildAllOfType(BoolType, IntType, StringType),
+		BuildAllOfType(BoolType, IntType, FloatType),
 	)
 
 	g.Expect(result).To(Equal(expected))
@@ -56,8 +56,8 @@ func TestAllOfOneOfBecomesOneOfAllOf(t *testing.T) {
 func TestAllOfEqualityDoesNotCareAboutOrder(t *testing.T) {
 	g := NewGomegaWithT(t)
 
-	x := MakeAllOfType(StringType, BoolType)
-	y := MakeAllOfType(BoolType, StringType)
+	x := BuildAllOfType(StringType, BoolType)
+	y := BuildAllOfType(BoolType, StringType)
 
 	g.Expect(x.Equals(y)).To(BeTrue())
 	g.Expect(y.Equals(x)).To(BeTrue())
@@ -66,8 +66,8 @@ func TestAllOfEqualityDoesNotCareAboutOrder(t *testing.T) {
 func TestAllOfMustHaveAllTypesToBeEqual(t *testing.T) {
 	g := NewGomegaWithT(t)
 
-	x := MakeAllOfType(StringType, BoolType, FloatType)
-	y := MakeAllOfType(BoolType, StringType)
+	x := BuildAllOfType(StringType, BoolType, FloatType)
+	y := BuildAllOfType(BoolType, StringType)
 
 	g.Expect(x.Equals(y)).To(BeFalse())
 	g.Expect(y.Equals(x)).To(BeFalse())
@@ -76,8 +76,8 @@ func TestAllOfMustHaveAllTypesToBeEqual(t *testing.T) {
 func TestAllOfsWithDifferentTypesAreNotEqual(t *testing.T) {
 	g := NewGomegaWithT(t)
 
-	x := MakeAllOfType(StringType, FloatType)
-	y := MakeAllOfType(BoolType, StringType)
+	x := BuildAllOfType(StringType, FloatType)
+	y := BuildAllOfType(BoolType, StringType)
 
 	g.Expect(x.Equals(y)).To(BeFalse())
 	g.Expect(y.Equals(x)).To(BeFalse())

--- a/hack/generator/pkg/astmodel/armconversion/convert_from_arm_function_builder.go
+++ b/hack/generator/pkg/astmodel/armconversion/convert_from_arm_function_builder.go
@@ -199,7 +199,7 @@ func (builder *convertFromArmBuilder) propertiesWithSameNameAndTypeHandler(
 	// check that we are assigning to the same type or a validated
 	// version of the same type
 	toType := toProp.PropertyType()
-	if toValidated, ok := toType.(astmodel.ValidatedType); ok {
+	if toValidated, ok := toType.(*astmodel.ValidatedType); ok {
 		toType = toValidated.ElementType()
 	}
 
@@ -311,7 +311,7 @@ func (builder *convertFromArmBuilder) fromArmComplexPropertyConversion(
 		return builder.convertComplexTypeNameProperty(params)
 	case *astmodel.PrimitiveType:
 		return builder.assignPrimitiveType(params)
-	case astmodel.ValidatedType:
+	case *astmodel.ValidatedType:
 		// pass through to underlying type
 		params.destinationType = concrete.ElementType()
 		return builder.fromArmComplexPropertyConversion(params)

--- a/hack/generator/pkg/astmodel/armconversion/convert_to_arm_function_builder.go
+++ b/hack/generator/pkg/astmodel/armconversion/convert_to_arm_function_builder.go
@@ -275,7 +275,7 @@ func (builder *convertToArmBuilder) toArmComplexPropertyConversion(
 	case *astmodel.PrimitiveType:
 		// No conversion needed in this case.
 		return builder.assignPrimitiveType(params)
-	case astmodel.ValidatedType:
+	case *astmodel.ValidatedType:
 		// pass through to underlying type
 		params.destinationType = concrete.ElementType()
 		return builder.toArmComplexPropertyConversion(params)

--- a/hack/generator/pkg/astmodel/errored_type.go
+++ b/hack/generator/pkg/astmodel/errored_type.go
@@ -36,32 +36,32 @@ func (e *ErroredType) InnerType() Type {
 	return e.inner
 }
 
-func (errored *ErroredType) WithType(t Type) *ErroredType {
+func (e *ErroredType) WithType(t Type) *ErroredType {
 	if otherError, ok := t.(*ErroredType); ok {
 		// nested errors merge errors & warnings
-		errored.inner = otherError.inner
-		errored.errors = append(errored.errors, otherError.errors...)
-		errored.warnings = append(errored.warnings, otherError.warnings...)
+		e.inner = otherError.inner
+		e.errors = append(e.errors, otherError.errors...)
+		e.warnings = append(e.warnings, otherError.warnings...)
 	} else {
-		errored.inner = t
+		e.inner = t
 	}
 
-	return errored
+	return e
 }
 
-func (errored *ErroredType) Equals(t Type) bool {
+func (e *ErroredType) Equals(t Type) bool {
 	other, ok := t.(*ErroredType)
 	if !ok {
 		return false
 	}
 
-	if errored == other {
+	if e == other {
 		return true // short-circuit
 	}
 
-	return ((errored.inner == nil && other.inner == nil) || errored.inner.Equals(other.inner)) &&
-		stringSlicesEqual(errored.warnings, other.warnings) &&
-		stringSlicesEqual(errored.errors, other.errors)
+	return ((e.inner == nil && other.inner == nil) || e.inner.Equals(other.inner)) &&
+		stringSlicesEqual(e.warnings, other.warnings) &&
+		stringSlicesEqual(e.errors, other.errors)
 }
 
 func stringSlicesEqual(l []string, r []string) bool {
@@ -78,68 +78,68 @@ func stringSlicesEqual(l []string, r []string) bool {
 	return true
 }
 
-func (errored *ErroredType) References() TypeNameSet {
-	if errored.inner == nil {
+func (e *ErroredType) References() TypeNameSet {
+	if e.inner == nil {
 		return nil
 	}
 
-	return errored.inner.References()
+	return e.inner.References()
 }
 
-func (errored *ErroredType) RequiredPackageReferences() *PackageReferenceSet {
-	if errored.inner == nil {
+func (e *ErroredType) RequiredPackageReferences() *PackageReferenceSet {
+	if e.inner == nil {
 		return NewPackageReferenceSet()
 	}
 
-	return errored.inner.RequiredPackageReferences()
+	return e.inner.RequiredPackageReferences()
 }
 
-func (errored *ErroredType) handleWarningsAndErrors() {
-	for _, warning := range errored.warnings {
+func (e *ErroredType) handleWarningsAndErrors() {
+	for _, warning := range e.warnings {
 		klog.Warning(warning)
 	}
 
-	if len(errored.errors) > 0 {
-		var es []error
-		for _, e := range errored.errors {
-			es = append(es, errors.New(e))
+	if len(e.errors) > 0 {
+		var errs []error
+		for _, err := range e.errors {
+			errs = append(errs, errors.New(err))
 		}
 
-		if len(es) == 1 {
-			panic(es[0])
+		if len(errs) == 1 {
+			panic(errs[0])
 		} else {
-			panic(kerrors.NewAggregate(es))
+			panic(kerrors.NewAggregate(errs))
 		}
 	}
 }
 
-func (errored *ErroredType) AsDeclarations(cgc *CodeGenerationContext, dc DeclarationContext) []dst.Decl {
-	errored.handleWarningsAndErrors()
-	if errored.inner == nil {
+func (e *ErroredType) AsDeclarations(cgc *CodeGenerationContext, dc DeclarationContext) []dst.Decl {
+	e.handleWarningsAndErrors()
+	if e.inner == nil {
 		return nil
 	}
 
-	return errored.inner.AsDeclarations(cgc, dc)
+	return e.inner.AsDeclarations(cgc, dc)
 }
 
-func (errored *ErroredType) AsType(cgc *CodeGenerationContext) dst.Expr {
-	errored.handleWarningsAndErrors()
-	if errored.inner == nil {
+func (e *ErroredType) AsType(cgc *CodeGenerationContext) dst.Expr {
+	e.handleWarningsAndErrors()
+	if e.inner == nil {
 		return nil
 	}
 
-	return errored.inner.AsType(cgc)
+	return e.inner.AsType(cgc)
 }
 
-func (errored *ErroredType) String() string {
-	if errored.inner == nil {
+func (e *ErroredType) String() string {
+	if e.inner == nil {
 		return "(error hole)"
 	}
 
 	has := "warnings"
-	if len(errored.errors) > 0 {
+	if len(e.errors) > 0 {
 		has = "errors"
 	}
 
-	return fmt.Sprintf("%s (has %s)", errored.inner.String(), has)
+	return fmt.Sprintf("%s (has %s)", e.inner.String(), has)
 }

--- a/hack/generator/pkg/astmodel/errored_type.go
+++ b/hack/generator/pkg/astmodel/errored_type.go
@@ -22,7 +22,7 @@ type ErroredType struct {
 
 var _ Type = &ErroredType{}
 
-func MakeErroredType(t Type, errors []string, warnings []string) *ErroredType {
+func NewErroredType(t Type, errors []string, warnings []string) *ErroredType {
 	result := &ErroredType{
 		inner:    nil,
 		errors:   errors,

--- a/hack/generator/pkg/astmodel/errored_type.go
+++ b/hack/generator/pkg/astmodel/errored_type.go
@@ -28,7 +28,7 @@ func MakeErroredType(t Type, errors []string, warnings []string) *ErroredType {
 		errors:   errors,
 		warnings: warnings,
 	}
-	
+
 	return result.WithType(t) // using WithType ensures warnings and errors get merged if needed
 }
 
@@ -48,7 +48,6 @@ func (errored *ErroredType) WithType(t Type) *ErroredType {
 
 	return errored
 }
-
 
 func (errored *ErroredType) Equals(t Type) bool {
 	other, ok := t.(*ErroredType)

--- a/hack/generator/pkg/astmodel/errored_type_test.go
+++ b/hack/generator/pkg/astmodel/errored_type_test.go
@@ -19,7 +19,7 @@ func TestErroredTypeProperties(t *testing.T) {
 	g.Property("wrapping an ErroredType with another merges its errors and warnings",
 		prop.ForAll(
 			func(e1 []string, e2 []string, w1 []string, w2 []string) bool {
-				t := MakeErroredType(MakeErroredType(StringType, e1, w1), e2, w2)
+				t := NewErroredType(NewErroredType(StringType, e1, w1), e2, w2)
 
 				return stringSlicesEqual(t.errors, append(e2, e1...)) &&
 					stringSlicesEqual(t.warnings, append(w2, w1...)) &&

--- a/hack/generator/pkg/astmodel/kubernetes_resource_interface.go
+++ b/hack/generator/pkg/astmodel/kubernetes_resource_interface.go
@@ -152,7 +152,7 @@ func generateDefaulter(resourceName TypeName, spec *ObjectType, idFactory Identi
 func getAzureNameFunctionsForType(r **ResourceType, spec *ObjectType, t Type, types Types) (asFuncType, asFuncType, error) {
 	// handle different types of AzureName property
 	switch azureNamePropType := t.(type) {
-	case ValidatedType:
+	case *ValidatedType:
 		if !azureNamePropType.ElementType().Equals(StringType) {
 			return nil, nil, errors.Errorf("unable to handle non-string validated types in AzureName property")
 		}

--- a/hack/generator/pkg/astmodel/object_type_serialization_test_case.go
+++ b/hack/generator/pkg/astmodel/object_type_serialization_test_case.go
@@ -573,7 +573,7 @@ func (o ObjectSerializationTestCase) createIndependentGenerator(
 			return astbuilder.CallQualifiedFunc(genPackage, "MapOf", keyGen, valueGen)
 		}
 
-	case ValidatedType:
+	case *ValidatedType:
 		// TODO: we should restrict the values of generated types
 		//       but at the moment this is only used for serialization tests, so doesn't affect
 		//       anything
@@ -630,7 +630,7 @@ func (o ObjectSerializationTestCase) createRelatedGenerator(
 			return astbuilder.CallQualifiedFunc(genPackageName, "MapOf", keyGen, valueGen)
 		}
 
-	case ValidatedType:
+	case *ValidatedType:
 		// TODO: we should restrict the values of generated types
 		//       but at the moment this is only used for serialization tests, so doesn't affect
 		//       anything

--- a/hack/generator/pkg/astmodel/oneof_type.go
+++ b/hack/generator/pkg/astmodel/oneof_type.go
@@ -26,10 +26,10 @@ type OneOfType struct {
 
 var _ Type = &OneOfType{}
 
-// MakeOneOfType is a smart constructor for a  OneOfType,
+// BuildOneOfType is a smart constructor for a  OneOfType,
 // maintaining the invariants. If only one unique type
 // is passed, the result will be that type, not a OneOf.
-func MakeOneOfType(types ...Type) Type {
+func BuildOneOfType(types ...Type) Type {
 	uniqueTypes := MakeTypeSet()
 	for _, t := range types {
 		if oneOf, ok := t.(*OneOfType); ok {

--- a/hack/generator/pkg/astmodel/oneof_type.go
+++ b/hack/generator/pkg/astmodel/oneof_type.go
@@ -24,13 +24,15 @@ type OneOfType struct {
 	types TypeSet
 }
 
+var _ Type = &OneOfType{}
+
 // MakeOneOfType is a smart constructor for a  OneOfType,
 // maintaining the invariants. If only one unique type
 // is passed, the result will be that type, not a OneOf.
 func MakeOneOfType(types ...Type) Type {
 	uniqueTypes := MakeTypeSet()
 	for _, t := range types {
-		if oneOf, ok := t.(OneOfType); ok {
+		if oneOf, ok := t.(*OneOfType); ok {
 			oneOf.types.ForEach(func(t Type, _ int) {
 				uniqueTypes.Add(t)
 			})
@@ -48,19 +50,17 @@ func MakeOneOfType(types ...Type) Type {
 		return result
 	}
 
-	return OneOfType{uniqueTypes}
+	return &OneOfType{uniqueTypes}
 }
-
-var _ Type = OneOfType{}
 
 // Types returns what types the OneOf can be.
 // Exposed as ReadonlyTypeSet so caller can't break invariants.
-func (oneOf OneOfType) Types() ReadonlyTypeSet {
+func (oneOf *OneOfType) Types() ReadonlyTypeSet {
 	return oneOf.types
 }
 
 // References returns any type referenced by the OneOf types
-func (oneOf OneOfType) References() TypeNameSet {
+func (oneOf *OneOfType) References() TypeNameSet {
 	var result TypeNameSet
 
 	oneOf.types.ForEach(func(t Type, _ int) {
@@ -91,17 +91,21 @@ func (oneOf OneOfType) RequiredPackageReferences() *PackageReferenceSet {
 
 // Equals returns true if the other Type is a OneOfType that contains
 // the same set of types
-func (oneOf OneOfType) Equals(t Type) bool {
-	other, ok := t.(OneOfType)
+func (oneOf *OneOfType) Equals(t Type) bool {
+	other, ok := t.(*OneOfType)
 	if !ok {
 		return false
+	}
+
+	if oneOf == other {
+		return true // short-circuit
 	}
 
 	return oneOf.types.Equals(other.types)
 }
 
 // String implements fmt.Stringer
-func (oneOf OneOfType) String() string {
+func (oneOf *OneOfType) String() string {
 	var subStrings []string
 	oneOf.types.ForEach(func(t Type, _ int) {
 		subStrings = append(subStrings, t.String())

--- a/hack/generator/pkg/astmodel/oneof_type_test.go
+++ b/hack/generator/pkg/astmodel/oneof_type_test.go
@@ -15,7 +15,7 @@ func TestOneOfOneTypeReturnsThatType(t *testing.T) {
 	g := NewGomegaWithT(t)
 
 	oneType := StringType
-	result := MakeOneOfType(oneType)
+	result := BuildOneOfType(oneType)
 
 	g.Expect(result).To(BeIdenticalTo(oneType))
 }
@@ -24,7 +24,7 @@ func TestOneOfIdenticalTypesReturnsThatType(t *testing.T) {
 	g := NewGomegaWithT(t)
 
 	oneType := StringType
-	result := MakeOneOfType(oneType, oneType)
+	result := BuildOneOfType(oneType, oneType)
 
 	g.Expect(result).To(BeIdenticalTo(oneType))
 }
@@ -32,9 +32,9 @@ func TestOneOfIdenticalTypesReturnsThatType(t *testing.T) {
 func TestOneOfFlattensNestedOneOfs(t *testing.T) {
 	g := NewGomegaWithT(t)
 
-	result := MakeOneOfType(BoolType, MakeOneOfType(StringType, IntType))
+	result := BuildOneOfType(BoolType, BuildOneOfType(StringType, IntType))
 
-	expected := MakeOneOfType(BoolType, StringType, IntType)
+	expected := BuildOneOfType(BoolType, StringType, IntType)
 
 	g.Expect(result).To(Equal(expected))
 }
@@ -42,8 +42,8 @@ func TestOneOfFlattensNestedOneOfs(t *testing.T) {
 func TestOneOfEqualityDoesNotCareAboutOrder(t *testing.T) {
 	g := NewGomegaWithT(t)
 
-	x := MakeOneOfType(StringType, BoolType)
-	y := MakeOneOfType(BoolType, StringType)
+	x := BuildOneOfType(StringType, BoolType)
+	y := BuildOneOfType(BoolType, StringType)
 
 	g.Expect(x.Equals(y)).To(BeTrue())
 	g.Expect(y.Equals(x)).To(BeTrue())
@@ -52,8 +52,8 @@ func TestOneOfEqualityDoesNotCareAboutOrder(t *testing.T) {
 func TestOneOfMustHaveAllTypesToBeEqual(t *testing.T) {
 	g := NewGomegaWithT(t)
 
-	x := MakeOneOfType(StringType, BoolType, FloatType)
-	y := MakeOneOfType(BoolType, StringType)
+	x := BuildOneOfType(StringType, BoolType, FloatType)
+	y := BuildOneOfType(BoolType, StringType)
 
 	g.Expect(x.Equals(y)).To(BeFalse())
 	g.Expect(y.Equals(x)).To(BeFalse())
@@ -62,8 +62,8 @@ func TestOneOfMustHaveAllTypesToBeEqual(t *testing.T) {
 func TestOneOfsWithDifferentTypesAreNotEqual(t *testing.T) {
 	g := NewGomegaWithT(t)
 
-	x := MakeOneOfType(StringType, FloatType)
-	y := MakeOneOfType(BoolType, StringType)
+	x := BuildOneOfType(StringType, FloatType)
+	y := BuildOneOfType(BoolType, StringType)
 
 	g.Expect(x.Equals(y)).To(BeFalse())
 	g.Expect(y.Equals(x)).To(BeFalse())

--- a/hack/generator/pkg/astmodel/property_definition.go
+++ b/hack/generator/pkg/astmodel/property_definition.go
@@ -252,7 +252,7 @@ func (property *PropertyDefinition) AsField(codeGenerationContext *CodeGeneratio
 
 	// if we have validations, unwrap them
 	propType := property.propertyType
-	if validated, ok := propType.(ValidatedType); ok {
+	if validated, ok := propType.(*ValidatedType); ok {
 		propType = validated.ElementType()
 		AddValidationComments(&doc, validated.Validations().ToKubeBuilderValidations())
 	}

--- a/hack/generator/pkg/astmodel/type.go
+++ b/hack/generator/pkg/astmodel/type.go
@@ -38,7 +38,7 @@ type Type interface {
 
 // IgnoringErrors returns the type stripped of any ErroredType wrapper
 func IgnoringErrors(t Type) Type {
-	if errored, ok := t.(ErroredType); ok {
+	if errored, ok := t.(*ErroredType); ok {
 		return errored.InnerType()
 	}
 

--- a/hack/generator/pkg/astmodel/type_visitor.go
+++ b/hack/generator/pkg/astmodel/type_visitor.go
@@ -301,6 +301,8 @@ func IdentityVisitOfAllOfType(this *TypeVisitor, it *AllOfType, ctx interface{})
 }
 
 // just checks reference equality of Types
+// this is used to short-circuit when we don't need to make new types,
+// in a fast manner than invoking Equals and walking the whole tree
 func typeSlicesFastEqual(t1 []Type, t2 []Type) bool {
 	if len(t1) != len(t2) {
 		return false

--- a/hack/generator/pkg/astmodel/type_visitor.go
+++ b/hack/generator/pkg/astmodel/type_visitor.go
@@ -274,7 +274,7 @@ func IdentityVisitOfOneOfType(this *TypeVisitor, it *OneOfType, ctx interface{})
 		return it, nil // short-circuit
 	}
 
-	return MakeOneOfType(newTypes...), nil
+	return BuildOneOfType(newTypes...), nil
 }
 
 func IdentityVisitOfAllOfType(this *TypeVisitor, it *AllOfType, ctx interface{}) (Type, error) {
@@ -297,7 +297,7 @@ func IdentityVisitOfAllOfType(this *TypeVisitor, it *AllOfType, ctx interface{})
 		return it, nil // short-circuit
 	}
 
-	return MakeAllOfType(newTypes...), nil
+	return BuildAllOfType(newTypes...), nil
 }
 
 // just checks reference equality of Types

--- a/hack/generator/pkg/astmodel/type_visitor.go
+++ b/hack/generator/pkg/astmodel/type_visitor.go
@@ -27,7 +27,7 @@ type TypeVisitor struct {
 	VisitEnumType      func(this *TypeVisitor, it *EnumType, ctx interface{}) (Type, error)
 	VisitResourceType  func(this *TypeVisitor, it *ResourceType, ctx interface{}) (Type, error)
 	VisitFlaggedType   func(this *TypeVisitor, it *FlaggedType, ctx interface{}) (Type, error)
-	VisitValidatedType func(this *TypeVisitor, it ValidatedType, ctx interface{}) (Type, error)
+	VisitValidatedType func(this *TypeVisitor, it *ValidatedType, ctx interface{}) (Type, error)
 	VisitErroredType   func(this *TypeVisitor, it *ErroredType, ctx interface{}) (Type, error)
 }
 
@@ -60,7 +60,7 @@ func (tv *TypeVisitor) Visit(t Type, ctx interface{}) (Type, error) {
 		return tv.VisitResourceType(tv, it, ctx)
 	case *FlaggedType:
 		return tv.VisitFlaggedType(tv, it, ctx)
-	case ValidatedType:
+	case *ValidatedType:
 		return tv.VisitValidatedType(tv, it, ctx)
 	case *ErroredType:
 		return tv.VisitErroredType(tv, it, ctx)
@@ -330,7 +330,7 @@ func IdentityVisitOfFlaggedType(this *TypeVisitor, ft *FlaggedType, ctx interfac
 	return ft.WithElement(nt), nil
 }
 
-func IdentityVisitOfValidatedType(this *TypeVisitor, v ValidatedType, ctx interface{}) (Type, error) {
+func IdentityVisitOfValidatedType(this *TypeVisitor, v *ValidatedType, ctx interface{}) (Type, error) {
 	nt, err := this.Visit(v.element, ctx)
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to visit validated type %T", v.element)

--- a/hack/generator/pkg/astmodel/type_visitor.go
+++ b/hack/generator/pkg/astmodel/type_visitor.go
@@ -17,8 +17,8 @@ import (
 // The `ctx` argument can be used to “smuggle” additional data down the call-chain.
 type TypeVisitor struct {
 	VisitTypeName      func(this *TypeVisitor, it TypeName, ctx interface{}) (Type, error)
-	VisitOneOfType     func(this *TypeVisitor, it OneOfType, ctx interface{}) (Type, error)
-	VisitAllOfType     func(this *TypeVisitor, it AllOfType, ctx interface{}) (Type, error)
+	VisitOneOfType     func(this *TypeVisitor, it *OneOfType, ctx interface{}) (Type, error)
+	VisitAllOfType     func(this *TypeVisitor, it *AllOfType, ctx interface{}) (Type, error)
 	VisitArrayType     func(this *TypeVisitor, it *ArrayType, ctx interface{}) (Type, error)
 	VisitPrimitive     func(this *TypeVisitor, it *PrimitiveType, ctx interface{}) (Type, error)
 	VisitObjectType    func(this *TypeVisitor, it *ObjectType, ctx interface{}) (Type, error)
@@ -28,7 +28,7 @@ type TypeVisitor struct {
 	VisitResourceType  func(this *TypeVisitor, it *ResourceType, ctx interface{}) (Type, error)
 	VisitFlaggedType   func(this *TypeVisitor, it *FlaggedType, ctx interface{}) (Type, error)
 	VisitValidatedType func(this *TypeVisitor, it ValidatedType, ctx interface{}) (Type, error)
-	VisitErroredType   func(this *TypeVisitor, it ErroredType, ctx interface{}) (Type, error)
+	VisitErroredType   func(this *TypeVisitor, it *ErroredType, ctx interface{}) (Type, error)
 }
 
 // Visit invokes the appropriate VisitX on TypeVisitor
@@ -40,9 +40,9 @@ func (tv *TypeVisitor) Visit(t Type, ctx interface{}) (Type, error) {
 	switch it := t.(type) {
 	case TypeName:
 		return tv.VisitTypeName(tv, it, ctx)
-	case OneOfType:
+	case *OneOfType:
 		return tv.VisitOneOfType(tv, it, ctx)
-	case AllOfType:
+	case *AllOfType:
 		return tv.VisitAllOfType(tv, it, ctx)
 	case *ArrayType:
 		return tv.VisitArrayType(tv, it, ctx)
@@ -62,7 +62,7 @@ func (tv *TypeVisitor) Visit(t Type, ctx interface{}) (Type, error) {
 		return tv.VisitFlaggedType(tv, it, ctx)
 	case ValidatedType:
 		return tv.VisitValidatedType(tv, it, ctx)
-	case ErroredType:
+	case *ErroredType:
 		return tv.VisitErroredType(tv, it, ctx)
 	}
 
@@ -145,6 +145,10 @@ func IdentityVisitOfArrayType(this *TypeVisitor, it *ArrayType, ctx interface{})
 		return nil, errors.Wrap(err, "failed to visit type of array")
 	}
 
+	if newElement == it.element {
+		return it, nil // short-circuit
+	}
+
 	return NewArrayType(newElement), nil
 }
 
@@ -206,6 +210,10 @@ func IdentityVisitOfMapType(this *TypeVisitor, it *MapType, ctx interface{}) (Ty
 		return nil, errors.Wrapf(err, "failed to visit map value type %T", it.value)
 	}
 
+	if visitedKey == it.key && visitedValue == it.value {
+		return it, nil // short-circuit
+	}
+
 	return NewMapType(visitedKey, visitedValue), nil
 }
 
@@ -219,6 +227,10 @@ func IdentityVisitOfOptionalType(this *TypeVisitor, it *OptionalType, ctx interf
 	visitedElement, err := this.Visit(it.element, ctx)
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to visit optional element type %T", it.element)
+	}
+
+	if visitedElement == it.element {
+		return it, nil // short-circuit
 	}
 
 	return NewOptionalType(visitedElement), nil
@@ -235,10 +247,14 @@ func IdentityVisitOfResourceType(this *TypeVisitor, it *ResourceType, ctx interf
 		return nil, errors.Wrapf(err, "failed to visit resource status type %T", it.status)
 	}
 
+	if visitedSpec == it.spec && visitedStatus == it.status {
+		return it, nil // short-circuit
+	}
+
 	return it.WithSpec(visitedSpec).WithStatus(visitedStatus), nil
 }
 
-func IdentityVisitOfOneOfType(this *TypeVisitor, it OneOfType, ctx interface{}) (Type, error) {
+func IdentityVisitOfOneOfType(this *TypeVisitor, it *OneOfType, ctx interface{}) (Type, error) {
 	var newTypes []Type
 	err := it.Types().ForEachError(func(oneOf Type, _ int) error {
 		newType, err := this.Visit(oneOf, ctx)
@@ -254,10 +270,14 @@ func IdentityVisitOfOneOfType(this *TypeVisitor, it OneOfType, ctx interface{}) 
 		return nil, err
 	}
 
+	if typeSlicesFastEqual(newTypes, it.types.types) {
+		return it, nil // short-circuit
+	}
+
 	return MakeOneOfType(newTypes...), nil
 }
 
-func IdentityVisitOfAllOfType(this *TypeVisitor, it AllOfType, ctx interface{}) (Type, error) {
+func IdentityVisitOfAllOfType(this *TypeVisitor, it *AllOfType, ctx interface{}) (Type, error) {
 	var newTypes []Type
 	err := it.Types().ForEachError(func(allOf Type, _ int) error {
 		newType, err := this.Visit(allOf, ctx)
@@ -273,7 +293,26 @@ func IdentityVisitOfAllOfType(this *TypeVisitor, it AllOfType, ctx interface{}) 
 		return nil, err
 	}
 
+	if typeSlicesFastEqual(newTypes, it.types.types) {
+		return it, nil // short-circuit
+	}
+
 	return MakeAllOfType(newTypes...), nil
+}
+
+// just checks reference equality of Types
+func typeSlicesFastEqual(t1 []Type, t2 []Type) bool {
+	if len(t1) != len(t2) {
+		return false
+	}
+
+	for ix := range t1 {
+		if t1[ix] != t2[ix] {
+			return false
+		}
+	}
+
+	return true
 }
 
 func IdentityVisitOfFlaggedType(this *TypeVisitor, ft *FlaggedType, ctx interface{}) (Type, error) {
@@ -283,7 +322,7 @@ func IdentityVisitOfFlaggedType(this *TypeVisitor, ft *FlaggedType, ctx interfac
 	}
 
 	if nt == ft.element {
-		return ft, nil
+		return ft, nil // short-circuit
 	}
 
 	return ft.WithElement(nt), nil
@@ -295,13 +334,21 @@ func IdentityVisitOfValidatedType(this *TypeVisitor, v ValidatedType, ctx interf
 		return nil, errors.Wrapf(err, "failed to visit validated type %T", v.element)
 	}
 
+	if nt == v.element {
+		return v, nil // short-circuit
+	}
+
 	return v.WithType(nt), nil
 }
 
-func IdentityVisitOfErroredType(this *TypeVisitor, e ErroredType, ctx interface{}) (Type, error) {
+func IdentityVisitOfErroredType(this *TypeVisitor, e *ErroredType, ctx interface{}) (Type, error) {
 	nt, err := this.Visit(e.inner, ctx)
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to visit errored type %T", e.inner)
+	}
+
+	if nt == e.inner {
+		return e, nil // short-circuit
 	}
 
 	return e.WithType(nt), nil

--- a/hack/generator/pkg/astmodel/validated_type.go
+++ b/hack/generator/pkg/astmodel/validated_type.go
@@ -147,44 +147,45 @@ func NewValidatedType(element Type, validations Validations) *ValidatedType {
 	return &ValidatedType{element: element, validations: validations}
 }
 
-func (v ValidatedType) ElementType() Type {
+func (v *ValidatedType) ElementType() Type {
 	return v.element
 }
 
-func (v ValidatedType) Validations() Validations {
+func (v *ValidatedType) Validations() Validations {
 	return v.validations
 }
 
-func (v ValidatedType) WithType(newElement Type) *ValidatedType {
-	v.element = newElement
-	return &v
+func (v *ValidatedType) WithType(newElement Type) *ValidatedType {
+	result := *v
+	result.element = newElement
+	return &result
 }
 
 var _ Type = &ValidatedType{}
 
-func (v ValidatedType) AsDeclarations(c *CodeGenerationContext, declContext DeclarationContext) []dst.Decl {
+func (v *ValidatedType) AsDeclarations(c *CodeGenerationContext, declContext DeclarationContext) []dst.Decl {
 	declContext.Validations = append(declContext.Validations, v.validations.ToKubeBuilderValidations()...)
 	return v.ElementType().AsDeclarations(c, declContext)
 }
 
-func (v ValidatedType) AsType(_ *CodeGenerationContext) dst.Expr {
+func (v *ValidatedType) AsType(_ *CodeGenerationContext) dst.Expr {
 	panic("Should never happen: validated types must either be named (handled by 'name types for CRDs' pipeline stage) or be directly under properties (handled by PropertyDefinition.AsField)")
 }
 
-func (v ValidatedType) References() TypeNameSet {
+func (v *ValidatedType) References() TypeNameSet {
 	return v.element.References()
 }
 
-func (v ValidatedType) RequiredPackageReferences() *PackageReferenceSet {
+func (v *ValidatedType) RequiredPackageReferences() *PackageReferenceSet {
 	return v.element.RequiredPackageReferences()
 }
 
-func (v ValidatedType) String() string {
+func (v *ValidatedType) String() string {
 	return fmt.Sprintf("Validated(%s)", v.element.String())
 }
 
-func (v ValidatedType) Equals(t Type) bool {
-	other, ok := t.(ValidatedType)
+func (v *ValidatedType) Equals(t Type) bool {
+	other, ok := t.(*ValidatedType)
 	if !ok {
 		return false
 	}

--- a/hack/generator/pkg/astmodel/validated_type.go
+++ b/hack/generator/pkg/astmodel/validated_type.go
@@ -143,8 +143,8 @@ type ValidatedType struct {
 	element     Type
 }
 
-func MakeValidatedType(element Type, validations Validations) ValidatedType {
-	return ValidatedType{element: element, validations: validations}
+func NewValidatedType(element Type, validations Validations) *ValidatedType {
+	return &ValidatedType{element: element, validations: validations}
 }
 
 func (v ValidatedType) ElementType() Type {
@@ -155,12 +155,12 @@ func (v ValidatedType) Validations() Validations {
 	return v.validations
 }
 
-func (v ValidatedType) WithType(newElement Type) ValidatedType {
+func (v ValidatedType) WithType(newElement Type) *ValidatedType {
 	v.element = newElement
-	return v
+	return &v
 }
 
-var _ Type = ValidatedType{}
+var _ Type = &ValidatedType{}
 
 func (v ValidatedType) AsDeclarations(c *CodeGenerationContext, declContext DeclarationContext) []dst.Decl {
 	declContext.Validations = append(declContext.Validations, v.validations.ToKubeBuilderValidations()...)

--- a/hack/generator/pkg/codegen/pipeline_augment_status.go
+++ b/hack/generator/pkg/codegen/pipeline_augment_status.go
@@ -80,7 +80,7 @@ func augmentResourcesWithStatus(idFactory astmodel.IdentifierFactory, config *co
 						klog.V(4).Infof("Swagger information missing for %v", typeName)
 						// add a warning that the status is missing
 						// this will be reported if the type is not pruned
-						newStatus = astmodel.MakeErroredType(nil, nil, []string{fmt.Sprintf("missing status information for %v", typeName)})
+						newStatus = astmodel.NewErroredType(nil, nil, []string{fmt.Sprintf("missing status information for %v", typeName)})
 					}
 					newTypes.Add(astmodel.MakeTypeDefinition(typeName, resource.WithStatus(newStatus)))
 				} else {

--- a/hack/generator/pkg/codegen/pipeline_convert_allof_and_oneof_to_objects.go
+++ b/hack/generator/pkg/codegen/pipeline_convert_allof_and_oneof_to_objects.go
@@ -623,7 +623,7 @@ func (s synthesizer) handleOneOf(left astmodel.Type, right astmodel.Type) (astmo
 		return nil, err
 	}
 
-	return astmodel.MakeOneOfType(newTypes...), nil
+	return astmodel.BuildOneOfType(newTypes...), nil
 }
 
 func (s synthesizer) handleTypeName(left astmodel.Type, right astmodel.Type) (astmodel.Type, error) {

--- a/hack/generator/pkg/codegen/pipeline_convert_allof_and_oneof_to_objects.go
+++ b/hack/generator/pkg/codegen/pipeline_convert_allof_and_oneof_to_objects.go
@@ -189,7 +189,7 @@ func (s synthesizer) getOneOfName(t astmodel.Type, propIndex int) (propertyNames
 			isGoodName: false, // TODO: This name sucks but what alternative do we have?
 		}, nil
 
-	case astmodel.ValidatedType:
+	case *astmodel.ValidatedType:
 		// pass-through to inner type
 		return s.getOneOfName(concreteType.ElementType(), propIndex)
 
@@ -673,7 +673,7 @@ func (synthesizer) handleEqualTypes(left astmodel.Type, right astmodel.Type) (as
 
 // a validated and non-validated version of the same type become the valiated version
 func (synthesizer) handleValidatedAndNonValidated(left astmodel.Type, right astmodel.Type) (astmodel.Type, error) {
-	if validated, ok := left.(astmodel.ValidatedType); ok {
+	if validated, ok := left.(*astmodel.ValidatedType); ok {
 		if validated.ElementType().Equals(right) {
 			return left, nil
 		}

--- a/hack/generator/pkg/codegen/pipeline_convert_allof_and_oneof_to_objects.go
+++ b/hack/generator/pkg/codegen/pipeline_convert_allof_and_oneof_to_objects.go
@@ -36,7 +36,7 @@ func convertAllOfAndOneOfToObjects(idFactory astmodel.IdentifierFactory) Pipelin
 			visitor := astmodel.MakeTypeVisitor()
 
 			// the context here is whether we are selecting spec or status fields
-			visitor.VisitAllOfType = func(this *astmodel.TypeVisitor, it astmodel.AllOfType, ctx interface{}) (astmodel.Type, error) {
+			visitor.VisitAllOfType = func(this *astmodel.TypeVisitor, it *astmodel.AllOfType, ctx interface{}) (astmodel.Type, error) {
 				synth := synthesizer{
 					specOrStatus: ctx.(resourceFieldSelector),
 					defs:         defs,
@@ -53,7 +53,7 @@ func convertAllOfAndOneOfToObjects(idFactory astmodel.IdentifierFactory) Pipelin
 				return this.Visit(object, ctx)
 			}
 
-			visitor.VisitOneOfType = func(this *astmodel.TypeVisitor, it astmodel.OneOfType, ctx interface{}) (astmodel.Type, error) {
+			visitor.VisitOneOfType = func(this *astmodel.TypeVisitor, it *astmodel.OneOfType, ctx interface{}) (astmodel.Type, error) {
 				synth := synthesizer{
 					specOrStatus: ctx.(resourceFieldSelector),
 					defs:         defs,
@@ -73,7 +73,7 @@ func convertAllOfAndOneOfToObjects(idFactory astmodel.IdentifierFactory) Pipelin
 					return nil, err
 				}
 
-				if resultOneOf, ok := result.(astmodel.OneOfType); ok {
+				if resultOneOf, ok := result.(*astmodel.OneOfType); ok {
 					result = synth.oneOfObject(resultOneOf, propNames)
 				}
 
@@ -146,7 +146,7 @@ func (ns propertyNames) betterThan(other propertyNames) bool {
 	return ns.depth <= other.depth
 }
 
-func (s synthesizer) getOneOfPropNames(oneOf astmodel.OneOfType) ([]propertyNames, error) {
+func (s synthesizer) getOneOfPropNames(oneOf *astmodel.OneOfType) ([]propertyNames, error) {
 
 	var result []propertyNames
 
@@ -215,7 +215,7 @@ func (s synthesizer) getOneOfName(t astmodel.Type, propIndex int) (propertyNames
 			isGoodName: false, // TODO: This name sucks but what alternative do we have?
 		}, nil
 
-	case astmodel.AllOfType:
+	case *astmodel.AllOfType:
 		var result *propertyNames
 		err := concreteType.Types().ForEachError(func(t astmodel.Type, ix int) error {
 			inner, err := s.getOneOfName(t, ix)
@@ -246,7 +246,7 @@ func (s synthesizer) getOneOfName(t astmodel.Type, propIndex int) (propertyNames
 	}
 }
 
-func (s synthesizer) oneOfObject(oneOf astmodel.OneOfType, propNames []propertyNames) astmodel.Type {
+func (s synthesizer) oneOfObject(oneOf *astmodel.OneOfType, propNames []propertyNames) astmodel.Type {
 	// If there's more than one option, synthesize a type.
 	// Note that this is required because Kubernetes CRDs do not support OneOf the same way
 	// OpenAPI does, see https://github.com/Azure/k8s-infra/issues/71
@@ -322,7 +322,7 @@ func init() {
 
 func (s synthesizer) handleErrored(left astmodel.Type, right astmodel.Type) (astmodel.Type, error) {
 	// can merge the contents of an ErroredType, if we preserve the errors
-	leftErrored, ok := left.(astmodel.ErroredType)
+	leftErrored, ok := left.(*astmodel.ErroredType)
 	if !ok {
 		return nil, nil
 	}
@@ -573,7 +573,7 @@ func (s synthesizer) handleEnum(left astmodel.Type, right astmodel.Type) (astmod
 }
 
 func (s synthesizer) handleAllOfType(left astmodel.Type, right astmodel.Type) (astmodel.Type, error) {
-	leftAllOf, ok := left.(astmodel.AllOfType)
+	leftAllOf, ok := left.(*astmodel.AllOfType)
 	if !ok {
 		return nil, nil
 	}
@@ -588,7 +588,7 @@ func (s synthesizer) handleAllOfType(left astmodel.Type, right astmodel.Type) (a
 
 // if combining a type with a oneOf that contains that type, the result is that type
 func (s synthesizer) handleOneOf(left astmodel.Type, right astmodel.Type) (astmodel.Type, error) {
-	leftOneOf, ok := left.(astmodel.OneOfType)
+	leftOneOf, ok := left.(*astmodel.OneOfType)
 	if !ok {
 		return nil, nil
 	}
@@ -703,7 +703,7 @@ func (synthesizer) handleMapObject(left astmodel.Type, right astmodel.Type) (ast
 }
 
 // makes an ObjectType for an AllOf type
-func (s synthesizer) allOfObject(allOf astmodel.AllOfType) (astmodel.Type, error) {
+func (s synthesizer) allOfObject(allOf *astmodel.AllOfType) (astmodel.Type, error) {
 
 	var intersection astmodel.Type = astmodel.AnyType
 	err := allOf.Types().ForEachError(func(t astmodel.Type, _ int) error {

--- a/hack/generator/pkg/codegen/pipeline_convert_allof_and_oneof_to_objects_test.go
+++ b/hack/generator/pkg/codegen/pipeline_convert_allof_and_oneof_to_objects_test.go
@@ -293,7 +293,7 @@ func TestOneOfResourceSpec(t *testing.T) {
 	g := NewGomegaWithT(t)
 
 	r := astmodel.NewResourceType(astmodel.StringType, astmodel.IntType)
-	oneOf := astmodel.MakeOneOfType(astmodel.BoolType, r).(astmodel.OneOfType)
+	oneOf := astmodel.MakeOneOfType(astmodel.BoolType, r).(*astmodel.OneOfType)
 
 	synth.specOrStatus = chooseSpec
 

--- a/hack/generator/pkg/codegen/pipeline_convert_allof_and_oneof_to_objects_test.go
+++ b/hack/generator/pkg/codegen/pipeline_convert_allof_and_oneof_to_objects_test.go
@@ -249,7 +249,7 @@ func TestMergeResourceWithOtherDependsOnSpecVsStatus(t *testing.T) {
 func TestMergeOneOf(t *testing.T) {
 	g := NewGomegaWithT(t)
 
-	oneOf := astmodel.MakeOneOfType(astmodel.IntType, astmodel.StringType, astmodel.BoolType)
+	oneOf := astmodel.BuildOneOfType(astmodel.IntType, astmodel.StringType, astmodel.BoolType)
 
 	g.Expect(synth.intersectTypes(oneOf, astmodel.BoolType)).To(Equal(astmodel.BoolType))
 	g.Expect(synth.intersectTypes(astmodel.BoolType, oneOf)).To(Equal(astmodel.BoolType))
@@ -276,7 +276,7 @@ func TestMergeOneOfEnum(t *testing.T) {
 
 	g := NewGomegaWithT(t)
 
-	oneOf := astmodel.MakeOneOfType(
+	oneOf := astmodel.BuildOneOfType(
 		astmodel.StringType,
 		defineEnum("a", "b", "c"),
 	)
@@ -293,7 +293,7 @@ func TestOneOfResourceSpec(t *testing.T) {
 	g := NewGomegaWithT(t)
 
 	r := astmodel.NewResourceType(astmodel.StringType, astmodel.IntType)
-	oneOf := astmodel.MakeOneOfType(astmodel.BoolType, r).(*astmodel.OneOfType)
+	oneOf := astmodel.BuildOneOfType(astmodel.BoolType, r).(*astmodel.OneOfType)
 
 	synth.specOrStatus = chooseSpec
 

--- a/hack/generator/pkg/codegen/pipeline_create_arm_types.go
+++ b/hack/generator/pkg/codegen/pipeline_create_arm_types.go
@@ -309,7 +309,7 @@ func removeValidations(t *astmodel.ObjectType) (*astmodel.ObjectType, error) {
 		p = p.SetRequired(false)
 
 		// remove all validation types by promoting inner type
-		if validated, ok := p.PropertyType().(astmodel.ValidatedType); ok {
+		if validated, ok := p.PropertyType().(*astmodel.ValidatedType); ok {
 			p = p.WithType(validated.ElementType())
 		}
 

--- a/hack/generator/pkg/codegen/pipeline_create_storage_types.go
+++ b/hack/generator/pkg/codegen/pipeline_create_storage_types.go
@@ -93,7 +93,7 @@ type StorageTypeFactory struct {
 // convert, deferring the conversion to another.
 type propertyConversion = func(property *astmodel.PropertyDefinition, ctx StorageTypesVisitorContext) (*astmodel.PropertyDefinition, error)
 
-func (factory *StorageTypeFactory) visitValidatedType(this *astmodel.TypeVisitor, v astmodel.ValidatedType, ctx interface{}) (astmodel.Type, error) {
+func (factory *StorageTypeFactory) visitValidatedType(this *astmodel.TypeVisitor, v *astmodel.ValidatedType, ctx interface{}) (astmodel.Type, error) {
 	// strip all type validations from storage types,
 	// act as if they do not exist
 	return this.Visit(v.ElementType(), ctx)

--- a/hack/generator/pkg/codegen/pipeline_export_generated_code.go
+++ b/hack/generator/pkg/codegen/pipeline_export_generated_code.go
@@ -95,6 +95,8 @@ func writeFiles(ctx context.Context, packages map[astmodel.PackageReference]*ast
 	errs := make(chan error, 10) // we will buffer up to 10 errors and ignore any leftovers
 
 	// write outputs with 8 workers
+	// this is parallelized mostly due to 'dst' conversion being slow, see: https://github.com/Azure/k8s-infra/pull/376
+	// potentially we could contribute improvements upstream
 	for c := 0; c < 8; c++ {
 		wg.Add(1)
 		go func() {

--- a/hack/generator/pkg/codegen/pipeline_name_types_for_crd.go
+++ b/hack/generator/pkg/codegen/pipeline_name_types_for_crd.go
@@ -127,7 +127,7 @@ func nameInnerTypes(
 		for _, prop := range it.Properties() {
 			propType := prop.PropertyType()
 			nameHint := nameHint + "_" + string(prop.PropertyName())
-			if validated, ok := propType.(astmodel.ValidatedType); ok {
+			if validated, ok := propType.(*astmodel.ValidatedType); ok {
 				// handle validated types in properties specially,
 				// they don't need to be named, so skip directly to element type
 				newElementType, err := this.Visit(validated.ElementType(), nameHint)

--- a/hack/generator/pkg/codegen/pipeline_name_types_for_crd.go
+++ b/hack/generator/pkg/codegen/pipeline_name_types_for_crd.go
@@ -75,7 +75,7 @@ func nameInnerTypes(
 		return namedEnum.Name(), nil
 	}
 
-	visitor.VisitValidatedType = func(this *astmodel.TypeVisitor, v astmodel.ValidatedType, ctx interface{}) (astmodel.Type, error) {
+	visitor.VisitValidatedType = func(this *astmodel.TypeVisitor, v *astmodel.ValidatedType, ctx interface{}) (astmodel.Type, error) {
 		// a validated type anywhere except directly under a property
 		// must be named so that we can put the validations on it
 		nameHint := ctx.(string)

--- a/hack/generator/pkg/codegen/pipeline_remove_type_aliases.go
+++ b/hack/generator/pkg/codegen/pipeline_remove_type_aliases.go
@@ -61,7 +61,7 @@ func resolveTypeName(visitor *astmodel.TypeVisitor, name astmodel.TypeName, type
 		return def.Name(), nil // must remain named so there is somewhere to put validations
 	case *astmodel.ResourceType:
 		return def.Name(), nil // must remain named for controller-gen
-	case astmodel.ValidatedType:
+	case *astmodel.ValidatedType:
 		return def.Name(), nil // must remain named so there is somewhere to put validations
 	case *astmodel.FlaggedType:
 		return def.Name(), nil // must remain named as it is just wrapping objectType (and objectType remains named)

--- a/hack/generator/pkg/jsonast/jsonast.go
+++ b/hack/generator/pkg/jsonast/jsonast.go
@@ -156,13 +156,13 @@ func (scanner *SchemaScanner) GenerateDefinitionsFromDeploymentTemplate(ctx cont
 		return nil, errors.Errorf("expected 'resources' property to be an array")
 	}
 
-	resourcesOneOf, ok := resourcesArray.Element().(astmodel.OneOfType)
+	resourcesOneOf, ok := resourcesArray.Element().(*astmodel.OneOfType)
 	if !ok {
 		return nil, errors.Errorf("expected 'resources' property to be an array containing oneOf")
 	}
 
 	err = resourcesOneOf.Types().ForEachError(func(oneType astmodel.Type, _ int) error {
-		allOf, ok := oneType.(astmodel.AllOfType)
+		allOf, ok := oneType.(*astmodel.AllOfType)
 		if !ok {
 			return errors.Errorf("unexpected resource shape: not an allOf")
 		}

--- a/hack/generator/pkg/jsonast/jsonast.go
+++ b/hack/generator/pkg/jsonast/jsonast.go
@@ -198,7 +198,7 @@ func (scanner *SchemaScanner) GenerateDefinitionsFromDeploymentTemplate(ctx cont
 
 		// now we will remove the existing resource definition and replace it with a new one that includes the base type
 		// first, reconstruct the allof with an anonymous type instead of the typename
-		specType := astmodel.MakeAllOfType(objectBase, resourceType.SpecType())
+		specType := astmodel.BuildAllOfType(objectBase, resourceType.SpecType())
 		// now replace it
 		scanner.removeTypeDefinition(resourceRef)
 		scanner.addTypeDefinition(resourceDef.WithType(astmodel.NewAzureResourceType(specType, nil, resourceDef.Name())))
@@ -286,7 +286,7 @@ func stringHandler(ctx context.Context, scanner *SchemaScanner, schema Schema) (
 	pattern := schema.pattern()
 
 	if maxLength != nil || minLength != nil || pattern != nil {
-		return astmodel.MakeValidatedType(t, astmodel.StringValidations{
+		return astmodel.NewValidatedType(t, astmodel.StringValidations{
 			MaxLength: maxLength,
 			MinLength: minLength,
 			Pattern:   pattern,
@@ -321,7 +321,7 @@ func numberHandler(ctx context.Context, scanner *SchemaScanner, schema Schema) (
 		}
 
 		t = astmodel.IntType
-		return astmodel.MakeValidatedType(t, *v), nil
+		return astmodel.NewValidatedType(t, *v), nil
 	}
 
 	return t, nil
@@ -344,7 +344,7 @@ func intHandler(ctx context.Context, scanner *SchemaScanner, schema Schema) (ast
 			}
 		}
 
-		return astmodel.MakeValidatedType(t, *v), nil
+		return astmodel.NewValidatedType(t, *v), nil
 	}
 
 	return t, nil
@@ -693,7 +693,7 @@ func allOfHandler(ctx context.Context, scanner *SchemaScanner, schema Schema) (a
 		types = append(types, objectType)
 	}
 
-	return astmodel.MakeAllOfType(types...), nil
+	return astmodel.BuildAllOfType(types...), nil
 }
 
 func oneOfHandler(ctx context.Context, scanner *SchemaScanner, schema Schema) (astmodel.Type, error) {
@@ -718,7 +718,7 @@ func generateOneOfUnionType(ctx context.Context, schema Schema, subschemas []Sch
 		}
 	}
 
-	result := astmodel.MakeOneOfType(types...)
+	result := astmodel.BuildOneOfType(types...)
 
 	// if the node that contains the oneOf(/anyOf) defines other properties, create an object type with them inside to merge
 	if len(schema.properties()) > 0 {
@@ -727,7 +727,7 @@ func generateOneOfUnionType(ctx context.Context, schema Schema, subschemas []Sch
 			return nil, err
 		}
 
-		result = astmodel.MakeAllOfType(objectType, result)
+		result = astmodel.BuildAllOfType(objectType, result)
 	}
 
 	return result, nil
@@ -784,7 +784,7 @@ func withArrayValidations(schema Schema, t *astmodel.ArrayType) astmodel.Type {
 	uniqueItems := schema.uniqueItems()
 
 	if maxItems != nil || minItems != nil || uniqueItems {
-		return astmodel.MakeValidatedType(t, astmodel.ArrayValidations{
+		return astmodel.NewValidatedType(t, astmodel.ArrayValidations{
 			MaxItems:    maxItems,
 			MinItems:    minItems,
 			UniqueItems: uniqueItems,


### PR DESCRIPTION
This cuts about a minute off the runtime.

* cache identifiers so that identifier factory doesn't keep recreating the same ones
  * some parts of the code were spending most of their time building identifiers! 
* parallelize file emitting (this makes the biggest difference)
* make `AllOfType`, `ErroredType`, `OneOfType` into pointers so that Type can be `==` compared for short-circuiting, and use this in `TypeVisitor`
  * should help reduce the amount of garbage made by visitors  

Before/after profiles (GitHub won’t let me attach SVG): [profiles.zip](https://github.com/Azure/k8s-infra/files/5882743/profiles.zip)
The baseline one might be after adding the identifier cache, can’t recall — but it shows a lot of allocation/GC time being spent in maps generated by `dst`. Potentially we could contribute improvements upstream for this.