### PR TITLE
Make APIVersion auto-inserted so user does not need to specify it

### DIFF
--- a/hack/generated/controllers/crd_cosmosdb_test.go
+++ b/hack/generated/controllers/crd_cosmosdb_test.go
@@ -34,10 +34,9 @@ func Test_CosmosDB_CRUD(t *testing.T) {
 	acct := &documentdb.DatabaseAccount{
 		ObjectMeta: testContext.MakeObjectMetaWithName(namer.GenerateName("db")),
 		Spec: documentdb.DatabaseAccounts_Spec{
-			ApiVersion: "2015-04-08", // TODO [apiversion]: This should be removed from the storage type eventually
-			Location:   &testContext.AzureRegion,
-			Owner:      testcommon.AsOwner(rg.ObjectMeta),
-			Kind:       &kind,
+			Location: &testContext.AzureRegion,
+			Owner:    testcommon.AsOwner(rg.ObjectMeta),
+			Kind:     &kind,
 			Properties: documentdb.DatabaseAccountCreateUpdateProperties{
 				DatabaseAccountOfferType: documentdb.DatabaseAccountCreateUpdatePropertiesDatabaseAccountOfferTypeStandard,
 				Locations: []documentdb.Location{

--- a/hack/generated/controllers/crd_storageaccount_test.go
+++ b/hack/generated/controllers/crd_storageaccount_test.go
@@ -35,10 +35,9 @@ func Test_StorageAccount_CRUD(t *testing.T) {
 	acct := &storage.StorageAccount{
 		ObjectMeta: testContext.MakeObjectMetaWithName(namer.GenerateName("stor")),
 		Spec: storage.StorageAccounts_Spec{
-			Location:   testContext.AzureRegion,
-			ApiVersion: "2019-04-01", // TODO [apiversion]: This should be removed from the storage type eventually
-			Owner:      testcommon.AsOwner(rg.ObjectMeta),
-			Kind:       storage.StorageAccountsSpecKindBlobStorage,
+			Location: testContext.AzureRegion,
+			Owner:    testcommon.AsOwner(rg.ObjectMeta),
+			Kind:     storage.StorageAccountsSpecKindBlobStorage,
 			Sku: storage.Sku{
 				Name: storage.SkuNameStandardLRS,
 			},
@@ -87,8 +86,7 @@ func StorageAccount_BlobServices_CRUD(t *testing.T, testContext testcommon.KubeP
 	blobService := &storage.StorageAccountsBlobService{
 		ObjectMeta: testContext.MakeObjectMeta("blobservice"),
 		Spec: storage.StorageAccountsBlobServices_Spec{
-			ApiVersion: "2019-04-01", // TODO [apiversion]: to be removed eventually
-			Owner:      testcommon.AsOwner(storageAccount),
+			Owner: testcommon.AsOwner(storageAccount),
 		},
 	}
 
@@ -118,8 +116,7 @@ func StorageAccount_BlobServices_Container_CRUD(t *testing.T, testContext testco
 	blobContainer := &storage.StorageAccountsBlobServicesContainer{
 		ObjectMeta: testContext.MakeObjectMeta("container"),
 		Spec: storage.StorageAccountsBlobServicesContainers_Spec{
-			ApiVersion: "2019-04-01", // TODO [apiversion]: to be removed eventually
-			Owner:      testcommon.AsOwner(blobService),
+			Owner: testcommon.AsOwner(blobService),
 		},
 	}
 

--- a/hack/generated/pkg/reflecthelpers/reflect_helpers_test.go
+++ b/hack/generated/pkg/reflecthelpers/reflect_helpers_test.go
@@ -42,9 +42,8 @@ func createResourceGroup() *resources.ResourceGroup {
 func createDummyResource() *batch.BatchAccount {
 	return &batch.BatchAccount{
 		Spec: batch.BatchAccounts_Spec{
-			ApiVersion: "apiVersion",
-			AzureName:  "azureName",
-			Location:   "westus",
+			AzureName: "azureName",
+			Location:  "westus",
 			Owner: genruntime.KnownResourceReference{
 				Name: "myrg",
 			},

--- a/hack/generated/pkg/reflecthelpers/reflect_helpers_test.go
+++ b/hack/generated/pkg/reflecthelpers/reflect_helpers_test.go
@@ -81,7 +81,7 @@ func Test_ConvertResourceToDeployableResource(t *testing.T) {
 	g.Expect(ok).To(BeTrue())
 	g.Expect("myrg").To(Equal(rgResource.ResourceGroup()))
 	g.Expect("azureName").To(Equal(rgResource.Spec().GetName()))
-	g.Expect("apiVersion").To(Equal(rgResource.Spec().GetApiVersion()))
+	g.Expect("2017-09-01").To(Equal(rgResource.Spec().GetApiVersion()))
 	g.Expect(string(batch.BatchAccountsSpecTypeMicrosoftBatchBatchAccounts)).To(Equal(rgResource.Spec().GetType()))
 
 }

--- a/hack/generator/pkg/codegen/pipeline_create_arm_types.go
+++ b/hack/generator/pkg/codegen/pipeline_create_arm_types.go
@@ -379,8 +379,10 @@ func modifyKubeResourceSpecDefinition(
 		// TODO: https://github.com/kubernetes-sigs/controller-tools/issues/461 is fixed
 
 		// drop Type property
-		// TODO: handle this generically so we automatically insert 1-value enums?
 		t = t.WithoutProperty("Type")
+
+		// drop ApiVersion property
+		t = t.WithoutProperty("ApiVersion")
 
 		nameProp, hasName := t.Property("Name")
 		if !hasName {

--- a/hack/generator/pkg/codegen/testdata/ArmResource/Arm_oneof_resource_conversion_on_arm_type_only.golden
+++ b/hack/generator/pkg/codegen/testdata/ArmResource/Arm_oneof_resource_conversion_on_arm_type_only.golden
@@ -87,9 +87,6 @@ type FakeResourceSpecType string
 const FakeResourceSpecTypeMicrosoftAzureFakeResource = FakeResourceSpecType("Microsoft.Azure/FakeResource")
 
 type FakeResource_Spec struct {
-	// +kubebuilder:validation:Required
-	ApiVersion FakeResourceSpecApiVersion `json:"apiVersion"`
-
 	//AzureName: The name of the resource in Azure. This is often the same as the name
 	//of the resource in Kubernetes but it doesn't have to be.
 	AzureName string `json:"azureName"`
@@ -107,7 +104,7 @@ func (fakeResourceSpec *FakeResource_Spec) ConvertToArm(name string) (interface{
 		return nil, nil
 	}
 	var result FakeResource_SpecArm
-	result.ApiVersion = fakeResourceSpec.ApiVersion
+	result.ApiVersion = FakeResourceSpecApiVersion20200601
 	result.Name = name
 	if fakeResourceSpec.Properties != nil {
 		properties, err := (*fakeResourceSpec.Properties).ConvertToArm(name)
@@ -132,7 +129,6 @@ func (fakeResourceSpec *FakeResource_Spec) PopulateFromArm(owner genruntime.Know
 	if !ok {
 		return fmt.Errorf("unexpected type supplied for PopulateFromArm() function. Expected FakeResource_SpecArm, got %T", armInput)
 	}
-	fakeResourceSpec.ApiVersion = typedInput.ApiVersion
 	fakeResourceSpec.SetAzureName(genruntime.ExtractKubernetesResourceNameFromArmName(typedInput.Name))
 	fakeResourceSpec.Owner = owner
 	var err error

--- a/hack/generator/pkg/codegen/testdata/ArmResource/Arm_test_dependent_resource_and_ownership.golden
+++ b/hack/generator/pkg/codegen/testdata/ArmResource/Arm_test_dependent_resource_and_ownership.golden
@@ -277,9 +277,6 @@ type ASpecType string
 const ASpecTypeMicrosoftAzureA = ASpecType("Microsoft.Azure/A")
 
 type A_Spec struct {
-	// +kubebuilder:validation:Required
-	ApiVersion ASpecApiVersion `json:"apiVersion"`
-
 	//AzureName: The name of the resource in Azure. This is often the same as the name
 	//of the resource in Kubernetes but it doesn't have to be.
 	AzureName string `json:"azureName"`
@@ -296,7 +293,7 @@ func (aSpec *A_Spec) ConvertToArm(name string) (interface{}, error) {
 		return nil, nil
 	}
 	var result A_SpecArm
-	result.ApiVersion = aSpec.ApiVersion
+	result.ApiVersion = ASpecApiVersion20200601
 	result.Name = name
 	result.Type = ASpecTypeMicrosoftAzureA
 	return result, nil
@@ -313,7 +310,6 @@ func (aSpec *A_Spec) PopulateFromArm(owner genruntime.KnownResourceReference, ar
 	if !ok {
 		return fmt.Errorf("unexpected type supplied for PopulateFromArm() function. Expected A_SpecArm, got %T", armInput)
 	}
-	aSpec.ApiVersion = typedInput.ApiVersion
 	aSpec.SetAzureName(genruntime.ExtractKubernetesResourceNameFromArmName(typedInput.Name))
 	aSpec.Owner = owner
 	return nil
@@ -333,9 +329,6 @@ type BSpecType string
 const BSpecTypeMicrosoftAzureB = BSpecType("Microsoft.Azure/B")
 
 type B_Spec struct {
-	// +kubebuilder:validation:Required
-	ApiVersion BSpecApiVersion `json:"apiVersion"`
-
 	//AzureName: The name of the resource in Azure. This is often the same as the name
 	//of the resource in Kubernetes but it doesn't have to be.
 	AzureName string `json:"azureName"`
@@ -352,7 +345,7 @@ func (bSpec *B_Spec) ConvertToArm(name string) (interface{}, error) {
 		return nil, nil
 	}
 	var result B_SpecArm
-	result.ApiVersion = bSpec.ApiVersion
+	result.ApiVersion = BSpecApiVersion20200601
 	result.Name = name
 	result.Type = BSpecTypeMicrosoftAzureB
 	return result, nil
@@ -369,7 +362,6 @@ func (bSpec *B_Spec) PopulateFromArm(owner genruntime.KnownResourceReference, ar
 	if !ok {
 		return fmt.Errorf("unexpected type supplied for PopulateFromArm() function. Expected B_SpecArm, got %T", armInput)
 	}
-	bSpec.ApiVersion = typedInput.ApiVersion
 	bSpec.SetAzureName(genruntime.ExtractKubernetesResourceNameFromArmName(typedInput.Name))
 	bSpec.Owner = owner
 	return nil
@@ -389,9 +381,6 @@ type CSpecType string
 const CSpecTypeMicrosoftAzureC = CSpecType("Microsoft.Azure/C")
 
 type C_Spec struct {
-	// +kubebuilder:validation:Required
-	ApiVersion CSpecApiVersion `json:"apiVersion"`
-
 	//AzureName: The name of the resource in Azure. This is often the same as the name
 	//of the resource in Kubernetes but it doesn't have to be.
 	AzureName string `json:"azureName"`
@@ -408,7 +397,7 @@ func (cSpec *C_Spec) ConvertToArm(name string) (interface{}, error) {
 		return nil, nil
 	}
 	var result C_SpecArm
-	result.ApiVersion = cSpec.ApiVersion
+	result.ApiVersion = CSpecApiVersion20200601
 	result.Name = name
 	result.Type = CSpecTypeMicrosoftAzureC
 	return result, nil
@@ -425,7 +414,6 @@ func (cSpec *C_Spec) PopulateFromArm(owner genruntime.KnownResourceReference, ar
 	if !ok {
 		return fmt.Errorf("unexpected type supplied for PopulateFromArm() function. Expected C_SpecArm, got %T", armInput)
 	}
-	cSpec.ApiVersion = typedInput.ApiVersion
 	cSpec.SetAzureName(genruntime.ExtractKubernetesResourceNameFromArmName(typedInput.Name))
 	cSpec.Owner = owner
 	return nil
@@ -445,9 +433,6 @@ type DSpecType string
 const DSpecTypeMicrosoftAzureD = DSpecType("Microsoft.Azure/D")
 
 type D_Spec struct {
-	// +kubebuilder:validation:Required
-	ApiVersion DSpecApiVersion `json:"apiVersion"`
-
 	//AzureName: The name of the resource in Azure. This is often the same as the name
 	//of the resource in Kubernetes but it doesn't have to be.
 	AzureName string `json:"azureName"`
@@ -464,7 +449,7 @@ func (dSpec *D_Spec) ConvertToArm(name string) (interface{}, error) {
 		return nil, nil
 	}
 	var result D_SpecArm
-	result.ApiVersion = dSpec.ApiVersion
+	result.ApiVersion = DSpecApiVersion20200601
 	result.Name = name
 	result.Type = DSpecTypeMicrosoftAzureD
 	return result, nil
@@ -481,7 +466,6 @@ func (dSpec *D_Spec) PopulateFromArm(owner genruntime.KnownResourceReference, ar
 	if !ok {
 		return fmt.Errorf("unexpected type supplied for PopulateFromArm() function. Expected D_SpecArm, got %T", armInput)
 	}
-	dSpec.ApiVersion = typedInput.ApiVersion
 	dSpec.SetAzureName(genruntime.ExtractKubernetesResourceNameFromArmName(typedInput.Name))
 	dSpec.Owner = owner
 	return nil

--- a/hack/generator/pkg/codegen/testdata/ArmResource/Arm_test_simple_resource_array_properties.golden
+++ b/hack/generator/pkg/codegen/testdata/ArmResource/Arm_test_simple_resource_array_properties.golden
@@ -100,9 +100,6 @@ const FakeResourceSpecTypeMicrosoftAzureFakeResource = FakeResourceSpecType("Mic
 
 type FakeResource_Spec struct {
 	// +kubebuilder:validation:Required
-	ApiVersion FakeResourceSpecApiVersion `json:"apiVersion"`
-
-	// +kubebuilder:validation:Required
 	ArrayFoo      []Foo            `json:"arrayFoo"`
 	ArrayOfArrays [][]Foo          `json:"arrayOfArrays,omitempty"`
 	ArrayOfEnums  []Color          `json:"arrayOfEnums,omitempty"`
@@ -124,7 +121,7 @@ func (fakeResourceSpec *FakeResource_Spec) ConvertToArm(name string) (interface{
 		return nil, nil
 	}
 	var result FakeResource_SpecArm
-	result.ApiVersion = fakeResourceSpec.ApiVersion
+	result.ApiVersion = FakeResourceSpecApiVersion20200601
 	for _, item := range fakeResourceSpec.ArrayFoo {
 		elem, err := item.ConvertToArm(name)
 		if err != nil {
@@ -177,7 +174,6 @@ func (fakeResourceSpec *FakeResource_Spec) PopulateFromArm(owner genruntime.Know
 	if !ok {
 		return fmt.Errorf("unexpected type supplied for PopulateFromArm() function. Expected FakeResource_SpecArm, got %T", armInput)
 	}
-	fakeResourceSpec.ApiVersion = typedInput.ApiVersion
 	var err error
 	for _, item := range typedInput.ArrayFoo {
 		var elem Foo

--- a/hack/generator/pkg/codegen/testdata/ArmResource/Arm_test_simple_resource_complex_properties.golden
+++ b/hack/generator/pkg/codegen/testdata/ArmResource/Arm_test_simple_resource_complex_properties.golden
@@ -97,9 +97,6 @@ type FakeResourceSpecType string
 const FakeResourceSpecTypeMicrosoftAzureFakeResource = FakeResourceSpecType("Microsoft.Azure/FakeResource")
 
 type FakeResource_Spec struct {
-	// +kubebuilder:validation:Required
-	ApiVersion FakeResourceSpecApiVersion `json:"apiVersion"`
-
 	//AzureName: The name of the resource in Azure. This is often the same as the name
 	//of the resource in Kubernetes but it doesn't have to be.
 	AzureName string                 `json:"azureName"`
@@ -121,7 +118,7 @@ func (fakeResourceSpec *FakeResource_Spec) ConvertToArm(name string) (interface{
 		return nil, nil
 	}
 	var result FakeResource_SpecArm
-	result.ApiVersion = fakeResourceSpec.ApiVersion
+	result.ApiVersion = FakeResourceSpecApiVersion20200601
 	if fakeResourceSpec.Color != nil {
 		colorTyped := *fakeResourceSpec.Color
 		result.Color = &colorTyped
@@ -155,7 +152,6 @@ func (fakeResourceSpec *FakeResource_Spec) PopulateFromArm(owner genruntime.Know
 	if !ok {
 		return fmt.Errorf("unexpected type supplied for PopulateFromArm() function. Expected FakeResource_SpecArm, got %T", armInput)
 	}
-	fakeResourceSpec.ApiVersion = typedInput.ApiVersion
 	fakeResourceSpec.SetAzureName(genruntime.ExtractKubernetesResourceNameFromArmName(typedInput.Name))
 	if typedInput.Color != nil {
 		colorTyped := *typedInput.Color

--- a/hack/generator/pkg/codegen/testdata/ArmResource/Arm_test_simple_resource_json_fields.golden
+++ b/hack/generator/pkg/codegen/testdata/ArmResource/Arm_test_simple_resource_json_fields.golden
@@ -89,9 +89,6 @@ type FakeResourceSpecType string
 const FakeResourceSpecTypeMicrosoftAzureFakeResource = FakeResourceSpecType("Microsoft.Azure/FakeResource")
 
 type FakeResource_Spec struct {
-	// +kubebuilder:validation:Required
-	ApiVersion FakeResourceSpecApiVersion `json:"apiVersion"`
-
 	//AzureName: The name of the resource in Azure. This is often the same as the name
 	//of the resource in Kubernetes but it doesn't have to be.
 	AzureName string `json:"azureName"`
@@ -115,7 +112,7 @@ func (fakeResourceSpec *FakeResource_Spec) ConvertToArm(name string) (interface{
 		return nil, nil
 	}
 	var result FakeResource_SpecArm
-	result.ApiVersion = fakeResourceSpec.ApiVersion
+	result.ApiVersion = FakeResourceSpecApiVersion20200601
 	result.JsonObject = make(map[string]v1.JSON)
 	for key, value := range fakeResourceSpec.JsonObject {
 		elemTyped := *value.DeepCopy()
@@ -142,7 +139,6 @@ func (fakeResourceSpec *FakeResource_Spec) PopulateFromArm(owner genruntime.Know
 	if !ok {
 		return fmt.Errorf("unexpected type supplied for PopulateFromArm() function. Expected FakeResource_SpecArm, got %T", armInput)
 	}
-	fakeResourceSpec.ApiVersion = typedInput.ApiVersion
 	fakeResourceSpec.SetAzureName(genruntime.ExtractKubernetesResourceNameFromArmName(typedInput.Name))
 	if typedInput.JsonObject != nil {
 		fakeResourceSpec.JsonObject = make(map[string]v1.JSON)

--- a/hack/generator/pkg/codegen/testdata/ArmResource/Arm_test_simple_resource_map_properties.golden
+++ b/hack/generator/pkg/codegen/testdata/ArmResource/Arm_test_simple_resource_map_properties.golden
@@ -100,9 +100,6 @@ type FakeResourceSpecType string
 const FakeResourceSpecTypeMicrosoftAzureFakeResource = FakeResourceSpecType("Microsoft.Azure/FakeResource")
 
 type FakeResource_Spec struct {
-	// +kubebuilder:validation:Required
-	ApiVersion FakeResourceSpecApiVersion `json:"apiVersion"`
-
 	//AzureName: The name of the resource in Azure. This is often the same as the name
 	//of the resource in Kubernetes but it doesn't have to be.
 	AzureName string `json:"azureName"`
@@ -126,7 +123,7 @@ func (fakeResourceSpec *FakeResource_Spec) ConvertToArm(name string) (interface{
 		return nil, nil
 	}
 	var result FakeResource_SpecArm
-	result.ApiVersion = fakeResourceSpec.ApiVersion
+	result.ApiVersion = FakeResourceSpecApiVersion20200601
 	result.MapFoo = make(map[string]FooArm)
 	for key, value := range fakeResourceSpec.MapFoo {
 		elem, err := value.ConvertToArm(name)
@@ -188,7 +185,6 @@ func (fakeResourceSpec *FakeResource_Spec) PopulateFromArm(owner genruntime.Know
 	if !ok {
 		return fmt.Errorf("unexpected type supplied for PopulateFromArm() function. Expected FakeResource_SpecArm, got %T", armInput)
 	}
-	fakeResourceSpec.ApiVersion = typedInput.ApiVersion
 	fakeResourceSpec.SetAzureName(genruntime.ExtractKubernetesResourceNameFromArmName(typedInput.Name))
 	var err error
 	if typedInput.MapFoo != nil {

--- a/hack/generator/pkg/codegen/testdata/ArmResource/Arm_test_simple_resource_renders_spec.golden
+++ b/hack/generator/pkg/codegen/testdata/ArmResource/Arm_test_simple_resource_renders_spec.golden
@@ -85,9 +85,6 @@ type FakeResourceSpecType string
 const FakeResourceSpecTypeMicrosoftAzureFakeResource = FakeResourceSpecType("Microsoft.Azure/FakeResource")
 
 type FakeResource_Spec struct {
-	// +kubebuilder:validation:Required
-	ApiVersion FakeResourceSpecApiVersion `json:"apiVersion"`
-
 	//AzureName: The name of the resource in Azure. This is often the same as the name
 	//of the resource in Kubernetes but it doesn't have to be.
 	AzureName string `json:"azureName"`
@@ -104,7 +101,7 @@ func (fakeResourceSpec *FakeResource_Spec) ConvertToArm(name string) (interface{
 		return nil, nil
 	}
 	var result FakeResource_SpecArm
-	result.ApiVersion = fakeResourceSpec.ApiVersion
+	result.ApiVersion = FakeResourceSpecApiVersion20200601
 	result.Name = name
 	result.Type = FakeResourceSpecTypeMicrosoftAzureFakeResource
 	return result, nil
@@ -121,7 +118,6 @@ func (fakeResourceSpec *FakeResource_Spec) PopulateFromArm(owner genruntime.Know
 	if !ok {
 		return fmt.Errorf("unexpected type supplied for PopulateFromArm() function. Expected FakeResource_SpecArm, got %T", armInput)
 	}
-	fakeResourceSpec.ApiVersion = typedInput.ApiVersion
 	fakeResourceSpec.SetAzureName(genruntime.ExtractKubernetesResourceNameFromArmName(typedInput.Name))
 	fakeResourceSpec.Owner = owner
 	return nil

--- a/hack/generator/pkg/codegen/testdata/EmbeddedTypes/Embedded_type_simple_resource.golden
+++ b/hack/generator/pkg/codegen/testdata/EmbeddedTypes/Embedded_type_simple_resource.golden
@@ -100,9 +100,6 @@ const FakeResourceSpecTypeMicrosoftAzureFakeResource = FakeResourceSpecType("Mic
 type FakeResource_Spec struct {
 	EmbeddedTestType `json:",inline"`
 
-	// +kubebuilder:validation:Required
-	ApiVersion FakeResourceSpecApiVersion `json:"apiVersion"`
-
 	//AzureName: The name of the resource in Azure. This is often the same as the name
 	//of the resource in Kubernetes but it doesn't have to be.
 	AzureName string                 `json:"azureName"`
@@ -124,7 +121,7 @@ func (fakeResourceSpec *FakeResource_Spec) ConvertToArm(name string) (interface{
 		return nil, nil
 	}
 	var result FakeResource_SpecArm
-	result.ApiVersion = fakeResourceSpec.ApiVersion
+	result.ApiVersion = FakeResourceSpecApiVersion20200601
 	if fakeResourceSpec.Color != nil {
 		colorTyped := *fakeResourceSpec.Color
 		result.Color = &colorTyped
@@ -158,7 +155,6 @@ func (fakeResourceSpec *FakeResource_Spec) PopulateFromArm(owner genruntime.Know
 	if !ok {
 		return fmt.Errorf("unexpected type supplied for PopulateFromArm() function. Expected FakeResource_SpecArm, got %T", armInput)
 	}
-	fakeResourceSpec.ApiVersion = typedInput.ApiVersion
 	fakeResourceSpec.SetAzureName(genruntime.ExtractKubernetesResourceNameFromArmName(typedInput.Name))
 	if typedInput.Color != nil {
 		colorTyped := *typedInput.Color

--- a/hack/generator/pkg/codegen/testdata/EnumNames/Multi_valued_enum_name.golden
+++ b/hack/generator/pkg/codegen/testdata/EnumNames/Multi_valued_enum_name.golden
@@ -85,9 +85,6 @@ type AResourceSpecType string
 const AResourceSpecTypeMicrosoftAzureAResource = AResourceSpecType("Microsoft.Azure/AResource")
 
 type AResource_Spec struct {
-	// +kubebuilder:validation:Required
-	ApiVersion AResourceSpecApiVersion `json:"apiVersion"`
-
 	//AzureName: The name of the resource in Azure. This is often the same as the name
 	//of the resource in Kubernetes but it doesn't have to be.
 	AzureName AResourceSpecName `json:"azureName"`
@@ -104,7 +101,7 @@ func (aResourceSpec *AResource_Spec) ConvertToArm(name string) (interface{}, err
 		return nil, nil
 	}
 	var result AResource_SpecArm
-	result.ApiVersion = aResourceSpec.ApiVersion
+	result.ApiVersion = AResourceSpecApiVersion20200601
 	result.Name = name
 	result.Type = AResourceSpecTypeMicrosoftAzureAResource
 	return result, nil
@@ -121,7 +118,6 @@ func (aResourceSpec *AResource_Spec) PopulateFromArm(owner genruntime.KnownResou
 	if !ok {
 		return fmt.Errorf("unexpected type supplied for PopulateFromArm() function. Expected AResource_SpecArm, got %T", armInput)
 	}
-	aResourceSpec.ApiVersion = typedInput.ApiVersion
 	aResourceSpec.SetAzureName(genruntime.ExtractKubernetesResourceNameFromArmName(typedInput.Name))
 	aResourceSpec.Owner = owner
 	return nil

--- a/hack/generator/pkg/codegen/testdata/EnumNames/Single_valued_enum_name.golden
+++ b/hack/generator/pkg/codegen/testdata/EnumNames/Single_valued_enum_name.golden
@@ -79,9 +79,6 @@ const AResourceSpecTypeMicrosoftAzureAResource = AResourceSpecType("Microsoft.Az
 
 type AResource_Spec struct {
 	// +kubebuilder:validation:Required
-	ApiVersion AResourceSpecApiVersion `json:"apiVersion"`
-
-	// +kubebuilder:validation:Required
 	Owner genruntime.KnownResourceReference `group:"microsoft.resources.infra.azure.com" json:"owner" kind:"ResourceGroup"`
 }
 
@@ -93,7 +90,7 @@ func (aResourceSpec *AResource_Spec) ConvertToArm(name string) (interface{}, err
 		return nil, nil
 	}
 	var result AResource_SpecArm
-	result.ApiVersion = aResourceSpec.ApiVersion
+	result.ApiVersion = AResourceSpecApiVersion20200601
 	result.Name = name
 	result.Type = AResourceSpecTypeMicrosoftAzureAResource
 	return result, nil
@@ -110,7 +107,6 @@ func (aResourceSpec *AResource_Spec) PopulateFromArm(owner genruntime.KnownResou
 	if !ok {
 		return fmt.Errorf("unexpected type supplied for PopulateFromArm() function. Expected AResource_SpecArm, got %T", armInput)
 	}
-	aResourceSpec.ApiVersion = typedInput.ApiVersion
 	aResourceSpec.Owner = owner
 	return nil
 }


### PR DESCRIPTION
This completes most of #124, but still need to insert the property for the storage type. Also need to double-check how we read from Azure…