### PR TITLE
Add new FileWriter abstraction

### DIFF
--- a/hack/generated/go.mod
+++ b/hack/generated/go.mod
@@ -18,6 +18,7 @@ require (
 	github.com/onsi/gomega v1.10.1
 	github.com/pkg/errors v0.9.1
 	k8s.io/api v0.18.6
+	k8s.io/apiextensions-apiserver v0.18.6
 	k8s.io/apimachinery v0.18.6
 	k8s.io/client-go v0.18.6
 	k8s.io/klog/v2 v2.0.0

--- a/hack/generator/pkg/astmodel/go_source_file.go
+++ b/hack/generator/pkg/astmodel/go_source_file.go
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) Microsoft Corporation.
+ * Licensed under the MIT license.
+ */
+
+package astmodel
+
+import (
+	"bufio"
+	"io"
+	"os"
+
+	"github.com/dave/dst"
+	"github.com/dave/dst/decorator"
+)
+
+// GoSourceFile represents a file of Go code
+type GoSourceFile interface {
+	// AsAst transforms the file into a dst.File (you can think of this as the AST representation of the file)
+	AsAst() (*dst.File, error)
+}
+
+type GoSourceFileWriter struct {
+	file GoSourceFile
+}
+
+// NewGoSourceFileWriter creates a new writer for writing the given file
+func NewGoSourceFileWriter(file GoSourceFile) *GoSourceFileWriter {
+	return &GoSourceFileWriter{
+		file: file,
+	}
+}
+
+// SaveToWriter writes the given FileAst to the destination
+func (w *GoSourceFileWriter) SaveToWriter(destination io.Writer) error {
+	content, err := w.file.AsAst()
+	if err != nil {
+		return err
+	}
+
+	buf := bufio.NewWriter(destination)
+	defer buf.Flush()
+
+	return decorator.Fprint(buf, content)
+}
+
+// SaveToFile writes the given FileAst to the specified file path
+func (w *GoSourceFileWriter) SaveToFile(filePath string) error {
+
+	file, err := os.Create(filePath)
+	if err != nil {
+		return err
+	}
+
+	defer func() {
+		file.Close()
+
+		// if we are panicking, the file will be in a broken
+		// state, so remove it
+		if r := recover(); r != nil {
+			os.Remove(filePath)
+			panic(r)
+		}
+	}()
+
+	err = w.SaveToWriter(file)
+	if err != nil {
+		// cleanup in case of errors
+		file.Close()
+		os.Remove(filePath)
+	}
+
+	return err
+}

--- a/hack/generator/pkg/astmodel/package_import_set.go
+++ b/hack/generator/pkg/astmodel/package_import_set.go
@@ -6,10 +6,12 @@
 package astmodel
 
 import (
-	"github.com/pkg/errors"
-	kerrors "k8s.io/apimachinery/pkg/util/errors"
 	"sort"
 	"strings"
+
+	"github.com/dave/dst"
+	"github.com/pkg/errors"
+	kerrors "k8s.io/apimachinery/pkg/util/errors"
 )
 
 // PackageImportSet represents a set of distinct PackageImport references
@@ -99,6 +101,16 @@ func (set *PackageImportSet) AsSortedSlice() []PackageImport {
 	})
 
 	return result
+}
+
+// AsImportSpecs returns the abstract syntax tree representation for importing the packages in this set
+func (set *PackageImportSet) AsImportSpecs() []dst.Spec {
+	var importSpecs []dst.Spec
+	for _, requiredImport := range set.AsSortedSlice() {
+		importSpecs = append(importSpecs, requiredImport.AsImportSpec())
+	}
+
+	return importSpecs
 }
 
 // Length returns the number of unique imports in this set

--- a/hack/generator/pkg/codegen/codegen_test.go
+++ b/hack/generator/pkg/codegen/codegen_test.go
@@ -206,7 +206,8 @@ func exportPackagesTestPipelineStage(t *testing.T, testName string) PipelineStag
 			fileDef := astmodel.NewFileDefinition(pr, ds, pkgs)
 
 			buf := &bytes.Buffer{}
-			err := fileDef.SaveToWriter(buf)
+			fileWriter := astmodel.NewGoSourceFileWriter(fileDef)
+			err := fileWriter.SaveToWriter(buf)
 			if err != nil {
 				t.Fatalf("could not generate file: %v", err)
 			}


### PR DESCRIPTION
Reduces duplication as we support more and more "file formats" such as test files, etc.

This is a stepping stone to adding a new file type for registering the CRD types with the controller.