### PR TITLE
Remove TypeOrFlaggedTypeAsObjectType() in favour of AsObjectType

### DIFF
--- a/hack/generator/pkg/astmodel/flagged_type.go
+++ b/hack/generator/pkg/astmodel/flagged_type.go
@@ -10,7 +10,6 @@ import (
 	"strings"
 
 	"github.com/dave/dst"
-	"github.com/pkg/errors"
 )
 
 type FlaggedType struct {
@@ -163,24 +162,6 @@ func (ft *FlaggedType) String() string {
 	}
 
 	return result.String()
-}
-
-// TypeOrFlaggedTypeAsObjectType returns the type as an ObjectType, or unwraps the element of
-// a FlaggedType and returns that as an ObjectType.
-func TypeOrFlaggedTypeAsObjectType(t Type) (*ObjectType, error) {
-	if objectType, ok := t.(*ObjectType); ok {
-		return objectType, nil
-	}
-
-	if flaggedType, ok := t.(*FlaggedType); ok {
-		if objectType, ok := flaggedType.element.(*ObjectType); ok {
-			return objectType, nil
-		}
-
-		return nil, errors.Errorf("type %v is a FlaggedType whose inner type is not Object", t)
-	}
-
-	return nil, errors.Errorf("type %v is not an object or a FlaggedType", t)
 }
 
 // Unwrap returns the type contained within the wrapper type

--- a/hack/generator/pkg/astmodel/kubernetes_resource_interface.go
+++ b/hack/generator/pkg/astmodel/kubernetes_resource_interface.go
@@ -35,8 +35,8 @@ func AddKubernetesResourceInterfaceImpls(
 		return nil, errors.Wrapf(err, "unable to resolve resource spec type")
 	}
 
-	spec, err := TypeOrFlaggedTypeAsObjectType(resolvedSpec) // TODO: Safe?
-	if err != nil {
+	spec := AsObjectType(resolvedSpec)
+	if spec == nil {
 		return nil, errors.Wrapf(err, "resource spec %q did not contain an object", r.SpecType().String())
 	}
 

--- a/hack/generator/pkg/codegen/pipeline_convert_allof_and_oneof_to_objects_test.go
+++ b/hack/generator/pkg/codegen/pipeline_convert_allof_and_oneof_to_objects_test.go
@@ -308,8 +308,8 @@ func TestOneOfResourceSpec(t *testing.T) {
 	g.Expect(err).To(BeNil())
 
 	result := synth.oneOfObject(oneOf, names)
-	result, err = astmodel.TypeOrFlaggedTypeAsObjectType(result)
-	g.Expect(err).To(BeNil())
+	result = astmodel.AsObjectType(result)
+
 	result = astmodel.NewObjectType().WithProperties(result.(*astmodel.ObjectType).Properties()...)
 	g.Expect(result).To(Equal(expected))
 }

--- a/hack/generator/pkg/codegen/pipeline_create_arm_types.go
+++ b/hack/generator/pkg/codegen/pipeline_create_arm_types.go
@@ -408,8 +408,8 @@ func addArmConversionInterface(
 	idFactory astmodel.IdentifierFactory,
 	typeType armconversion.TypeKind) (astmodel.TypeDefinition, error) {
 
-	objectType, err := astmodel.TypeOrFlaggedTypeAsObjectType(armDef.Type())
-	if err != nil {
+	objectType := astmodel.AsObjectType(armDef.Type())
+	if objectType == nil {
 		emptyDef := astmodel.TypeDefinition{}
 		return emptyDef, errors.Errorf("ARM definition %q did not define an object type", armDef.Name())
 	}


### PR DESCRIPTION
Minor cleanup now that we have `AsObjectType()`