### PR TITLE
Improve Type Unwrapping 

### DIFF
--- a/hack/generator/pkg/astmodel/kubernetes_resource_interface.go
+++ b/hack/generator/pkg/astmodel/kubernetes_resource_interface.go
@@ -35,14 +35,14 @@ func AddKubernetesResourceInterfaceImpls(
 		return nil, errors.Wrapf(err, "unable to resolve resource spec type")
 	}
 
-	spec := AsObjectType(resolvedSpec)
-	if spec == nil {
-		return nil, errors.Wrapf(err, "resource spec %q did not contain an object", r.SpecType().String())
+	spec, ok := AsObjectType(resolvedSpec)
+	if !ok {
+		return nil, errors.Errorf("resource spec %q did not contain an object", r.SpecType().String())
 	}
 
 	// Check the spec first to ensure it looks how we expect
 	ownerProperty := idFactory.CreatePropertyName(OwnerProperty, Exported)
-	_, ok := spec.Property(ownerProperty)
+	_, ok = spec.Property(ownerProperty)
 	if !ok {
 		return nil, errors.Errorf("resource spec doesn't have %q property", ownerProperty)
 	}

--- a/hack/generator/pkg/astmodel/meta_type.go
+++ b/hack/generator/pkg/astmodel/meta_type.go
@@ -77,3 +77,16 @@ func AsOptionalType(aType Type) *OptionalType {
 
 	return nil
 }
+
+// AsEnumType unwraps any wrappers around the provided type and returns either the underlying EnumType and true, or nil and false.
+func AsEnumType(aType Type) (*EnumType, bool) {
+	if enm, ok := aType.(*EnumType); ok {
+		return enm, true
+	}
+
+	if wrapper, ok := aType.(MetaType); ok {
+		return AsEnumType(wrapper.Unwrap())
+	}
+
+	return nil
+}

--- a/hack/generator/pkg/astmodel/meta_type.go
+++ b/hack/generator/pkg/astmodel/meta_type.go
@@ -89,4 +89,16 @@ func AsEnumType(aType Type) (*EnumType, bool) {
 	}
 
 	return nil
+
+// AsTypeName unwraps any wrappers around the provided type and returns either the underlying TypeName and true, or a blank and false.
+func AsTypeName(aType Type) (TypeName, bool) {
+	if name, ok := aType.(TypeName); ok {
+		return name, true
+	}
+
+	if wrapper, ok := aType.(MetaType); ok {
+		return AsTypeName(wrapper.Unwrap())
+	}
+
+	return TypeName{}, false
 }

--- a/hack/generator/pkg/astmodel/meta_type.go
+++ b/hack/generator/pkg/astmodel/meta_type.go
@@ -12,70 +12,73 @@ type MetaType interface {
 }
 
 // AsPrimitiveType unwraps any wrappers around the provided type and returns either the underlying
-// PrimitiveType or nil
-func AsPrimitiveType(aType Type) *PrimitiveType {
+// PrimitiveType and true, or nil and false.
+func AsPrimitiveType(aType Type) (*PrimitiveType, bool) {
 	if primitive, ok := aType.(*PrimitiveType); ok {
-		return primitive
+		return primitive, true
 	}
 
 	if wrapper, ok := aType.(MetaType); ok {
 		return AsPrimitiveType(wrapper.Unwrap())
 	}
 
-	return nil
+	return nil, false
 }
 
 // AsObjectType unwraps any wrappers around the provided type and returns either the underlying
-// ObjectType or nil
-func AsObjectType(aType Type) *ObjectType {
+// ObjectType and true, or nil and false.
+func AsObjectType(aType Type) (*ObjectType, bool) {
 	if obj, ok := aType.(*ObjectType); ok {
-		return obj
+		return obj, true
 	}
 
 	if wrapper, ok := aType.(MetaType); ok {
 		return AsObjectType(wrapper.Unwrap())
 	}
 
-	return nil
+	return nil, false
 }
 
-// AsArrayType unwraps any wrappers the provided type and returns either the underlying ArrayType or nil
-func AsArrayType(aType Type) *ArrayType {
+// AsArrayType unwraps any wrappers around the provided type and returns either the underlying
+// ArrayType and true, or nil and false.
+func AsArrayType(aType Type) (*ArrayType, bool) {
 	if arr, ok := aType.(*ArrayType); ok {
-		return arr
+		return arr, true
 	}
 
 	if wrapper, ok := aType.(MetaType); ok {
 		return AsArrayType(wrapper.Unwrap())
 	}
 
-	return nil
+	return nil, false
 }
 
-// AsMapType unwraps any wrappers around the provided type and returns either the underlying MapType or nil
-func AsMapType(aType Type) *MapType {
+// AsMapType unwraps any wrappers around the provided type and returns either the underlying
+// MapType and true, or nil and false.
+func AsMapType(aType Type) (*MapType, bool) {
 	if mt, ok := aType.(*MapType); ok {
-		return mt
+		return mt, true
 	}
 
 	if wrapper, ok := aType.(MetaType); ok {
 		return AsMapType(wrapper.Unwrap())
 	}
 
-	return nil
+	return nil, false
 }
 
-// AsOptionalType unwraps any wrappers around the provided type and returns either the underlying OptionalType or nil
-func AsOptionalType(aType Type) *OptionalType {
+// AsOptionalType unwraps any wrappers around the provided type and returns either the underlying
+// OptionalType and true, or nil and false.
+func AsOptionalType(aType Type) (*OptionalType, bool) {
 	if opt, ok := aType.(*OptionalType); ok {
-		return opt
+		return opt, true
 	}
 
 	if wrapper, ok := aType.(MetaType); ok {
 		return AsOptionalType(wrapper.Unwrap())
 	}
 
-	return nil
+	return nil, false
 }
 
 // AsEnumType unwraps any wrappers around the provided type and returns either the underlying EnumType and true, or nil and false.
@@ -88,7 +91,8 @@ func AsEnumType(aType Type) (*EnumType, bool) {
 		return AsEnumType(wrapper.Unwrap())
 	}
 
-	return nil
+	return nil, false
+}
 
 // AsTypeName unwraps any wrappers around the provided type and returns either the underlying TypeName and true, or a blank and false.
 func AsTypeName(aType Type) (TypeName, bool) {

--- a/hack/generator/pkg/astmodel/meta_type_test.go
+++ b/hack/generator/pkg/astmodel/meta_type_test.go
@@ -17,6 +17,7 @@ func TestAsPrimitiveType(t *testing.T) {
 	arrayType := NewArrayType(StringType)
 	mapType := NewMapType(StringType, StringType)
 	optionalType := NewOptionalType(arrayType)
+	enumType := NewEnumType(StringType, []EnumValue{})
 
 	cases := []struct {
 		name     string
@@ -27,6 +28,7 @@ func TestAsPrimitiveType(t *testing.T) {
 		{"ObjectAreNotPrimitives", objectType, nil},
 		{"ArraysAreNotPrimitives", arrayType, nil},
 		{"MapsAreNotPrimitives", mapType, nil},
+		{"EnumsAreNotPrimitives", enumType, nil},
 		{"OptionalAreNotPrimitives", optionalType, nil},
 		{"OptionalContainingPrimitive", NewOptionalType(StringType), StringType},
 		{"OptionalNotContainingPrimitive", NewOptionalType(objectType), nil},
@@ -62,6 +64,7 @@ func TestAsObjectType(t *testing.T) {
 	arrayType := NewArrayType(StringType)
 	mapType := NewMapType(StringType, StringType)
 	optionalType := NewOptionalType(StringType)
+	enumType := NewEnumType(StringType, []EnumValue{})
 
 	cases := []struct {
 		name     string
@@ -72,6 +75,7 @@ func TestAsObjectType(t *testing.T) {
 		{"ObjectsAreObjects", objectType, objectType},
 		{"ArraysAreNotObjects", arrayType, nil},
 		{"MapsAreNotObjects", mapType, nil},
+		{"EnumsAreNotObjects", enumType, nil},
 		{"OptionalAreNotObjects", optionalType, nil},
 		{"OptionalContainingObject", NewOptionalType(objectType), objectType},
 		{"OptionalNotContainingObject", NewOptionalType(StringType), nil},
@@ -107,6 +111,7 @@ func TestAsArrayType(t *testing.T) {
 	arrayType := NewArrayType(StringType)
 	mapType := NewMapType(StringType, StringType)
 	optionalType := NewOptionalType(objectType)
+	enumType := NewEnumType(StringType, []EnumValue{})
 
 	cases := []struct {
 		name     string
@@ -117,6 +122,7 @@ func TestAsArrayType(t *testing.T) {
 		{"ObjectsAreNotArrays", objectType, nil},
 		{"ArraysAreArrays", arrayType, arrayType},
 		{"MapsAreNotArrays", mapType, nil},
+		{"EnumsAreNotArrays", enumType, nil},
 		{"OptionalAreNotArrays", optionalType, nil},
 		{"OptionalContainingArray", NewOptionalType(arrayType), arrayType},
 		{"OptionalNotContainingArray", NewOptionalType(StringType), nil},
@@ -152,6 +158,7 @@ func TestAsMapType(t *testing.T) {
 	arrayType := NewArrayType(StringType)
 	mapType := NewMapType(StringType, StringType)
 	optionalType := NewOptionalType(objectType)
+	enumType := NewEnumType(StringType, []EnumValue{})
 
 	cases := []struct {
 		name     string
@@ -162,6 +169,7 @@ func TestAsMapType(t *testing.T) {
 		{"ObjectsAreNotMaps", objectType, nil},
 		{"ArraysAreNotMaps", arrayType, nil},
 		{"MapsAreMaps", mapType, mapType},
+		{"EnumsAreNotMaps", enumType, nil},
 		{"OptionalAreNotMaps", optionalType, nil},
 		{"OptionalContainingMaps", NewOptionalType(mapType), mapType},
 		{"OptionalNotContainingMaps", NewOptionalType(StringType), nil},
@@ -197,6 +205,7 @@ func TestAsOptionalType(t *testing.T) {
 	arrayType := NewArrayType(StringType)
 	mapType := NewMapType(StringType, StringType)
 	optionalType := NewOptionalType(objectType)
+	enumType := NewEnumType(StringType, []EnumValue{})
 
 	cases := []struct {
 		name     string
@@ -207,6 +216,7 @@ func TestAsOptionalType(t *testing.T) {
 		{"ObjectsAreNotOptional", objectType, nil},
 		{"ArraysAreNotOptional", arrayType, nil},
 		{"MapsAreNotOptional", mapType, nil},
+		{"EnumsAreNotOptional", enumType, nil},
 		{"OptionalAreOptional", optionalType, optionalType},
 		{"FlaggedContainingOptional", OneOfFlag.ApplyTo(optionalType), optionalType},
 		{"FlaggedNotContainingOptional", OneOfFlag.ApplyTo(StringType), nil},
@@ -228,6 +238,52 @@ func TestAsOptionalType(t *testing.T) {
 				g.Expect(actual).To(BeNil())
 			} else {
 				g.Expect(actual).To(Equal(c.expected))
+			}
+
+		})
+	}
+}
+
+func TestAsEnumType(t *testing.T) {
+
+	objectType := NewObjectType()
+	arrayType := NewArrayType(StringType)
+	mapType := NewMapType(StringType, StringType)
+	optionalType := NewOptionalType(objectType)
+	enumType := NewEnumType(StringType, []EnumValue{})
+
+	cases := []struct {
+		name     string
+		subject  Type
+		expected Type
+	}{
+		{"PrimitivesAreNotEnums", StringType, nil},
+		{"ObjectsAreNotEnums", objectType, nil},
+		{"ArraysAreNotEnums", arrayType, nil},
+		{"MapsAreNotEnums", mapType, nil},
+		{"EnumsAreEnums", enumType, enumType},
+		{"OptionalAreNotEnums", optionalType, nil},
+		{"FlaggedContainingEnums", OneOfFlag.ApplyTo(enumType), enumType},
+		{"FlaggedNotContainingEnums", OneOfFlag.ApplyTo(StringType), nil},
+		{"ValidatedContainingEnums", NewValidatedType(enumType, nil), enumType},
+		{"ValidatedNotContainingEnums", NewValidatedType(StringType, nil), nil},
+		{"ErroredContainingEnums", NewErroredType(enumType, nil, nil), enumType},
+		{"ErroredNotContainingEnums", NewErroredType(StringType, nil, nil), nil},
+	}
+
+	for _, c := range cases {
+		c := c
+		t.Run(c.name, func(t *testing.T) {
+			t.Parallel()
+			g := NewGomegaWithT(t)
+
+			actual, ok := AsEnumType(c.subject)
+
+			if c.expected == nil {
+				g.Expect(ok).To(BeFalse())
+			} else {
+				g.Expect(actual).To(Equal(c.expected))
+				g.Expect(ok).To(BeTrue())
 			}
 
 		})

--- a/hack/generator/pkg/astmodel/meta_type_test.go
+++ b/hack/generator/pkg/astmodel/meta_type_test.go
@@ -18,6 +18,7 @@ func TestAsPrimitiveType(t *testing.T) {
 	mapType := NewMapType(StringType, StringType)
 	optionalType := NewOptionalType(arrayType)
 	enumType := NewEnumType(StringType, []EnumValue{})
+	nameType := MakeTypeName(makeTestLocalPackageReference("g", "v"), "foo")
 
 	cases := []struct {
 		name     string
@@ -29,6 +30,7 @@ func TestAsPrimitiveType(t *testing.T) {
 		{"ArraysAreNotPrimitives", arrayType, nil},
 		{"MapsAreNotPrimitives", mapType, nil},
 		{"EnumsAreNotPrimitives", enumType, nil},
+		{"NamesAreNotPrimitives", nameType, nil},
 		{"OptionalAreNotPrimitives", optionalType, nil},
 		{"OptionalContainingPrimitive", NewOptionalType(StringType), StringType},
 		{"OptionalNotContainingPrimitive", NewOptionalType(objectType), nil},
@@ -65,6 +67,7 @@ func TestAsObjectType(t *testing.T) {
 	mapType := NewMapType(StringType, StringType)
 	optionalType := NewOptionalType(StringType)
 	enumType := NewEnumType(StringType, []EnumValue{})
+	nameType := MakeTypeName(makeTestLocalPackageReference("g", "v"), "foo")
 
 	cases := []struct {
 		name     string
@@ -76,6 +79,7 @@ func TestAsObjectType(t *testing.T) {
 		{"ArraysAreNotObjects", arrayType, nil},
 		{"MapsAreNotObjects", mapType, nil},
 		{"EnumsAreNotObjects", enumType, nil},
+		{"NamesAreNotObjects", nameType, nil},
 		{"OptionalAreNotObjects", optionalType, nil},
 		{"OptionalContainingObject", NewOptionalType(objectType), objectType},
 		{"OptionalNotContainingObject", NewOptionalType(StringType), nil},
@@ -112,6 +116,7 @@ func TestAsArrayType(t *testing.T) {
 	mapType := NewMapType(StringType, StringType)
 	optionalType := NewOptionalType(objectType)
 	enumType := NewEnumType(StringType, []EnumValue{})
+	nameType := MakeTypeName(makeTestLocalPackageReference("g", "v"), "foo")
 
 	cases := []struct {
 		name     string
@@ -123,6 +128,7 @@ func TestAsArrayType(t *testing.T) {
 		{"ArraysAreArrays", arrayType, arrayType},
 		{"MapsAreNotArrays", mapType, nil},
 		{"EnumsAreNotArrays", enumType, nil},
+		{"NamesAreNotArrays", nameType, nil},
 		{"OptionalAreNotArrays", optionalType, nil},
 		{"OptionalContainingArray", NewOptionalType(arrayType), arrayType},
 		{"OptionalNotContainingArray", NewOptionalType(StringType), nil},
@@ -159,6 +165,7 @@ func TestAsMapType(t *testing.T) {
 	mapType := NewMapType(StringType, StringType)
 	optionalType := NewOptionalType(objectType)
 	enumType := NewEnumType(StringType, []EnumValue{})
+	nameType := MakeTypeName(makeTestLocalPackageReference("g", "v"), "foo")
 
 	cases := []struct {
 		name     string
@@ -170,6 +177,7 @@ func TestAsMapType(t *testing.T) {
 		{"ArraysAreNotMaps", arrayType, nil},
 		{"MapsAreMaps", mapType, mapType},
 		{"EnumsAreNotMaps", enumType, nil},
+		{"NamesAreNotMaps", nameType, nil},
 		{"OptionalAreNotMaps", optionalType, nil},
 		{"OptionalContainingMaps", NewOptionalType(mapType), mapType},
 		{"OptionalNotContainingMaps", NewOptionalType(StringType), nil},
@@ -206,6 +214,7 @@ func TestAsOptionalType(t *testing.T) {
 	mapType := NewMapType(StringType, StringType)
 	optionalType := NewOptionalType(objectType)
 	enumType := NewEnumType(StringType, []EnumValue{})
+	nameType := MakeTypeName(makeTestLocalPackageReference("g", "v"), "foo")
 
 	cases := []struct {
 		name     string
@@ -217,6 +226,7 @@ func TestAsOptionalType(t *testing.T) {
 		{"ArraysAreNotOptional", arrayType, nil},
 		{"MapsAreNotOptional", mapType, nil},
 		{"EnumsAreNotOptional", enumType, nil},
+		{"NamesAreNotOptional", nameType, nil},
 		{"OptionalAreOptional", optionalType, optionalType},
 		{"FlaggedContainingOptional", OneOfFlag.ApplyTo(optionalType), optionalType},
 		{"FlaggedNotContainingOptional", OneOfFlag.ApplyTo(StringType), nil},
@@ -262,6 +272,7 @@ func TestAsEnumType(t *testing.T) {
 		{"ArraysAreNotEnums", arrayType, nil},
 		{"MapsAreNotEnums", mapType, nil},
 		{"EnumsAreEnums", enumType, enumType},
+		{"NamesAreNotEnums", nameType, nil},
 		{"OptionalAreNotEnums", optionalType, nil},
 		{"FlaggedContainingEnums", OneOfFlag.ApplyTo(enumType), enumType},
 		{"FlaggedNotContainingEnums", OneOfFlag.ApplyTo(StringType), nil},
@@ -278,6 +289,54 @@ func TestAsEnumType(t *testing.T) {
 			g := NewGomegaWithT(t)
 
 			actual, ok := AsEnumType(c.subject)
+
+			if c.expected == nil {
+				g.Expect(ok).To(BeFalse())
+			} else {
+				g.Expect(actual).To(Equal(c.expected))
+				g.Expect(ok).To(BeTrue())
+			}
+
+		})
+	}
+}
+
+func TestAsTypeName(t *testing.T) {
+
+	objectType := NewObjectType()
+	arrayType := NewArrayType(StringType)
+	mapType := NewMapType(StringType, StringType)
+	optionalType := NewOptionalType(objectType)
+	enumType := NewEnumType(StringType, []EnumValue{})
+	nameType := MakeTypeName(makeTestLocalPackageReference("g", "v"), "foo")
+
+	cases := []struct {
+		name     string
+		subject  Type
+		expected Type
+	}{
+		{"PrimitivesAreNotNames", StringType, nil},
+		{"ObjectsAreNotNames", objectType, nil},
+		{"ArraysAreNotNames", arrayType, nil},
+		{"MapsAreNotNames", mapType, nil},
+		{"EnumsAreNotNames", enumType, nil},
+		{"NamesAreNames", nameType, nameType},
+		{"OptionalAreNotNames", optionalType, nil},
+		{"FlaggedContainingNames", OneOfFlag.ApplyTo(nameType), nameType},
+		{"FlaggedNotContainingNames", OneOfFlag.ApplyTo(StringType), nil},
+		{"ValidatedContainingNames", NewValidatedType(nameType, nil), nameType},
+		{"ValidatedNotContainingNames", NewValidatedType(StringType, nil), nil},
+		{"ErroredContainingNames", NewErroredType(nameType, nil, nil), nameType},
+		{"ErroredNotContainingNames", NewErroredType(StringType, nil, nil), nil},
+	}
+
+	for _, c := range cases {
+		c := c
+		t.Run(c.name, func(t *testing.T) {
+			t.Parallel()
+			g := NewGomegaWithT(t)
+
+			actual, ok := AsTypeName(c.subject)
 
 			if c.expected == nil {
 				g.Expect(ok).To(BeFalse())

--- a/hack/generator/pkg/astmodel/meta_type_test.go
+++ b/hack/generator/pkg/astmodel/meta_type_test.go
@@ -48,12 +48,13 @@ func TestAsPrimitiveType(t *testing.T) {
 			t.Parallel()
 			g := NewGomegaWithT(t)
 
-			actual := AsPrimitiveType(c.subject)
+			actual, ok := AsPrimitiveType(c.subject)
 
 			if c.expected == nil {
-				g.Expect(actual).To(BeNil())
+				g.Expect(ok).To(BeFalse())
 			} else {
 				g.Expect(actual).To(Equal(c.expected))
+				g.Expect(ok).To(BeTrue())
 			}
 
 		})
@@ -97,12 +98,13 @@ func TestAsObjectType(t *testing.T) {
 			t.Parallel()
 			g := NewGomegaWithT(t)
 
-			actual := AsObjectType(c.subject)
+			actual, ok := AsObjectType(c.subject)
 
 			if c.expected == nil {
-				g.Expect(actual).To(BeNil())
+				g.Expect(ok).To(BeFalse())
 			} else {
 				g.Expect(actual).To(Equal(c.expected))
+				g.Expect(ok).To(BeTrue())
 			}
 
 		})
@@ -146,12 +148,13 @@ func TestAsArrayType(t *testing.T) {
 			t.Parallel()
 			g := NewGomegaWithT(t)
 
-			actual := AsArrayType(c.subject)
+			actual, ok := AsArrayType(c.subject)
 
 			if c.expected == nil {
-				g.Expect(actual).To(BeNil())
+				g.Expect(ok).To(BeFalse())
 			} else {
 				g.Expect(actual).To(Equal(c.expected))
+				g.Expect(ok).To(BeTrue())
 			}
 
 		})
@@ -195,12 +198,13 @@ func TestAsMapType(t *testing.T) {
 			t.Parallel()
 			g := NewGomegaWithT(t)
 
-			actual := AsMapType(c.subject)
+			actual, ok := AsMapType(c.subject)
 
 			if c.expected == nil {
-				g.Expect(actual).To(BeNil())
+				g.Expect(ok).To(BeFalse())
 			} else {
 				g.Expect(actual).To(Equal(c.expected))
+				g.Expect(ok).To(BeTrue())
 			}
 
 		})
@@ -242,12 +246,13 @@ func TestAsOptionalType(t *testing.T) {
 			t.Parallel()
 			g := NewGomegaWithT(t)
 
-			actual := AsOptionalType(c.subject)
+			actual, ok := AsOptionalType(c.subject)
 
 			if c.expected == nil {
-				g.Expect(actual).To(BeNil())
+				g.Expect(ok).To(BeFalse())
 			} else {
 				g.Expect(actual).To(Equal(c.expected))
+				g.Expect(ok).To(BeTrue())
 			}
 
 		})
@@ -261,6 +266,7 @@ func TestAsEnumType(t *testing.T) {
 	mapType := NewMapType(StringType, StringType)
 	optionalType := NewOptionalType(objectType)
 	enumType := NewEnumType(StringType, []EnumValue{})
+	nameType := MakeTypeName(makeTestLocalPackageReference("g", "v"), "foo")
 
 	cases := []struct {
 		name     string

--- a/hack/generator/pkg/astmodel/object_type.go
+++ b/hack/generator/pkg/astmodel/object_type.go
@@ -501,27 +501,17 @@ func (objectType *ObjectType) TestCases() []TestCase {
 	return result
 }
 
-// IsObjectType returns true if the passed type is an object type OR if it is a wrapper type containing an object type
-func IsObjectType(t Type) bool {
-	_, ok := t.(*ObjectType)
+// IsObjectDefinition returns true if the passed definition is for a Arm type; false otherwise.
+func IsObjectDefinition(definition TypeDefinition) bool {
+	_, ok := AsObjectType(definition.theType)
 	return ok
 }
 
-// IsObjectDefinition returns true if the passed definition is for a Arm type; false otherwise.
-func IsObjectDefinition(definition TypeDefinition) bool {
-	return IsObjectType(definition.theType)
-}
-
 func extractEmbeddedTypeName(t Type) (TypeName, error) {
-	typeName, isTypeName := t.(TypeName)
-	optionalType, isOptionalType := t.(*OptionalType)
-	if isOptionalType {
-		typeName, isTypeName = optionalType.Element().(TypeName)
+	typeName, isTypeName := AsTypeName(t)
+	if isTypeName {
+		return typeName, nil
 	}
 
-	if !isTypeName {
-		return TypeName{}, errors.Errorf("embedded property type must be TypeName or Optional[TypeName], was: %T", t)
-	}
-
-	return typeName, nil
+	return TypeName{}, errors.Errorf("embedded property type must be TypeName, was: %T", t)
 }

--- a/hack/generator/pkg/astmodel/storage_conversion_function.go
+++ b/hack/generator/pkg/astmodel/storage_conversion_function.go
@@ -373,12 +373,22 @@ func (fn *StorageConversionFunction) generateAssignments(
 // createConversions iterates through the properties on our receiver type, matching them up with
 // our other type and generating conversions where possible
 func (fn *StorageConversionFunction) createConversions(receiver TypeDefinition) error {
-	receiverObject := AsObjectType(receiver.Type())
+	receiverObject, ok := AsObjectType(receiver.Type())
+	if !ok {
+		return errors.Errorf("expected TypeDefinition %q to wrap receiver object type, but none found", receiver.name.String())
+	}
+
 	var otherObject *ObjectType
 	if fn.intermediateType == nil {
-		otherObject = AsObjectType(fn.hubType.Type())
+		otherObject, ok = AsObjectType(fn.hubType.Type())
+		if !ok {
+			return errors.Errorf("expected TypeDefinition %q to wrap hub object type, but none found", fn.hubType.Name().String())
+		}
 	} else {
-		otherObject = AsObjectType(fn.intermediateType.Type())
+		otherObject, ok = AsObjectType(fn.intermediateType.Type())
+		if !ok {
+			return errors.Errorf("expected TypeDefinition %q to wrap intermediate object type, but none found", fn.intermediateType.Name().String())
+		}
 	}
 
 	var errs []error

--- a/hack/generator/pkg/codegen/codegen_test.go
+++ b/hack/generator/pkg/codegen/codegen_test.go
@@ -73,7 +73,7 @@ func injectEmbeddedStructType() PipelineStage {
 
 			results := make(astmodel.Types)
 			for _, def := range defs {
-				if astmodel.IsObjectType(def.Type()) {
+				if astmodel.IsObjectDefinition(def) {
 					result, err := def.ApplyObjectTransformation(func(objectType *astmodel.ObjectType) (astmodel.Type, error) {
 						prop := astmodel.NewPropertyDefinition(
 							"",

--- a/hack/generator/pkg/codegen/pipeline_convert_allof_and_oneof_to_objects_test.go
+++ b/hack/generator/pkg/codegen/pipeline_convert_allof_and_oneof_to_objects_test.go
@@ -308,8 +308,8 @@ func TestOneOfResourceSpec(t *testing.T) {
 	g.Expect(err).To(BeNil())
 
 	result := synth.oneOfObject(oneOf, names)
-	result = astmodel.AsObjectType(result)
-
+	result, ok := astmodel.AsObjectType(result)
+	g.Expect(ok).To(BeTrue())
 	result = astmodel.NewObjectType().WithProperties(result.(*astmodel.ObjectType).Properties()...)
 	g.Expect(result).To(Equal(expected))
 }

--- a/hack/generator/pkg/codegen/pipeline_create_arm_types.go
+++ b/hack/generator/pkg/codegen/pipeline_create_arm_types.go
@@ -408,8 +408,8 @@ func addArmConversionInterface(
 	idFactory astmodel.IdentifierFactory,
 	typeType armconversion.TypeKind) (astmodel.TypeDefinition, error) {
 
-	objectType := astmodel.AsObjectType(armDef.Type())
-	if objectType == nil {
+	objectType, ok := astmodel.AsObjectType(armDef.Type())
+	if !ok {
 		emptyDef := astmodel.TypeDefinition{}
 		return emptyDef, errors.Errorf("ARM definition %q did not define an object type", armDef.Name())
 	}

--- a/hack/generator/pkg/codegen/pipeline_determine_resource_ownership.go
+++ b/hack/generator/pkg/codegen/pipeline_determine_resource_ownership.go
@@ -7,7 +7,6 @@ package codegen
 
 import (
 	"context"
-	"fmt"
 	"strings"
 
 	"github.com/Azure/k8s-infra/hack/generator/pkg/astmodel"
@@ -165,16 +164,16 @@ func extractChildResourceTypeNames(resourcesPropertyTypeDef astmodel.TypeDefinit
 	// This type should be ResourceType, or ObjectType if modelling a OneOf/AllOf
 	_, isResource := resourcesPropertyTypeDef.Type().(*astmodel.ResourceType)
 
-	resourcesPropertyTypeAsObject := astmodel.AsObjectType(resourcesPropertyTypeDef.Type())
-	if !isResource && resourcesPropertyTypeAsObject == nil {
-		return nil, fmt.Errorf(
+	resourcesPropertyTypeAsObject, ok := astmodel.AsObjectType(resourcesPropertyTypeDef.Type())
+	if !isResource && !ok {
+		return nil, errors.Errorf(
 			"Resources property type %s was not of type *astmodel.ResourceType and didn't wrap *astmodel.ObjectType, instead %T",
 			resourcesPropertyTypeDef.Name(),
 			resourcesPropertyTypeDef.Type())
 	}
 
 	// Determine if this is a OneOf/AllOf
-	if astmodel.OneOfFlag.IsOn(resourcesPropertyTypeDef.Type()) {
+	if ok && astmodel.OneOfFlag.IsOn(resourcesPropertyTypeDef.Type()) {
 		return resolveResourcesTypeNames(resourcesPropertyTypeDef.Name(), resourcesPropertyTypeAsObject)
 	} else {
 		return []astmodel.TypeName{resourcesPropertyTypeDef.Name()}, nil


### PR DESCRIPTION
Expanding on the set of utility unwrapping functions to cover additional cases

* Changes the signature of all the methods to better fit the Go idiom of returning a bool to indicate whether the conversion works. 
* Removes IsObjectType() from `object_type.go` in favour of `AsObjectType()`
* Simplifies implementation of `extractEmbeddedTypeName()` in `object_type.go` by using `AsTypeName()`


Background: When adding the conversion `AsTypeName()`, I realised that it couldn't return a **nil** value to indicate failure; the obvious solution was to use the usual Go idiom and return `(TypeName, bool)` - but then that method would have been inconsistent with the existing methods. Solution: change all of them!