### PR TITLE
Create a standard approach for unwrapping nested Types

### DIFF
--- a/hack/generator/pkg/astmodel/errored_type.go
+++ b/hack/generator/pkg/astmodel/errored_type.go
@@ -22,6 +22,8 @@ type ErroredType struct {
 
 var _ Type = &ErroredType{}
 
+var _ MetaType = &ErroredType{}
+
 func NewErroredType(t Type, errors []string, warnings []string) *ErroredType {
 	result := &ErroredType{
 		inner:    nil,
@@ -142,4 +144,9 @@ func (e *ErroredType) String() string {
 	}
 
 	return fmt.Sprintf("%s (has %s)", e.inner.String(), has)
+}
+
+// Unwrap returns the type contained within the error type
+func (e *ErroredType) Unwrap() Type {
+	return e.inner
 }

--- a/hack/generator/pkg/astmodel/flagged_type.go
+++ b/hack/generator/pkg/astmodel/flagged_type.go
@@ -20,6 +20,8 @@ type FlaggedType struct {
 
 var _ Type = &FlaggedType{}
 
+var _ MetaType = &FlaggedType{}
+
 // NewFlaggedType applies flags to an existing type and returns a wrapper
 func NewFlaggedType(t Type, flags ...TypeFlag) *FlaggedType {
 	result := &FlaggedType{
@@ -179,4 +181,9 @@ func TypeOrFlaggedTypeAsObjectType(t Type) (*ObjectType, error) {
 	}
 
 	return nil, errors.Errorf("type %v is not an object or a FlaggedType", t)
+}
+
+// Unwrap returns the type contained within the wrapper type
+func (ft *FlaggedType) Unwrap() Type {
+	return ft.element
 }

--- a/hack/generator/pkg/astmodel/meta_type.go
+++ b/hack/generator/pkg/astmodel/meta_type.go
@@ -11,6 +11,20 @@ type MetaType interface {
 	Unwrap() Type
 }
 
+// AsPrimitiveType unwraps any wrappers around the provided type and returns either the underlying
+// PrimitiveType or nil
+func AsPrimitiveType(aType Type) *PrimitiveType {
+	if primitive, ok := aType.(*PrimitiveType); ok {
+		return primitive
+	}
+
+	if wrapper, ok := aType.(MetaType); ok {
+		return AsPrimitiveType(wrapper.Unwrap())
+	}
+
+	return nil
+}
+
 // AsObjectType unwraps any wrappers around the provided type and returns either the underlying
 // ObjectType or nil
 func AsObjectType(aType Type) *ObjectType {

--- a/hack/generator/pkg/astmodel/meta_type.go
+++ b/hack/generator/pkg/astmodel/meta_type.go
@@ -10,3 +10,17 @@ type MetaType interface {
 	// Unwrap returns the type contained within the wrapper type
 	Unwrap() Type
 }
+
+// AsObjectType unwraps any wrappers around the provided type and returns either the underlying
+// ObjectType or nil
+func AsObjectType(aType Type) *ObjectType {
+	if obj, ok := aType.(*ObjectType); ok {
+		return obj
+	}
+
+	if wrapper, ok := aType.(MetaType); ok {
+		return AsObjectType(wrapper.Unwrap())
+	}
+
+	return nil
+}

--- a/hack/generator/pkg/astmodel/meta_type.go
+++ b/hack/generator/pkg/astmodel/meta_type.go
@@ -51,3 +51,16 @@ func AsArrayType(aType Type) *ArrayType {
 
 	return nil
 }
+
+// AsMapType unwraps any wrappers around the provided type and returns either the underlying MapType or nil
+func AsMapType(aType Type) *MapType {
+	if mt, ok := aType.(*MapType); ok {
+		return mt
+	}
+
+	if wrapper, ok := aType.(MetaType); ok {
+		return AsMapType(wrapper.Unwrap())
+	}
+
+	return nil
+}

--- a/hack/generator/pkg/astmodel/meta_type.go
+++ b/hack/generator/pkg/astmodel/meta_type.go
@@ -64,3 +64,16 @@ func AsMapType(aType Type) *MapType {
 
 	return nil
 }
+
+// AsOptionalType unwraps any wrappers around the provided type and returns either the underlying OptionalType or nil
+func AsOptionalType(aType Type) *OptionalType {
+	if opt, ok := aType.(*OptionalType); ok {
+		return opt
+	}
+
+	if wrapper, ok := aType.(MetaType); ok {
+		return AsOptionalType(wrapper.Unwrap())
+	}
+
+	return nil
+}

--- a/hack/generator/pkg/astmodel/meta_type.go
+++ b/hack/generator/pkg/astmodel/meta_type.go
@@ -1,0 +1,12 @@
+/*
+ * Copyright (c) Microsoft Corporation.
+ * Licensed under the MIT license.
+ */
+
+package astmodel
+
+// A MetaType is a type wrapper that provide additional information/context about another type
+type MetaType interface {
+	// Unwrap returns the type contained within the wrapper type
+	Unwrap() Type
+}

--- a/hack/generator/pkg/astmodel/meta_type.go
+++ b/hack/generator/pkg/astmodel/meta_type.go
@@ -38,3 +38,16 @@ func AsObjectType(aType Type) *ObjectType {
 
 	return nil
 }
+
+// AsArrayType unwraps any wrappers the provided type and returns either the underlying ArrayType or nil
+func AsArrayType(aType Type) *ArrayType {
+	if arr, ok := aType.(*ArrayType); ok {
+		return arr
+	}
+
+	if wrapper, ok := aType.(MetaType); ok {
+		return AsArrayType(wrapper.Unwrap())
+	}
+
+	return nil
+}

--- a/hack/generator/pkg/astmodel/meta_type_test.go
+++ b/hack/generator/pkg/astmodel/meta_type_test.go
@@ -95,3 +95,48 @@ func TestAsObjectType(t *testing.T) {
 		})
 	}
 }
+
+func TestAsArrayType(t *testing.T) {
+
+	objectType := NewObjectType()
+	arrayType := NewArrayType(StringType)
+	mapType := NewMapType(StringType, StringType)
+	optionalType := NewOptionalType(objectType)
+
+	cases := []struct {
+		name     string
+		subject  Type
+		expected Type
+	}{
+		{"PrimitivesAreNotArrays", StringType, nil},
+		{"ObjectsAreNotArrays", objectType, nil},
+		{"ArraysAreArrays", arrayType, arrayType},
+		{"MapsAreNotArrays", mapType, nil},
+		{"OptionalAreNotArrays", optionalType, nil},
+		{"OptionalContainingArray", NewOptionalType(arrayType), arrayType},
+		{"OptionalNotContainingArray", NewOptionalType(StringType), nil},
+		{"FlaggedContainingArray", OneOfFlag.ApplyTo(arrayType), arrayType},
+		{"FlaggedNotContainingArray", OneOfFlag.ApplyTo(StringType), nil},
+		{"ValidatedContainingArray", MakeValidatedType(arrayType, nil), arrayType},
+		{"ValidatedNotContainingArray", MakeValidatedType(StringType, nil), nil},
+		{"ErroredContainingArray", MakeErroredType(arrayType, nil, nil), arrayType},
+		{"ErroredNotContainingArray", MakeErroredType(StringType, nil, nil), nil},
+	}
+
+	for _, c := range cases {
+		c := c
+		t.Run(c.name, func(t *testing.T) {
+			t.Parallel()
+			g := NewGomegaWithT(t)
+
+			actual := AsArrayType(c.subject)
+
+			if c.expected == nil {
+				g.Expect(actual).To(BeNil())
+			} else {
+				g.Expect(actual).To(Equal(c.expected))
+			}
+
+		})
+	}
+}

--- a/hack/generator/pkg/astmodel/meta_type_test.go
+++ b/hack/generator/pkg/astmodel/meta_type_test.go
@@ -32,10 +32,10 @@ func TestAsPrimitiveType(t *testing.T) {
 		{"OptionalNotContainingPrimitive", NewOptionalType(objectType), nil},
 		{"FlaggedContainingPrimitive", OneOfFlag.ApplyTo(StringType), StringType},
 		{"FlaggedNotContainingPrimitive", OneOfFlag.ApplyTo(objectType), nil},
-		{"ValidatedContainingPrimitive", MakeValidatedType(StringType, nil), StringType},
-		{"ValidatedNotContainingPrimitive", MakeValidatedType(objectType, nil), nil},
-		{"ErroredContainingPrimitive", MakeErroredType(StringType, nil, nil), StringType},
-		{"ErroredNotContainingPrimitive", MakeErroredType(objectType, nil, nil), nil},
+		{"ValidatedContainingPrimitive", NewValidatedType(StringType, nil), StringType},
+		{"ValidatedNotContainingPrimitive", NewValidatedType(objectType, nil), nil},
+		{"ErroredContainingPrimitive", NewErroredType(StringType, nil, nil), StringType},
+		{"ErroredNotContainingPrimitive", NewErroredType(objectType, nil, nil), nil},
 	}
 
 	for _, c := range cases {
@@ -77,10 +77,10 @@ func TestAsObjectType(t *testing.T) {
 		{"OptionalNotContainingObject", NewOptionalType(StringType), nil},
 		{"FlaggedContainingObject", OneOfFlag.ApplyTo(objectType), objectType},
 		{"FlaggedNotContainingObject", OneOfFlag.ApplyTo(StringType), nil},
-		{"ValidatedContainingObject", MakeValidatedType(objectType, nil), objectType},
-		{"ValidatedNotContainingObject", MakeValidatedType(StringType, nil), nil},
-		{"ErroredContainingObject", MakeErroredType(objectType, nil, nil), objectType},
-		{"ErroredNotContainingObject", MakeErroredType(StringType, nil, nil), nil},
+		{"ValidatedContainingObject", NewValidatedType(objectType, nil), objectType},
+		{"ValidatedNotContainingObject", NewValidatedType(StringType, nil), nil},
+		{"ErroredContainingObject", NewErroredType(objectType, nil, nil), objectType},
+		{"ErroredNotContainingObject", NewErroredType(StringType, nil, nil), nil},
 	}
 
 	for _, c := range cases {
@@ -122,10 +122,10 @@ func TestAsArrayType(t *testing.T) {
 		{"OptionalNotContainingArray", NewOptionalType(StringType), nil},
 		{"FlaggedContainingArray", OneOfFlag.ApplyTo(arrayType), arrayType},
 		{"FlaggedNotContainingArray", OneOfFlag.ApplyTo(StringType), nil},
-		{"ValidatedContainingArray", MakeValidatedType(arrayType, nil), arrayType},
-		{"ValidatedNotContainingArray", MakeValidatedType(StringType, nil), nil},
-		{"ErroredContainingArray", MakeErroredType(arrayType, nil, nil), arrayType},
-		{"ErroredNotContainingArray", MakeErroredType(StringType, nil, nil), nil},
+		{"ValidatedContainingArray", NewValidatedType(arrayType, nil), arrayType},
+		{"ValidatedNotContainingArray", NewValidatedType(StringType, nil), nil},
+		{"ErroredContainingArray", NewErroredType(arrayType, nil, nil), arrayType},
+		{"ErroredNotContainingArray", NewErroredType(StringType, nil, nil), nil},
 	}
 
 	for _, c := range cases {
@@ -167,10 +167,10 @@ func TestAsMapType(t *testing.T) {
 		{"OptionalNotContainingMaps", NewOptionalType(StringType), nil},
 		{"FlaggedContainingMaps", OneOfFlag.ApplyTo(mapType), mapType},
 		{"FlaggedNotContainingMaps", OneOfFlag.ApplyTo(StringType), nil},
-		{"ValidatedContainingMaps", MakeValidatedType(mapType, nil), mapType},
-		{"ValidatedNotContainingMaps", MakeValidatedType(StringType, nil), nil},
-		{"ErroredContainingMaps", MakeErroredType(mapType, nil, nil), mapType},
-		{"ErroredNotContainingMaps", MakeErroredType(StringType, nil, nil), nil},
+		{"ValidatedContainingMaps", NewValidatedType(mapType, nil), mapType},
+		{"ValidatedNotContainingMaps", NewValidatedType(StringType, nil), nil},
+		{"ErroredContainingMaps", NewErroredType(mapType, nil, nil), mapType},
+		{"ErroredNotContainingMaps", NewErroredType(StringType, nil, nil), nil},
 	}
 
 	for _, c := range cases {
@@ -210,10 +210,10 @@ func TestAsOptionalType(t *testing.T) {
 		{"OptionalAreOptional", optionalType, optionalType},
 		{"FlaggedContainingOptional", OneOfFlag.ApplyTo(optionalType), optionalType},
 		{"FlaggedNotContainingOptional", OneOfFlag.ApplyTo(StringType), nil},
-		{"ValidatedContainingOptional", MakeValidatedType(optionalType, nil), optionalType},
-		{"ValidatedNotContainingOptional", MakeValidatedType(StringType, nil), nil},
-		{"ErroredContainingOptional", MakeErroredType(optionalType, nil, nil), optionalType},
-		{"ErroredNotContainingOptional", MakeErroredType(StringType, nil, nil), nil},
+		{"ValidatedContainingOptional", NewValidatedType(optionalType, nil), optionalType},
+		{"ValidatedNotContainingOptional", NewValidatedType(StringType, nil), nil},
+		{"ErroredContainingOptional", NewErroredType(optionalType, nil, nil), optionalType},
+		{"ErroredNotContainingOptional", NewErroredType(StringType, nil, nil), nil},
 	}
 
 	for _, c := range cases {

--- a/hack/generator/pkg/astmodel/meta_type_test.go
+++ b/hack/generator/pkg/astmodel/meta_type_test.go
@@ -140,3 +140,48 @@ func TestAsArrayType(t *testing.T) {
 		})
 	}
 }
+
+func TestAsMapType(t *testing.T) {
+
+	objectType := NewObjectType()
+	arrayType := NewArrayType(StringType)
+	mapType := NewMapType(StringType, StringType)
+	optionalType := NewOptionalType(objectType)
+
+	cases := []struct {
+		name     string
+		subject  Type
+		expected Type
+	}{
+		{"PrimitivesAreNotMaps", StringType, nil},
+		{"ObjectsAreNotMaps", objectType, nil},
+		{"ArraysAreNotMaps", arrayType, nil},
+		{"MapsAreMaps", mapType, mapType},
+		{"OptionalAreNotMaps", optionalType, nil},
+		{"OptionalContainingMaps", NewOptionalType(mapType), mapType},
+		{"OptionalNotContainingMaps", NewOptionalType(StringType), nil},
+		{"FlaggedContainingMaps", OneOfFlag.ApplyTo(mapType), mapType},
+		{"FlaggedNotContainingMaps", OneOfFlag.ApplyTo(StringType), nil},
+		{"ValidatedContainingMaps", MakeValidatedType(mapType, nil), mapType},
+		{"ValidatedNotContainingMaps", MakeValidatedType(StringType, nil), nil},
+		{"ErroredContainingMaps", MakeErroredType(mapType, nil, nil), mapType},
+		{"ErroredNotContainingMaps", MakeErroredType(StringType, nil, nil), nil},
+	}
+
+	for _, c := range cases {
+		c := c
+		t.Run(c.name, func(t *testing.T) {
+			t.Parallel()
+			g := NewGomegaWithT(t)
+
+			actual := AsMapType(c.subject)
+
+			if c.expected == nil {
+				g.Expect(actual).To(BeNil())
+			} else {
+				g.Expect(actual).To(Equal(c.expected))
+			}
+
+		})
+	}
+}

--- a/hack/generator/pkg/astmodel/meta_type_test.go
+++ b/hack/generator/pkg/astmodel/meta_type_test.go
@@ -6,6 +6,51 @@ import (
 	. "github.com/onsi/gomega"
 )
 
+func TestAsPrimitiveType(t *testing.T) {
+
+	objectType := NewObjectType()
+	arrayType := NewArrayType(StringType)
+	mapType := NewMapType(StringType, StringType)
+	optionalType := NewOptionalType(arrayType)
+
+	cases := []struct {
+		name     string
+		subject  Type
+		expected Type
+	}{
+		{"PrimitivesArePrimitives", StringType, StringType},
+		{"ObjectAreNotPrimitives", objectType, nil},
+		{"ArraysAreNotPrimitives", arrayType, nil},
+		{"MapsAreNotPrimitives", mapType, nil},
+		{"OptionalAreNotPrimitives", optionalType, nil},
+		{"OptionalContainingPrimitive", NewOptionalType(StringType), StringType},
+		{"OptionalNotContainingPrimitive", NewOptionalType(objectType), nil},
+		{"FlaggedContainingPrimitive", OneOfFlag.ApplyTo(StringType), StringType},
+		{"FlaggedNotContainingPrimitive", OneOfFlag.ApplyTo(objectType), nil},
+		{"ValidatedContainingPrimitive", MakeValidatedType(StringType, nil), StringType},
+		{"ValidatedNotContainingPrimitive", MakeValidatedType(objectType, nil), nil},
+		{"ErroredContainingPrimitive", MakeErroredType(StringType, nil, nil), StringType},
+		{"ErroredNotContainingPrimitive", MakeErroredType(objectType, nil, nil), nil},
+	}
+
+	for _, c := range cases {
+		c := c
+		t.Run(c.name, func(t *testing.T) {
+			t.Parallel()
+			g := NewGomegaWithT(t)
+
+			actual := AsPrimitiveType(c.subject)
+
+			if c.expected == nil {
+				g.Expect(actual).To(BeNil())
+			} else {
+				g.Expect(actual).To(Equal(c.expected))
+			}
+
+		})
+	}
+}
+
 func TestAsObjectType(t *testing.T) {
 
 	objectType := NewObjectType()

--- a/hack/generator/pkg/astmodel/meta_type_test.go
+++ b/hack/generator/pkg/astmodel/meta_type_test.go
@@ -185,3 +185,46 @@ func TestAsMapType(t *testing.T) {
 		})
 	}
 }
+
+func TestAsOptionalType(t *testing.T) {
+
+	objectType := NewObjectType()
+	arrayType := NewArrayType(StringType)
+	mapType := NewMapType(StringType, StringType)
+	optionalType := NewOptionalType(objectType)
+
+	cases := []struct {
+		name     string
+		subject  Type
+		expected Type
+	}{
+		{"PrimitivesAreNotOptional", StringType, nil},
+		{"ObjectsAreNotOptional", objectType, nil},
+		{"ArraysAreNotOptional", arrayType, nil},
+		{"MapsAreNotOptional", mapType, nil},
+		{"OptionalAreOptional", optionalType, optionalType},
+		{"FlaggedContainingOptional", OneOfFlag.ApplyTo(optionalType), optionalType},
+		{"FlaggedNotContainingOptional", OneOfFlag.ApplyTo(StringType), nil},
+		{"ValidatedContainingOptional", MakeValidatedType(optionalType, nil), optionalType},
+		{"ValidatedNotContainingOptional", MakeValidatedType(StringType, nil), nil},
+		{"ErroredContainingOptional", MakeErroredType(optionalType, nil, nil), optionalType},
+		{"ErroredNotContainingOptional", MakeErroredType(StringType, nil, nil), nil},
+	}
+
+	for _, c := range cases {
+		c := c
+		t.Run(c.name, func(t *testing.T) {
+			t.Parallel()
+			g := NewGomegaWithT(t)
+
+			actual := AsOptionalType(c.subject)
+
+			if c.expected == nil {
+				g.Expect(actual).To(BeNil())
+			} else {
+				g.Expect(actual).To(Equal(c.expected))
+			}
+
+		})
+	}
+}

--- a/hack/generator/pkg/astmodel/meta_type_test.go
+++ b/hack/generator/pkg/astmodel/meta_type_test.go
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) Microsoft Corporation.
+ * Licensed under the MIT license.
+ */
+
 package astmodel
 
 import (

--- a/hack/generator/pkg/astmodel/meta_type_test.go
+++ b/hack/generator/pkg/astmodel/meta_type_test.go
@@ -1,0 +1,52 @@
+package astmodel
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+)
+
+func TestAsObjectType(t *testing.T) {
+
+	objectType := NewObjectType()
+	arrayType := NewArrayType(StringType)
+	mapType := NewMapType(StringType, StringType)
+	optionalType := NewOptionalType(StringType)
+
+	cases := []struct {
+		name     string
+		subject  Type
+		expected Type
+	}{
+		{"PrimitivesAreNotObjects", StringType, nil},
+		{"ObjectsAreObjects", objectType, objectType},
+		{"ArraysAreNotObjects", arrayType, nil},
+		{"MapsAreNotObjects", mapType, nil},
+		{"OptionalAreNotObjects", optionalType, nil},
+		{"OptionalContainingObject", NewOptionalType(objectType), objectType},
+		{"OptionalNotContainingObject", NewOptionalType(StringType), nil},
+		{"FlaggedContainingObject", OneOfFlag.ApplyTo(objectType), objectType},
+		{"FlaggedNotContainingObject", OneOfFlag.ApplyTo(StringType), nil},
+		{"ValidatedContainingObject", MakeValidatedType(objectType, nil), objectType},
+		{"ValidatedNotContainingObject", MakeValidatedType(StringType, nil), nil},
+		{"ErroredContainingObject", MakeErroredType(objectType, nil, nil), objectType},
+		{"ErroredNotContainingObject", MakeErroredType(StringType, nil, nil), nil},
+	}
+
+	for _, c := range cases {
+		c := c
+		t.Run(c.name, func(t *testing.T) {
+			t.Parallel()
+			g := NewGomegaWithT(t)
+
+			actual := AsObjectType(c.subject)
+
+			if c.expected == nil {
+				g.Expect(actual).To(BeNil())
+			} else {
+				g.Expect(actual).To(Equal(c.expected))
+			}
+
+		})
+	}
+}

--- a/hack/generator/pkg/astmodel/optional_type.go
+++ b/hack/generator/pkg/astmodel/optional_type.go
@@ -16,6 +16,10 @@ type OptionalType struct {
 	element Type
 }
 
+var _ Type = &OptionalType{}
+
+var _ MetaType = &OptionalType{}
+
 // NewOptionalType creates a new optional type that may or may not have the specified 'element' type
 func NewOptionalType(element Type) Type {
 	if isTypeOptional(element) {
@@ -44,9 +48,6 @@ func isTypeOptional(t Type) bool {
 func (optional *OptionalType) Element() Type {
 	return optional.element
 }
-
-// assert we implemented Type correctly
-var _ Type = (*OptionalType)(nil)
 
 func (optional *OptionalType) AsDeclarations(codeGenerationContext *CodeGenerationContext, declContext DeclarationContext) []dst.Decl {
 	return AsSimpleDeclarations(codeGenerationContext, declContext, optional)
@@ -95,4 +96,9 @@ func (optional *OptionalType) BaseType() Type {
 // String implements fmt.Stringer
 func (optional *OptionalType) String() string {
 	return fmt.Sprintf("(optional: %s)", optional.element.String())
+}
+
+// Unwrap returns the type contained within the wrapper type
+func (optional *OptionalType) Unwrap() Type {
+	return optional.element
 }

--- a/hack/generator/pkg/astmodel/validated_type.go
+++ b/hack/generator/pkg/astmodel/validated_type.go
@@ -143,6 +143,10 @@ type ValidatedType struct {
 	element     Type
 }
 
+var _ Type = &ValidatedType{}
+
+var _ MetaType = &ValidatedType{}
+
 func NewValidatedType(element Type, validations Validations) *ValidatedType {
 	return &ValidatedType{element: element, validations: validations}
 }
@@ -160,8 +164,6 @@ func (v *ValidatedType) WithType(newElement Type) *ValidatedType {
 	result.element = newElement
 	return &result
 }
-
-var _ Type = &ValidatedType{}
 
 func (v *ValidatedType) AsDeclarations(c *CodeGenerationContext, declContext DeclarationContext) []dst.Decl {
 	declContext.Validations = append(declContext.Validations, v.validations.ToKubeBuilderValidations()...)
@@ -216,4 +218,9 @@ func equalOptionalRegexps(left *regexp.Regexp, right *regexp.Regexp) bool {
 	}
 
 	return right == nil
+}
+
+// Unwrap returns the type contained within the validated type
+func (v ValidatedType) Unwrap() Type {
+	return v.element
 }


### PR DESCRIPTION
Adds some utility methods to unwrap nested Types for easier handling, with full test coverage. One of the goals is to make it easier to do certain forms of pattern matching.

Includes a new interface (`MetaType`) used to identify wrapper types that add metadata to existing types.