### PR TITLE
Improvements to astbuilder

### DIFF
--- a/hack/generator/pkg/astbuilder/assignments.go
+++ b/hack/generator/pkg/astbuilder/assignments.go
@@ -17,11 +17,11 @@ import (
 func SimpleAssignment(lhs dst.Expr, tok token.Token, rhs dst.Expr) *dst.AssignStmt {
 	return &dst.AssignStmt{
 		Lhs: []dst.Expr{
-			lhs,
+			dst.Clone(lhs).(dst.Expr),
 		},
 		Tok: tok,
 		Rhs: []dst.Expr{
-			rhs,
+			dst.Clone(rhs).(dst.Expr),
 		},
 	}
 }
@@ -33,12 +33,12 @@ func SimpleAssignmentWithErr(lhs dst.Expr, tok token.Token, rhs dst.Expr) *dst.A
 	errId := dst.NewIdent("err")
 	return &dst.AssignStmt{
 		Lhs: []dst.Expr{
-			lhs,
+			dst.Clone(lhs).(dst.Expr),
 			errId,
 		},
 		Tok: tok,
 		Rhs: []dst.Expr{
-			rhs,
+			dst.Clone(rhs).(dst.Expr),
 		},
 	}
 }

--- a/hack/generator/pkg/astbuilder/builder.go
+++ b/hack/generator/pkg/astbuilder/builder.go
@@ -117,41 +117,6 @@ func VariableDeclaration(ident string, typ dst.Expr, comment string) *dst.GenDec
 	return decl
 }
 
-// AppendList returns a statement for a list append, like:
-//     <lhs> = append(<lhs>, <rhs>)
-func AppendList(lhs dst.Expr, rhs dst.Expr) dst.Stmt {
-	return SimpleAssignment(
-		dst.Clone(lhs).(dst.Expr),
-		token.ASSIGN,
-		CallFunc("append", dst.Clone(lhs).(dst.Expr), dst.Clone(rhs).(dst.Expr)))
-}
-
-// InsertMap returns an assignment statement for inserting an item into a map, like:
-// 	<m>[<key>] = <rhs>
-func InsertMap(m dst.Expr, key dst.Expr, rhs dst.Expr) *dst.AssignStmt {
-	return SimpleAssignment(
-		&dst.IndexExpr{
-			X:     dst.Clone(m).(dst.Expr),
-			Index: dst.Clone(key).(dst.Expr),
-		},
-		token.ASSIGN,
-		dst.Clone(rhs).(dst.Expr))
-}
-
-// MakeMap returns the call expression for making a map, like:
-// 	make(map[<key>]<value>)
-func MakeMap(key dst.Expr, value dst.Expr) *dst.CallExpr {
-	return &dst.CallExpr{
-		Fun: dst.NewIdent("make"),
-		Args: []dst.Expr{
-			&dst.MapType{
-				Key:   dst.Clone(key).(dst.Expr),
-				Value: dst.Clone(value).(dst.Expr),
-			},
-		},
-	}
-}
-
 // TypeAssert returns an assignment statement with a type assertion
 // 	<lhs>, ok := <rhs>.(<type>)
 func TypeAssert(lhs dst.Expr, rhs dst.Expr, typ dst.Expr) *dst.AssignStmt {
@@ -262,8 +227,8 @@ func AddrOf(exp dst.Expr) *dst.UnaryExpr {
 }
 
 // Dereference returns a statement that dereferences the pointer returned by the provided expression
-func Dereference(exp ast.Expr) *ast.UnaryExpr {
-	return &ast.UnaryExpr{
+func Dereference(exp dst.Expr) *dst.UnaryExpr {
+	return &dst.UnaryExpr{
 		Op: token.MUL,
 		X:  exp,
 	}
@@ -292,9 +257,9 @@ func QualifiedTypeName(pkg string, name string) *dst.SelectorExpr {
 	}
 }
 
-func Selector(expr ast.Expr, name string) *ast.SelectorExpr {
-	return &ast.SelectorExpr{
+func Selector(expr dst.Expr, name string) *dst.SelectorExpr {
+	return &dst.SelectorExpr{
 		X:   expr,
-		Sel: ast.NewIdent(name),
+		Sel: dst.NewIdent(name),
 	}
 }

--- a/hack/generator/pkg/astbuilder/builder.go
+++ b/hack/generator/pkg/astbuilder/builder.go
@@ -257,6 +257,10 @@ func QualifiedTypeName(pkg string, name string) *dst.SelectorExpr {
 	}
 }
 
+// Selector generates a field reference into an existing expression
+//
+// <expr>.<name>
+//
 func Selector(expr dst.Expr, name string) *dst.SelectorExpr {
 	return &dst.SelectorExpr{
 		X:   dst.Clone(expr).(dst.Expr),
@@ -264,6 +268,10 @@ func Selector(expr dst.Expr, name string) *dst.SelectorExpr {
 	}
 }
 
+// NotEqual generates a != comparison between the two expressions
+//
+// <lhs> != <rhs>
+//
 func NotEqual(lhs dst.Expr, rhs dst.Expr) *dst.BinaryExpr {
 	return &dst.BinaryExpr{
 		X:  dst.Clone(lhs).(dst.Expr),
@@ -272,6 +280,7 @@ func NotEqual(lhs dst.Expr, rhs dst.Expr) *dst.BinaryExpr {
 	}
 }
 
+// cloneExprSlice is a utility method to clone a slice of expressions
 func cloneExprSlice(exprs []dst.Expr) []dst.Expr {
 	var result []dst.Expr
 	for _, exp := range exprs {
@@ -281,6 +290,7 @@ func cloneExprSlice(exprs []dst.Expr) []dst.Expr {
 	return result
 }
 
+// cloneStmtSlice is a utility method to clone a slice of statements
 func cloneStmtSlice(stmts []dst.Stmt) []dst.Stmt {
 	var result []dst.Stmt
 	for _, st := range stmts {

--- a/hack/generator/pkg/astbuilder/builder.go
+++ b/hack/generator/pkg/astbuilder/builder.go
@@ -264,6 +264,14 @@ func Selector(expr dst.Expr, name string) *dst.SelectorExpr {
 	}
 }
 
+func NotEqual(lhs dst.Expr, rhs dst.Expr) *dst.BinaryExpr {
+	return &dst.BinaryExpr{
+		X:  dst.Clone(lhs).(dst.Expr),
+		Op: token.NEQ,
+		Y:  dst.Clone(rhs).(dst.Expr),
+	}
+}
+
 func cloneExprSlice(exprs []dst.Expr) []dst.Expr {
 	var result []dst.Expr
 	for _, exp := range exprs {

--- a/hack/generator/pkg/astbuilder/builder.go
+++ b/hack/generator/pkg/astbuilder/builder.go
@@ -291,3 +291,10 @@ func QualifiedTypeName(pkg string, name string) *dst.SelectorExpr {
 		Sel: dst.NewIdent(name),
 	}
 }
+
+func Selector(expr ast.Expr, name string) *ast.SelectorExpr {
+	return &ast.SelectorExpr{
+		X:   expr,
+		Sel: ast.NewIdent(name),
+	}
+}

--- a/hack/generator/pkg/astbuilder/builder.go
+++ b/hack/generator/pkg/astbuilder/builder.go
@@ -11,7 +11,8 @@ import (
 	"github.com/dave/dst"
 )
 
-// CheckErrorAndReturn checks if the err is non-nil, and if it is returns. For example:
+// CheckErrorAndReturn checks if the err is non-nil, and if it is returns.
+//
 // 	if err != nil {
 // 		return <otherReturns...>, err
 //	}
@@ -87,17 +88,21 @@ func NewVariable(varName string, structName string) dst.Stmt {
 	}
 }
 
-// LocalVariableDeclaration performs a local variable declaration for use within a method like:
+// LocalVariableDeclaration performs a local variable declaration for use within a method
+//
 // 	var <ident> <typ>
+//
 func LocalVariableDeclaration(ident string, typ dst.Expr, comment string) dst.Stmt {
 	return &dst.DeclStmt{
 		Decl: VariableDeclaration(ident, typ, comment),
 	}
 }
 
-// VariableDeclaration performs a global variable declaration like:
+// VariableDeclaration performs a global variable declaration
+//
 //  // <comment>
 // 	var <ident> <typ>
+//
 // For a LocalVariable within a method, use LocalVariableDeclaration() to create an ast.Stmt instead
 func VariableDeclaration(ident string, typ dst.Expr, comment string) *dst.GenDecl {
 	decl := &dst.GenDecl{
@@ -118,7 +123,9 @@ func VariableDeclaration(ident string, typ dst.Expr, comment string) *dst.GenDec
 }
 
 // TypeAssert returns an assignment statement with a type assertion
+//
 // 	<lhs>, ok := <rhs>.(<type>)
+//
 func TypeAssert(lhs dst.Expr, rhs dst.Expr, typ dst.Expr) *dst.AssignStmt {
 
 	return &dst.AssignStmt{
@@ -137,17 +144,21 @@ func TypeAssert(lhs dst.Expr, rhs dst.Expr, typ dst.Expr) *dst.AssignStmt {
 }
 
 // ReturnIfOk checks a boolean ok variable and if it is ok returns the specified values
+//
 //	if ok {
 //		return <returns>
 //	}
+//
 func ReturnIfOk(returns ...dst.Expr) *dst.IfStmt {
 	return ReturnIfExpr(dst.NewIdent("ok"), returns...)
 }
 
 // ReturnIfNotOk checks a boolean ok variable and if it is not ok returns the specified values
+//
 //	if !ok {
 //		return <returns>
 //	}
+//
 func ReturnIfNotOk(returns ...dst.Expr) *dst.IfStmt {
 	return ReturnIfExpr(
 		&dst.UnaryExpr{
@@ -157,10 +168,12 @@ func ReturnIfNotOk(returns ...dst.Expr) *dst.IfStmt {
 		returns...)
 }
 
-// ReturnIfNil checks if a variable is nil and if it is returns, like:
+// ReturnIfNil checks if a variable is nil and if it is returns
+//
 // 	if <toCheck> == nil {
 // 		return <returns...>
 //	}
+//
 func ReturnIfNil(toCheck dst.Expr, returns ...dst.Expr) dst.Stmt {
 	return ReturnIfExpr(
 		&dst.BinaryExpr{
@@ -171,10 +184,12 @@ func ReturnIfNil(toCheck dst.Expr, returns ...dst.Expr) dst.Stmt {
 		returns...)
 }
 
-// ReturnIfNotNil checks if a variable is not nil and if it is returns, like:
+// ReturnIfNotNil checks if a variable is not nil and if it is returns
+//
 // 	if <toCheck> != nil {
 // 		return <returns...>
 //	}
+//
 func ReturnIfNotNil(toCheck dst.Expr, returns ...dst.Expr) dst.Stmt {
 	return ReturnIfExpr(
 		&dst.BinaryExpr{
@@ -185,10 +200,12 @@ func ReturnIfNotNil(toCheck dst.Expr, returns ...dst.Expr) dst.Stmt {
 		returns...)
 }
 
-// ReturnIfExpr returns if the expression evaluates as true.
+// ReturnIfExpr returns if the expression evaluates as true
+//
 //	if <cond> {
 // 		return <returns...>
 //	}
+//
 func ReturnIfExpr(cond dst.Expr, returns ...dst.Expr) *dst.IfStmt {
 	if len(returns) == 0 {
 		panic("Expected at least 1 return for ReturnIfOk")
@@ -207,7 +224,9 @@ func ReturnIfExpr(cond dst.Expr, returns ...dst.Expr) *dst.IfStmt {
 }
 
 // FormatError produces a call to fmt.Errorf with the given format string and args
+//
 //	fmt.Errorf(<formatString>, <args>)
+//
 func FormatError(fmtPackage string, formatString string, args ...dst.Expr) dst.Expr {
 	var callArgs []dst.Expr
 	callArgs = append(
@@ -218,25 +237,32 @@ func FormatError(fmtPackage string, formatString string, args ...dst.Expr) dst.E
 }
 
 // AddrOf returns a statement that gets the address of the provided expression.
+//
 //	&<expr>
-func AddrOf(exp dst.Expr) *dst.UnaryExpr {
+//
+func AddrOf(expr dst.Expr) *dst.UnaryExpr {
 	return &dst.UnaryExpr{
 		Op: token.AND,
-		X:  dst.Clone(exp).(dst.Expr),
+		X:  dst.Clone(expr).(dst.Expr),
 	}
 }
 
 // Dereference returns a statement that dereferences the pointer returned by the provided expression
-func Dereference(exp dst.Expr) *dst.UnaryExpr {
+//
+// *<expr>
+//
+func Dereference(expr dst.Expr) *dst.UnaryExpr {
 	return &dst.UnaryExpr{
 		Op: token.MUL,
-		X:  dst.Clone(exp).(dst.Expr),
+		X:  dst.Clone(expr).(dst.Expr),
 	}
 }
 
 // Returns creates a return statement with one or more expressions, of the form
+//
 //    return <expr>
 // or return <expr>, <expr>, ...
+//
 func Returns(returns ...dst.Expr) dst.Stmt {
 	return &dst.ReturnStmt{
 		Decs: dst.ReturnStmtDecorations{
@@ -249,7 +275,9 @@ func Returns(returns ...dst.Expr) dst.Stmt {
 }
 
 // QualifiedTypeName generates a reference to a type within an imported package
-// of the form <pkg>.<name>
+//
+// <pkg>.<name>
+//
 func QualifiedTypeName(pkg string, name string) *dst.SelectorExpr {
 	return &dst.SelectorExpr{
 		X:   dst.NewIdent(pkg),

--- a/hack/generator/pkg/astbuilder/builder.go
+++ b/hack/generator/pkg/astbuilder/builder.go
@@ -261,6 +261,14 @@ func AddrOf(exp dst.Expr) *dst.UnaryExpr {
 	}
 }
 
+// Dereference returns a statement that dereferences the pointer returned by the provided expression
+func Dereference(exp ast.Expr) *ast.UnaryExpr {
+	return &ast.UnaryExpr{
+		Op: token.MUL,
+		X:  exp,
+	}
+}
+
 // Returns creates a return statement with one or more expressions, of the form
 //    return <expr>
 // or return <expr>, <expr>, ...

--- a/hack/generator/pkg/astbuilder/calls.go
+++ b/hack/generator/pkg/astbuilder/calls.go
@@ -15,7 +15,7 @@ import (
 func CallFunc(funcName string, arguments ...dst.Expr) dst.Expr {
 	return &dst.CallExpr{
 		Fun:  dst.NewIdent(funcName),
-		Args: arguments,
+		Args: cloneExprSlice(arguments),
 	}
 }
 
@@ -28,7 +28,7 @@ func CallQualifiedFunc(qualifier string, funcName string, arguments ...dst.Expr)
 			X:   dst.NewIdent(qualifier),
 			Sel: dst.NewIdent(funcName),
 		},
-		Args: arguments,
+		Args: cloneExprSlice(arguments),
 	}
 }
 

--- a/hack/generator/pkg/astbuilder/calls.go
+++ b/hack/generator/pkg/astbuilder/calls.go
@@ -9,9 +9,10 @@ import (
 	"github.com/dave/dst"
 )
 
-// CallFunc creates an expression to call a function with specified arguments, generating code
-// like:
+// CallFunc creates an expression to call a function with specified arguments
+//
 // <funcName>(<arguments>...)
+//
 func CallFunc(funcName string, arguments ...dst.Expr) dst.Expr {
 	return &dst.CallExpr{
 		Fun:  dst.NewIdent(funcName),
@@ -20,8 +21,10 @@ func CallFunc(funcName string, arguments ...dst.Expr) dst.Expr {
 }
 
 // CallQualifiedFunc creates an expression to call a qualified function with the specified
-// arguments, generating code like:
+// arguments
+//
 // <qualifier>.<funcName>(arguments...)
+//
 func CallQualifiedFunc(qualifier string, funcName string, arguments ...dst.Expr) dst.Expr {
 	return &dst.CallExpr{
 		Fun: &dst.SelectorExpr{
@@ -32,9 +35,10 @@ func CallQualifiedFunc(qualifier string, funcName string, arguments ...dst.Expr)
 	}
 }
 
-// InvokeFunc creates a statement to invoke a function with specified arguments, generating code
-// like
+// InvokeFunc creates a statement to invoke a function with specified arguments
+//
 // <funcName>(arguments...)
+//
 // If you want to use the result of the function call as a value, use CallFunc() instead
 func InvokeFunc(funcName string, arguments ...dst.Expr) dst.Stmt {
 	return &dst.ExprStmt{
@@ -43,8 +47,10 @@ func InvokeFunc(funcName string, arguments ...dst.Expr) dst.Stmt {
 }
 
 // InvokeQualifiedFunc creates a statement to invoke a qualified function with specified
-// arguments, generating code like:
+// arguments
+//
 // <qualifier>.<funcName>(arguments...)
+//
 // If you want to use the result of the function call as a value, use CallQualifiedFunc() instead
 func InvokeQualifiedFunc(qualifier string, funcName string, arguments ...dst.Expr) dst.Stmt {
 	return &dst.ExprStmt{

--- a/hack/generator/pkg/astbuilder/lists.go
+++ b/hack/generator/pkg/astbuilder/lists.go
@@ -5,7 +5,7 @@ import (
 	"go/token"
 )
 
-// MakeSlice returns the call expression for making a slice, like:
+// MakeList returns the call expression for making a slice, like:
 // 	make([]<value>)
 func MakeList(listType dst.Expr, len dst.Expr) *dst.CallExpr {
 	return &dst.CallExpr{

--- a/hack/generator/pkg/astbuilder/lists.go
+++ b/hack/generator/pkg/astbuilder/lists.go
@@ -10,8 +10,10 @@ import (
 	"go/token"
 )
 
-// MakeList returns the call expression for making a slice, like:
-// 	make([]<value>)
+// MakeList returns the call expression for making a slice
+//
+// make([]<value>)
+//
 func MakeList(listType dst.Expr, len dst.Expr) *dst.CallExpr {
 	return &dst.CallExpr{
 		Fun: dst.NewIdent("make"),
@@ -22,8 +24,10 @@ func MakeList(listType dst.Expr, len dst.Expr) *dst.CallExpr {
 	}
 }
 
-// AppendList returns a statement for a list append, like:
-//     <lhs> = append(<lhs>, <rhs>)
+// AppendList returns a statement for a list append
+//
+// <lhs> = append(<lhs>, <rhs>)
+//
 func AppendList(lhs dst.Expr, rhs dst.Expr) dst.Stmt {
 	return SimpleAssignment(
 		dst.Clone(lhs).(dst.Expr),

--- a/hack/generator/pkg/astbuilder/lists.go
+++ b/hack/generator/pkg/astbuilder/lists.go
@@ -45,7 +45,7 @@ func IterateOverListWithIndex(index string, item string, list dst.Expr, statemen
 		Tok:   token.DEFINE,
 		X:     list,
 		Body: &dst.BlockStmt{
-			List: statements,
+			List: cloneStmtSlice(statements),
 		},
 	}
 }

--- a/hack/generator/pkg/astbuilder/lists.go
+++ b/hack/generator/pkg/astbuilder/lists.go
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) Microsoft Corporation.
+ * Licensed under the MIT license.
+ */
+
 package astbuilder
 
 import (

--- a/hack/generator/pkg/astbuilder/lists.go
+++ b/hack/generator/pkg/astbuilder/lists.go
@@ -31,6 +31,13 @@ func AppendList(lhs dst.Expr, rhs dst.Expr) dst.Stmt {
 		CallFunc("append", dst.Clone(lhs).(dst.Expr), dst.Clone(rhs).(dst.Expr)))
 }
 
+// IterateOverList creates a statement to iterate over the content of a list using the specified
+// identifier for each element in the list
+//
+// for _, <item> := range <list> {
+//     <statements>
+// }
+//
 func IterateOverList(item string, list dst.Expr, statements ...dst.Stmt) *dst.RangeStmt {
 	return &dst.RangeStmt{
 		Key:   dst.NewIdent("_"),
@@ -43,6 +50,13 @@ func IterateOverList(item string, list dst.Expr, statements ...dst.Stmt) *dst.Ra
 	}
 }
 
+// IterateOverListWithIndex creates a statement to iterate over the content of a list using the specified
+// identifiers for each index and element in the list
+//
+// for <index>, <item> := range <list> {
+//     <statements>
+// }
+//
 func IterateOverListWithIndex(index string, item string, list dst.Expr, statements ...dst.Stmt) *dst.RangeStmt {
 	return &dst.RangeStmt{
 		Key:   dst.NewIdent(index),

--- a/hack/generator/pkg/astbuilder/lists.go
+++ b/hack/generator/pkg/astbuilder/lists.go
@@ -1,0 +1,51 @@
+package astbuilder
+
+import (
+	"github.com/dave/dst"
+	"go/token"
+)
+
+// MakeSlice returns the call expression for making a slice, like:
+// 	make([]<value>)
+func MakeList(listType dst.Expr, len dst.Expr) *dst.CallExpr {
+	return &dst.CallExpr{
+		Fun: dst.NewIdent("make"),
+		Args: []dst.Expr{
+			listType,
+			len,
+		},
+	}
+}
+
+// AppendList returns a statement for a list append, like:
+//     <lhs> = append(<lhs>, <rhs>)
+func AppendList(lhs dst.Expr, rhs dst.Expr) dst.Stmt {
+	return SimpleAssignment(
+		dst.Clone(lhs).(dst.Expr),
+		token.ASSIGN,
+		CallFunc("append", dst.Clone(lhs).(dst.Expr), dst.Clone(rhs).(dst.Expr)))
+}
+
+func IterateOverList(item string, list dst.Expr, statements ...dst.Stmt) *dst.RangeStmt {
+	return &dst.RangeStmt{
+		Key:   dst.NewIdent("_"),
+		Value: dst.NewIdent(item),
+		Tok:   token.DEFINE,
+		X:     list,
+		Body: &dst.BlockStmt{
+			List: statements,
+		},
+	}
+}
+
+func IterateOverListWithIndex(index string, item string, list dst.Expr, statements ...dst.Stmt) *dst.RangeStmt {
+	return &dst.RangeStmt{
+		Key:   dst.NewIdent(index),
+		Value: dst.NewIdent(item),
+		Tok:   token.DEFINE,
+		X:     list,
+		Body: &dst.BlockStmt{
+			List: statements,
+		},
+	}
+}

--- a/hack/generator/pkg/astbuilder/maps.go
+++ b/hack/generator/pkg/astbuilder/maps.go
@@ -30,3 +30,15 @@ func InsertMap(m dst.Expr, key dst.Expr, rhs dst.Expr) *dst.AssignStmt {
 		token.ASSIGN,
 		dst.Clone(rhs).(dst.Expr))
 }
+
+func IterateOverMapWithValue(key string, item string, list dst.Expr, statements ...dst.Stmt) *dst.RangeStmt {
+	return &dst.RangeStmt{
+		Key:   dst.NewIdent(key),
+		Value: dst.NewIdent(item),
+		Tok:   token.DEFINE,
+		X:     list,
+		Body: &dst.BlockStmt{
+			List: cloneStmtSlice(statements),
+		},
+	}
+}

--- a/hack/generator/pkg/astbuilder/maps.go
+++ b/hack/generator/pkg/astbuilder/maps.go
@@ -36,12 +36,19 @@ func InsertMap(m dst.Expr, key dst.Expr, rhs dst.Expr) *dst.AssignStmt {
 		dst.Clone(rhs).(dst.Expr))
 }
 
-func IterateOverMapWithValue(key string, item string, list dst.Expr, statements ...dst.Stmt) *dst.RangeStmt {
+// IterateOverMapWithValue creates a statement to iterate over the content of a map using the
+// specified identifiers for each key and value found.
+//
+// for <key>, <item> := range <mapExpr> {
+//     <statements>
+// }
+//
+func IterateOverMapWithValue(key string, item string, mapExpr dst.Expr, statements ...dst.Stmt) *dst.RangeStmt {
 	return &dst.RangeStmt{
 		Key:   dst.NewIdent(key),
 		Value: dst.NewIdent(item),
 		Tok:   token.DEFINE,
-		X:     list,
+		X:     mapExpr,
 		Body: &dst.BlockStmt{
 			List: cloneStmtSlice(statements),
 		},

--- a/hack/generator/pkg/astbuilder/maps.go
+++ b/hack/generator/pkg/astbuilder/maps.go
@@ -10,8 +10,10 @@ import (
 	"go/token"
 )
 
-// MakeMap returns the call expression for making a map, like:
+// MakeMap returns the call expression for making a map
+//
 // 	make(map[<key>]<value>)
+//
 func MakeMap(key dst.Expr, value dst.Expr) *dst.CallExpr {
 	return &dst.CallExpr{
 		Fun: dst.NewIdent("make"),
@@ -24,12 +26,14 @@ func MakeMap(key dst.Expr, value dst.Expr) *dst.CallExpr {
 	}
 }
 
-// InsertMap returns an assignment statement for inserting an item into a map, like:
-// 	<m>[<key>] = <rhs>
-func InsertMap(m dst.Expr, key dst.Expr, rhs dst.Expr) *dst.AssignStmt {
+// InsertMap returns an assignment statement for inserting an item into a map
+//
+// 	<mapExpr>[<key>] = <rhs>
+//
+func InsertMap(mapExpr dst.Expr, key dst.Expr, rhs dst.Expr) *dst.AssignStmt {
 	return SimpleAssignment(
 		&dst.IndexExpr{
-			X:     dst.Clone(m).(dst.Expr),
+			X:     dst.Clone(mapExpr).(dst.Expr),
 			Index: dst.Clone(key).(dst.Expr),
 		},
 		token.ASSIGN,

--- a/hack/generator/pkg/astbuilder/maps.go
+++ b/hack/generator/pkg/astbuilder/maps.go
@@ -1,0 +1,32 @@
+package astbuilder
+
+import (
+	"github.com/dave/dst"
+	"go/token"
+)
+
+// MakeMap returns the call expression for making a map, like:
+// 	make(map[<key>]<value>)
+func MakeMap(key dst.Expr, value dst.Expr) *dst.CallExpr {
+	return &dst.CallExpr{
+		Fun: dst.NewIdent("make"),
+		Args: []dst.Expr{
+			&dst.MapType{
+				Key:   dst.Clone(key).(dst.Expr),
+				Value: dst.Clone(value).(dst.Expr),
+			},
+		},
+	}
+}
+
+// InsertMap returns an assignment statement for inserting an item into a map, like:
+// 	<m>[<key>] = <rhs>
+func InsertMap(m dst.Expr, key dst.Expr, rhs dst.Expr) *dst.AssignStmt {
+	return SimpleAssignment(
+		&dst.IndexExpr{
+			X:     dst.Clone(m).(dst.Expr),
+			Index: dst.Clone(key).(dst.Expr),
+		},
+		token.ASSIGN,
+		dst.Clone(rhs).(dst.Expr))
+}

--- a/hack/generator/pkg/astbuilder/maps.go
+++ b/hack/generator/pkg/astbuilder/maps.go
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) Microsoft Corporation.
+ * Licensed under the MIT license.
+ */
+
 package astbuilder
 
 import (


### PR DESCRIPTION
Pulled out of #378, a collection of changes to the `astbuilder` package, including:

* Automatic cloning of passed parameters to avoid errors writing generated code
* Creation of `lists.go` and `maps.go` to group functions for easier discovery
* New methods `Dereference()` `Selector()` and `NotEqual()`
* Helper methods to clone slices of `dst.Expr` and `dst.Stmt`