### PR TITLE
Split creation of ARM types from conversion interface

### DIFF
--- a/hack/generator/pkg/astmodel/types.go
+++ b/hack/generator/pkg/astmodel/types.go
@@ -157,7 +157,7 @@ func (types Types) ResolveResourceStatusDefinition(
 
 	statusName, ok := resourceType.StatusType().(TypeName)
 	if !ok {
-		return TypeDefinition{}, errors.Errorf("status was not of type TypeName, instead: %T", resourceType.SpecType())
+		return TypeDefinition{}, errors.Errorf("status was not of type TypeName, instead: %T", resourceType.StatusType())
 	}
 
 	resourceStatusDef, ok := types[statusName]

--- a/hack/generator/pkg/codegen/code_generator.go
+++ b/hack/generator/pkg/codegen/code_generator.go
@@ -134,7 +134,8 @@ func createAllPipelineStages(idFactory astmodel.IdentifierFactory, configuration
 		replaceAnyTypeWithJSON(),
 		reportOnTypesAndVersions(configuration).UsedFor(ArmTarget), // TODO: For now only used for ARM
 
-		createArmTypesAndCleanKubernetesTypes(idFactory).UsedFor(ArmTarget),
+		createARMTypes(idFactory).UsedFor(ArmTarget),
+		applyArmConversionInterface(idFactory).UsedFor(ArmTarget),
 		applyKubernetesResourceInterface(idFactory).UsedFor(ArmTarget),
 
 		addCrossplaneOwnerProperties(idFactory).UsedFor(CrossplaneTarget),

--- a/hack/generator/pkg/codegen/codegen_test.go
+++ b/hack/generator/pkg/codegen/codegen_test.go
@@ -139,7 +139,7 @@ func NewTestCodeGenerator(testName string, path string, t *testing.T, testConfig
 	case config.GenerationPipelineAzure:
 		codegen.RemoveStages("deleteGenerated", "rogueCheck", "createStorage", "reportTypesAndVersions")
 		if !testConfig.HasArmResources {
-			codegen.RemoveStages("createArmTypes")
+			codegen.RemoveStages("createArmTypes", "applyArmConversionInterface")
 			codegen.ReplaceStage("stripUnreferenced", stripUnusedTypesPipelineStage())
 		}
 	case config.GenerationPipelineCrossplane:

--- a/hack/generator/pkg/codegen/pipeline_add_arm_conversion_interface.go
+++ b/hack/generator/pkg/codegen/pipeline_add_arm_conversion_interface.go
@@ -1,0 +1,267 @@
+/*
+ * Copyright (c) Microsoft Corporation.
+ * Licensed under the MIT license.
+ */
+
+package codegen
+
+import (
+	"context"
+	"strings"
+
+	"github.com/pkg/errors"
+
+	"github.com/Azure/k8s-infra/hack/generator/pkg/astmodel"
+	"github.com/Azure/k8s-infra/hack/generator/pkg/astmodel/armconversion"
+)
+
+// applyArmConversionInterface adds the genruntime.ArmTransformer interface and the Owner property
+// to all Kubernetes types.
+// The ArmTransformer interface is used to convert from the Kubernetes type to the corresponding ARM type and back.
+func applyArmConversionInterface(idFactory astmodel.IdentifierFactory) PipelineStage {
+	return MakePipelineStage(
+		"applyArmConversionInterface",
+		"Apply the ARM conversion interface to Kubernetes types",
+		func(ctx context.Context, definitions astmodel.Types) (astmodel.Types, error) {
+			converter := &armConversionApplier{
+				definitions: definitions,
+				idFactory:   idFactory,
+			}
+
+			return converter.transformTypes()
+		})
+}
+
+type armConversionApplier struct {
+	definitions astmodel.Types
+	idFactory   astmodel.IdentifierFactory
+}
+
+// getARMTypeDefinition gets the ARM type definition for a given Kubernetes type name.
+// If no matching definition can be found an error is returned.
+func (c *armConversionApplier) getARMTypeDefinition(name astmodel.TypeName) (astmodel.TypeDefinition, error) {
+	armDefinition, ok := c.definitions[astmodel.CreateArmTypeName(name)]
+	if !ok {
+		return astmodel.TypeDefinition{}, errors.Errorf("couldn't find arm definition matching kube name %q", name)
+	}
+
+	return armDefinition, nil
+}
+
+// transformResourceSpecs applies the genruntime.ArmTransformer interface to all of the resource Spec types.
+// It also adds the Owner property.
+func (c *armConversionApplier) transformResourceSpecs() (astmodel.Types, error) {
+	result := make(astmodel.Types)
+
+	resources := c.definitions.Where(func(td astmodel.TypeDefinition) bool {
+		_, ok := astmodel.AsResourceType(td.Type())
+		return ok
+	})
+
+	for _, td := range resources {
+		resource, ok := astmodel.AsResourceType(td.Type())
+		if !ok {
+			return nil, errors.Errorf("%q was not a resource, instead %T", td.Name(), td.Type())
+		}
+
+		specDefinition, err := c.transformSpec(resource)
+		if err != nil {
+			return nil, err
+		}
+
+		armSpecDefinition, err := c.getARMTypeDefinition(specDefinition.Name())
+		if err != nil {
+			return nil, err
+		}
+
+		specDefinition, err = c.addArmConversionInterface(specDefinition, armSpecDefinition, armconversion.SpecType)
+		if err != nil {
+			return nil, err
+		}
+
+		result.Add(specDefinition)
+	}
+
+	return result, nil
+}
+
+// transformResourceStatuses applies the genruntime.ArmTransformer interface to all of the resource Status types.
+func (c *armConversionApplier) transformResourceStatuses() (astmodel.Types, error) {
+	result := make(astmodel.Types)
+
+	statusDefs := c.definitions.Where(func(def astmodel.TypeDefinition) bool {
+		_, ok := astmodel.AsObjectType(def.Type())
+		// TODO: We need labels
+		// Some status types are initially anonymous and then get named later (so end with a _Status_Xyz suffix)
+		return ok && strings.Contains(def.Name().Name(), "_Status") && !astmodel.ArmFlag.IsOn(def.Type())
+	})
+
+	for _, td := range statusDefs {
+		statusType := astmodel.IgnoringErrors(td.Type())
+		if statusType != nil {
+			armStatusDefinition, err := c.getARMTypeDefinition(td.Name())
+			if err != nil {
+				return nil, err
+			}
+
+			statusDefinition, err := c.addArmConversionInterface(td, armStatusDefinition, armconversion.StatusType)
+			if err != nil {
+				return nil, err
+			}
+
+			result.Add(statusDefinition)
+		}
+	}
+
+	return result, nil
+}
+
+// transformTypes adds the required ARM conversion information to all applicable types.
+// If a type doesn't need any modification, it is returned unmodified.
+func (c *armConversionApplier) transformTypes() (astmodel.Types, error) {
+
+	result := make(astmodel.Types)
+
+	// Specs
+	specs, err := c.transformResourceSpecs()
+	if err != nil {
+		return nil, err
+	}
+	result.AddTypes(specs)
+
+	// Status
+	statuses, err := c.transformResourceStatuses()
+	if err != nil {
+		return nil, err
+	}
+	result.AddTypes(statuses)
+
+	// Everything else
+	otherDefs := c.definitions.Except(result)
+	for _, td := range otherDefs {
+
+		_, isObjectType := astmodel.AsObjectType(td.Type())
+		hasARMFlag := astmodel.ArmFlag.IsOn(td.Type())
+		if !isObjectType || hasARMFlag {
+			// No special handling needed just add the existing type and continue
+			result.Add(td)
+			continue
+		}
+
+		armDefinition, err := c.getARMTypeDefinition(td.Name())
+		if err != nil {
+			return nil, err
+		}
+
+		modifiedDef, err := c.addArmConversionInterface(td, armDefinition, armconversion.OrdinaryType)
+		if err != nil {
+			return nil, errors.Wrapf(err, "failed to add ARM conversion interface to %q", td.Name())
+		}
+
+		result.Add(modifiedDef)
+	}
+
+	return result, nil
+}
+
+// transformSpec adds an owner property to the given resource spec, and adds the ARM conversion interface
+// to the spec with some special property remappings (for Type, Name, APIVersion, etc).
+func (c *armConversionApplier) transformSpec(resourceType *astmodel.ResourceType) (astmodel.TypeDefinition, error) {
+
+	resourceSpecDef, err := c.definitions.ResolveResourceSpecDefinition(resourceType)
+	if err != nil {
+		return astmodel.TypeDefinition{}, err
+	}
+
+	injectOwnerProperty := func(t *astmodel.ObjectType) (*astmodel.ObjectType, error) {
+		if resourceType.Owner() != nil {
+			ownerField, err := c.createOwnerProperty(resourceType.Owner())
+			if err != nil {
+				return nil, err
+			}
+			t = t.WithProperty(ownerField)
+		}
+
+		return t, nil
+	}
+
+	remapProperties := func(t *astmodel.ObjectType) (*astmodel.ObjectType, error) {
+		// TODO: Right now the Kubernetes type has all of its standard requiredness (validations). If we want to allow
+		// TODO: users to submit "just a name and owner" types we will have to strip some validation until
+		// TODO: https://github.com/kubernetes-sigs/controller-tools/issues/461 is fixed
+
+		// drop Type property
+		t = t.WithoutProperty("Type")
+
+		// drop ApiVersion property
+		t = t.WithoutProperty("ApiVersion")
+
+		nameProp, hasName := t.Property("Name")
+		if !hasName {
+			return t, nil
+		}
+
+		// rename Name to AzureName
+		azureNameProp := armconversion.GetAzureNameProperty(c.idFactory).WithType(nameProp.PropertyType())
+		return t.WithoutProperty("Name").WithProperty(azureNameProp), nil
+	}
+
+	kubernetesDef, err := resourceSpecDef.ApplyObjectTransformations(remapProperties, injectOwnerProperty)
+	if err != nil {
+		return astmodel.TypeDefinition{}, errors.Wrapf(err, "remapping properties of Kubernetes definition")
+	}
+
+	return kubernetesDef, nil
+}
+
+func (c *armConversionApplier) addArmConversionInterface(
+	kubeDef astmodel.TypeDefinition,
+	armDef astmodel.TypeDefinition,
+	typeType armconversion.TypeKind) (astmodel.TypeDefinition, error) {
+
+	objectType, ok := astmodel.AsObjectType(armDef.Type())
+	if !ok {
+		emptyDef := astmodel.TypeDefinition{}
+		return emptyDef, errors.Errorf("ARM definition %q did not define an object type", armDef.Name())
+	}
+
+	addInterfaceHandler := func(t *astmodel.ObjectType) (astmodel.Type, error) {
+		result := t.WithInterface(armconversion.NewArmTransformerImpl(
+			armDef.Name(),
+			objectType,
+			c.idFactory,
+			typeType))
+		return result, nil
+	}
+
+	result, err := kubeDef.ApplyObjectTransformation(addInterfaceHandler)
+	if err != nil {
+		emptyDef := astmodel.TypeDefinition{}
+		return emptyDef,
+			errors.Errorf("Failed to add ARM conversion interface to Kubenetes object definition %v", armDef.Name())
+	}
+
+	return result, nil
+}
+
+func (c *armConversionApplier) createOwnerProperty(ownerTypeName *astmodel.TypeName) (*astmodel.PropertyDefinition, error) {
+
+	knownResourceReferenceType := astmodel.MakeTypeName(
+		astmodel.GenRuntimeReference,
+		"KnownResourceReference")
+
+	prop := astmodel.NewPropertyDefinition(
+		c.idFactory.CreatePropertyName(astmodel.OwnerProperty, astmodel.Exported),
+		c.idFactory.CreateIdentifier(astmodel.OwnerProperty, astmodel.NotExported),
+		knownResourceReferenceType)
+
+	if localRef, ok := ownerTypeName.PackageReference.AsLocalPackage(); ok {
+		group := localRef.Group() + astmodel.GroupSuffix
+		prop = prop.WithTag("group", group).WithTag("kind", ownerTypeName.Name())
+		prop = prop.SetRequired(true) // Owner is always required
+	} else {
+		return nil, errors.New("owners from external packages not currently supported")
+	}
+
+	return prop, nil
+}

--- a/hack/generator/pkg/codegen/pipeline_convert_allof_and_oneof_to_objects.go
+++ b/hack/generator/pkg/codegen/pipeline_convert_allof_and_oneof_to_objects.go
@@ -100,7 +100,7 @@ func convertAllOfAndOneOfToObjects(idFactory astmodel.IdentifierFactory) Pipelin
 			for _, def := range defs {
 				resourceUpdater := chooseSpec
 				// TODO: we need flags
-				if strings.HasSuffix(def.Name().Name(), "_Status") {
+				if strings.Contains(def.Name().Name(), "_Status") {
 					resourceUpdater = chooseStatus
 				}
 

--- a/hack/generator/pkg/codegen/pipeline_create_arm_types.go
+++ b/hack/generator/pkg/codegen/pipeline_create_arm_types.go
@@ -13,256 +13,98 @@ import (
 	"k8s.io/klog/v2"
 
 	"github.com/Azure/k8s-infra/hack/generator/pkg/astmodel"
-	"github.com/Azure/k8s-infra/hack/generator/pkg/astmodel/armconversion"
 )
 
-// createArmTypesAndCleanKubernetesTypes walks the type graph and builds new types for communicating
-// with ARM, as well as removes ARM-only properties from the Kubernetes types.
-func createArmTypesAndCleanKubernetesTypes(idFactory astmodel.IdentifierFactory) PipelineStage {
+// createARMTypes walks the type graph and builds new types for communicating
+// with ARM
+func createARMTypes(idFactory astmodel.IdentifierFactory) PipelineStage {
 	return MakePipelineStage(
 		"createArmTypes",
-		"Create ARM types and remove ARM-only properties from Kubernetes types",
+		"Creates ARM types",
 		func(ctx context.Context, definitions astmodel.Types) (astmodel.Types, error) {
-			// 1. Walk types and produce the new ARM types, as well as a mapping of Kubernetes Type -> Arm Type
-			// 2. Walk Kubernetes types, remove ARM-only properties and add conversion interface (use mapping
-			//    from step 1 to determine which ARM resource we need to convert to).
-			// 3. Merge results from 1 and 2 together. Add any type/definition from the originally provided
-			//    definitions that wasn't changed by the previous steps (enums primarily).
 
-			armTypes, kubeNameToArmDefs, err := createArmTypes(definitions, idFactory)
+			armTypeCreator := &armTypeCreator{definitions: definitions, idFactory: idFactory}
+			armTypes, err := armTypeCreator.createArmTypes()
+
 			if err != nil {
 				return nil, err
 			}
 
-			kubeTypes, err := modifyKubeTypes(definitions, kubeNameToArmDefs, idFactory)
-			if err != nil {
-				return nil, err
-			}
-
-			result := astmodel.TypesDisjointUnion(armTypes, kubeTypes)
-			for _, def := range definitions {
-				if _, ok := result[def.Name()]; !ok {
-					result.Add(def)
-				}
-			}
+			result := astmodel.TypesDisjointUnion(armTypes, definitions)
 
 			return result, nil
 		})
 }
 
-func createArmTypes(
-	definitions astmodel.Types,
-	idFactory astmodel.IdentifierFactory) (astmodel.Types, astmodel.Types, error) {
-
-	kubeNameToArmDefs := make(astmodel.Types)
-
-	armDefs, err := iterDefs(
-		definitions,
-		// Resource handler
-		func(name astmodel.TypeName, resourceType *astmodel.ResourceType) ([]astmodel.TypeName, []astmodel.TypeDefinition, error) {
-			armSpecDef, kubeSpecName, err := createArmResourceSpecDefinition(definitions, resourceType, idFactory)
-			if err != nil {
-				return nil, nil, errors.Wrapf(err, "unable to create arm resource spec definition for resource %s", name)
-			}
-
-			if deffed, ok := kubeNameToArmDefs[kubeSpecName]; ok {
-				if !deffed.Type().Equals(armSpecDef.Type()) {
-					return nil, nil, errors.Errorf("kubeNameToArmDefs already defined for %v", kubeSpecName)
-				}
-			}
-
-			kubeNameToArmDefs[kubeSpecName] = armSpecDef
-			return []astmodel.TypeName{kubeSpecName}, []astmodel.TypeDefinition{armSpecDef}, nil
-		},
-		// Other defs handler
-		func(def astmodel.TypeDefinition) (astmodel.TypeDefinition, error) {
-			armDef, err := createArmTypeDefinition(
-				definitions,
-				false, // not Spec type
-				def,
-				idFactory)
-			if err != nil {
-				return astmodel.TypeDefinition{}, err
-			}
-
-			kubeNameToArmDefs[def.Name()] = armDef
-
-			return armDef, nil
-		})
-	if err != nil {
-		return nil, nil, err
-	}
-
-	return armDefs, kubeNameToArmDefs, nil
+type armTypeCreator struct {
+	definitions astmodel.Types
+	idFactory   astmodel.IdentifierFactory
 }
 
-func modifyKubeTypes(
-	definitions astmodel.Types,
-	kubeNameToArmDefs astmodel.Types,
-	idFactory astmodel.IdentifierFactory) (astmodel.Types, error) {
-
-	return iterDefs(
-		definitions,
-		// Resource handler
-		func(name astmodel.TypeName, resourceType *astmodel.ResourceType) ([]astmodel.TypeName, []astmodel.TypeDefinition, error) {
-			specDef, err := modifyKubeResourceSpecDefinition(definitions, idFactory, resourceType)
-			if err != nil {
-				return nil, nil, errors.Wrapf(err, "unable to modify kube resource spec definition for resource %s", name)
-			}
-
-			armSpecDef, ok := kubeNameToArmDefs[specDef.Name()]
-			if !ok {
-				return nil, nil, errors.Errorf("couldn't find arm def matching kube def %q", specDef.Name())
-			}
-
-			modifiedSpec, err := addArmConversionInterface(specDef, armSpecDef, idFactory, armconversion.SpecType)
-			if err != nil {
-				return nil, nil, err
-			}
-
-			names := []astmodel.TypeName{modifiedSpec.Name()}
-			defs := []astmodel.TypeDefinition{modifiedSpec}
-
-			statusType := astmodel.IgnoringErrors(resourceType.StatusType())
-			if statusType != nil {
-				statusName, ok := statusType.(astmodel.TypeName)
-				if !ok {
-					return nil, nil, errors.Errorf("expected Status type to be a name, instead was %T", statusType)
-				}
-
-				statusDef, ok := definitions[statusName]
-				if !ok {
-					return nil, nil, errors.Errorf("could not find Status type %v", statusName)
-				}
-
-				armStatusDef, ok := kubeNameToArmDefs[statusName]
-				if !ok {
-					return nil, nil, errors.Errorf("could not find ARM Status type %v", statusName)
-				}
-
-				newStatus, err := addArmConversionInterface(statusDef, armStatusDef, idFactory, armconversion.StatusType)
-				if err != nil {
-					return nil, nil, err
-				}
-
-				names = append(names, newStatus.Name())
-				defs = append(defs, newStatus)
-			}
-
-			return names, defs, nil
-		},
-		// Other defs handler
-		func(def astmodel.TypeDefinition) (astmodel.TypeDefinition, error) {
-			armDef, ok := kubeNameToArmDefs[def.Name()]
-			if !ok {
-				return astmodel.TypeDefinition{}, errors.Errorf("couldn't find arm def matching kube def %q", def.Name())
-			}
-
-			modifiedDef, err := addArmConversionInterface(def, armDef, idFactory, armconversion.OrdinaryType)
-			if err != nil {
-				return astmodel.TypeDefinition{}, errors.Wrapf(err, "failed to add ARM conversion interface to %q", def.Name())
-			}
-
-			return modifiedDef, nil
-		})
-}
-
-func iterDefs(
-	definitions astmodel.Types,
-	resourceHandler func(name astmodel.TypeName, resourceType *astmodel.ResourceType) ([]astmodel.TypeName, []astmodel.TypeDefinition, error),
-	otherDefsHandler func(def astmodel.TypeDefinition) (astmodel.TypeDefinition, error)) (astmodel.Types, error) {
-
-	newDefs := make(astmodel.Types)
-	actionedDefs := make(map[astmodel.TypeName]struct{})
-
-	// TODO: a better way to do all this following would be if we had Spec/Status tags
-	// for Spec/Status types. Then we would only do one pass over all types and
-	// just examine the flags, rather than walking all resources first and
-	// the remaining definitions in a different pass… and we wouldn’t have to deal with
-	// multiple uses of the same type (see the panic below), etc, etc…
-
-	// Do all the resources first - this ensures we avoid handling a spec before we've processed
-	// its associated resource.
+func getAllSpecDefinitions(definitions astmodel.Types) (astmodel.Types, error) {
+	result := make(astmodel.Types)
 	for _, def := range definitions {
-		// Special handling for resources because we need to modify their specs with extra properties
-		if resourceType, ok := def.Type().(*astmodel.ResourceType); ok {
-			handledNames, defs, err := resourceHandler(def.Name(), resourceType)
+		if resourceType, ok := astmodel.AsResourceType(def.Type()); ok {
+			spec, err := definitions.ResolveResourceSpecDefinition(resourceType)
 			if err != nil {
 				return nil, err
 			}
-
-			for _, name := range handledNames {
-				actionedDefs[name] = struct{}{}
-			}
-
-			for _, def := range defs {
-				// don't add if already defined.
-				// some status types are shared by multiple resources…
-				// this would be fixed by TODO above
-
-				if alreadyDef, ok := newDefs[def.Name()]; !ok {
-					newDefs[def.Name()] = def
-				} else {
-					if !alreadyDef.Type().Equals(def.Type()) {
-						panic("generated two types with identical names that do not equal each other")
-					}
-				}
-			}
+			result.Add(spec)
 		}
 	}
 
-	// Process the remaining definitions
-	for _, def := range definitions {
-		// If it's a type which has already been handled (specs from above), skip it
-		if _, ok := actionedDefs[def.Name()]; ok {
-			continue
+	return result, nil
+}
+
+func (c *armTypeCreator) createArmTypes() (astmodel.Types, error) {
+
+	result := make(astmodel.Types)
+	resourceSpecDefs, err := getAllSpecDefinitions(c.definitions)
+	if err != nil {
+		return nil, errors.Wrap(err, "couldn't get all resource spec definitions")
+	}
+
+	for _, def := range resourceSpecDefs {
+		armSpecDef, err := c.createArmResourceSpecDefinition(def)
+		if err != nil {
+			return nil, errors.Wrapf(err, "unable to create arm resource spec definition for resource %s", def.Name())
 		}
 
-		// Note: We would need to do something about type aliases here if they weren't already
-		// removed earlier in the pipeline
+		result.Add(armSpecDef)
+	}
 
-		// Other types can be reused in both the Kube type graph and the ARM type graph, for
-		// example enums which are effectively primitive types, all primitive types, etc.
+	otherDefs := c.definitions.Except(resourceSpecDefs).Where(func(def astmodel.TypeDefinition) bool {
+		_, ok := astmodel.AsObjectType(def.Type())
+		return ok
+	})
 
-		switch def.Type().(type) {
-		case *astmodel.ObjectType:
-		case *astmodel.FlaggedType:
-			// TODO: Do we need to tolerate other types here?
-		default:
-			continue
-		}
-
-		newDef, err := otherDefsHandler(def)
+	for _, def := range otherDefs {
+		armDef, err := c.createArmTypeDefinition(
+			false, // not Spec type
+			def)
 		if err != nil {
 			return nil, err
 		}
-		newDefs.Add(newDef)
+
+		result.Add(armDef)
 	}
 
-	return newDefs, nil
+	return result, nil
 }
 
-func createArmResourceSpecDefinition(
-	definitions astmodel.Types,
-	resourceType *astmodel.ResourceType,
-	idFactory astmodel.IdentifierFactory) (astmodel.TypeDefinition, astmodel.TypeName, error) {
+func (c *armTypeCreator) createArmResourceSpecDefinition(
+	resourceSpecDef astmodel.TypeDefinition) (astmodel.TypeDefinition, error) {
 
-	emptyName := astmodel.TypeName{}
 	emptyDef := astmodel.TypeDefinition{}
 
-	resourceSpecDef, err := definitions.ResolveResourceSpecDefinition(resourceType)
+	armTypeDef, err := c.createArmTypeDefinition(true, resourceSpecDef)
 	if err != nil {
-		return emptyDef, emptyName, err
-	}
-
-	armTypeDef, err := createArmTypeDefinition(definitions, true, resourceSpecDef, idFactory)
-	if err != nil {
-		return emptyDef, emptyName, err
+		return emptyDef, err
 	}
 
 	// ARM specs have a special interface that they need to implement, go ahead and create that here
 	if !astmodel.ArmFlag.IsOn(armTypeDef.Type()) {
-		return emptyDef, emptyName, errors.Errorf("Arm spec %q isn't a flagged object, instead: %T", armTypeDef.Name(), armTypeDef.Type())
+		return emptyDef, errors.Errorf("arm spec %q isn't a flagged object, instead: %T", armTypeDef.Name(), armTypeDef.Type())
 	}
 
 	// Safe because above test passed
@@ -270,18 +112,18 @@ func createArmResourceSpecDefinition(
 
 	specObj, ok := flagged.Element().(*astmodel.ObjectType)
 	if !ok {
-		return emptyDef, emptyName, errors.Errorf("Arm spec %q isn't an object, instead: %T", armTypeDef.Name(), armTypeDef.Type())
+		return emptyDef, errors.Errorf("arm spec %q isn't an object, instead: %T", armTypeDef.Name(), armTypeDef.Type())
 	}
 
-	iface, err := astmodel.NewArmSpecInterfaceImpl(idFactory, specObj)
+	iface, err := astmodel.NewArmSpecInterfaceImpl(c.idFactory, specObj)
 	if err != nil {
-		return emptyDef, emptyName, err
+		return emptyDef, err
 	}
 
 	updatedSpec := specObj.WithInterface(iface)
 	armTypeDef = armTypeDef.WithType(astmodel.ArmFlag.ApplyTo(updatedSpec))
 
-	return armTypeDef, resourceSpecDef.Name(), nil
+	return armTypeDef, nil
 }
 
 func removeValidations(t *astmodel.ObjectType) (*astmodel.ObjectType, error) {
@@ -301,15 +143,15 @@ func removeValidations(t *astmodel.ObjectType) (*astmodel.ObjectType, error) {
 	return t, nil
 }
 
-func createArmTypeDefinition(definitions astmodel.Types, isSpecType bool, def astmodel.TypeDefinition, idFactory astmodel.IdentifierFactory) (astmodel.TypeDefinition, error) {
+func (c *armTypeCreator) createArmTypeDefinition(isSpecType bool, def astmodel.TypeDefinition) (astmodel.TypeDefinition, error) {
 	convertPropertiesToArmTypesWrapper := func(t *astmodel.ObjectType) (*astmodel.ObjectType, error) {
-		return convertPropertiesToArmTypes(t, isSpecType, definitions)
+		return c.convertPropertiesToArmTypes(t, isSpecType)
 	}
 
 	addOneOfConversionFunctionIfNeeded := func(t *astmodel.ObjectType) (*astmodel.ObjectType, error) {
 		if astmodel.OneOfFlag.IsOn(def.Type()) {
 			klog.V(4).Infof("Type %s is a OneOf type, adding MarshalJSON()", def.Name())
-			return t.WithFunction(astmodel.NewOneOfJSONMarshalFunction(t, idFactory)), nil
+			return t.WithFunction(astmodel.NewOneOfJSONMarshalFunction(t, c.idFactory)), nil
 		}
 
 		return t, nil
@@ -333,89 +175,7 @@ func createArmTypeDefinition(definitions astmodel.Types, isSpecType bool, def as
 	return result, nil
 }
 
-func modifyKubeResourceSpecDefinition(
-	definitions astmodel.Types,
-	idFactory astmodel.IdentifierFactory,
-	resourceType *astmodel.ResourceType) (astmodel.TypeDefinition, error) {
-
-	resourceSpecDef, err := definitions.ResolveResourceSpecDefinition(resourceType)
-	if err != nil {
-		return astmodel.TypeDefinition{}, err
-	}
-
-	injectOwnerProperty := func(t *astmodel.ObjectType) (*astmodel.ObjectType, error) {
-		if resourceType.Owner() != nil {
-			ownerField, err := createOwnerProperty(idFactory, resourceType.Owner())
-			if err != nil {
-				return nil, err
-			}
-			t = t.WithProperty(ownerField)
-		}
-
-		return t, nil
-	}
-
-	remapProperties := func(t *astmodel.ObjectType) (*astmodel.ObjectType, error) {
-		// TODO: Right now the Kubernetes type has all of its standard requiredness (validations). If we want to allow
-		// TODO: users to submit "just a name and owner" types we will have to strip some validation until
-		// TODO: https://github.com/kubernetes-sigs/controller-tools/issues/461 is fixed
-
-		// drop Type property
-		t = t.WithoutProperty("Type")
-
-		// drop ApiVersion property
-		t = t.WithoutProperty("ApiVersion")
-
-		nameProp, hasName := t.Property("Name")
-		if !hasName {
-			return t, nil
-		}
-
-		// rename Name to AzureName
-		azureNameProp := armconversion.GetAzureNameProperty(idFactory).WithType(nameProp.PropertyType())
-		return t.WithoutProperty("Name").WithProperty(azureNameProp), nil
-	}
-
-	kubernetesDef, err := resourceSpecDef.ApplyObjectTransformations(remapProperties, injectOwnerProperty)
-	if err != nil {
-		return astmodel.TypeDefinition{}, errors.Wrapf(err, "remapping properties of Kubernetes definition")
-	}
-
-	return kubernetesDef, nil
-}
-
-func addArmConversionInterface(
-	kubeDef astmodel.TypeDefinition,
-	armDef astmodel.TypeDefinition,
-	idFactory astmodel.IdentifierFactory,
-	typeType armconversion.TypeKind) (astmodel.TypeDefinition, error) {
-
-	objectType, ok := astmodel.AsObjectType(armDef.Type())
-	if !ok {
-		emptyDef := astmodel.TypeDefinition{}
-		return emptyDef, errors.Errorf("ARM definition %q did not define an object type", armDef.Name())
-	}
-
-	addInterfaceHandler := func(t *astmodel.ObjectType) (astmodel.Type, error) {
-		result := t.WithInterface(armconversion.NewArmTransformerImpl(
-			armDef.Name(),
-			objectType,
-			idFactory,
-			typeType))
-		return result, nil
-	}
-
-	result, err := kubeDef.ApplyObjectTransformation(addInterfaceHandler)
-	if err != nil {
-		emptyDef := astmodel.TypeDefinition{}
-		return emptyDef,
-			errors.Errorf("Failed to add ARM conversion interface to Kubenetes object definition %v", armDef.Name())
-	}
-
-	return result, nil
-}
-
-func convertArmPropertyTypeIfNeeded(definitions astmodel.Types, t astmodel.Type) (astmodel.Type, error) {
+func (c *armTypeCreator) convertArmPropertyTypeIfNeeded(t astmodel.Type) (astmodel.Type, error) {
 
 	visitor := astmodel.MakeTypeVisitor()
 	visitor.VisitTypeName = func(this *astmodel.TypeVisitor, it astmodel.TypeName, ctx interface{}) (astmodel.Type, error) {
@@ -424,7 +184,7 @@ func convertArmPropertyTypeIfNeeded(definitions astmodel.Types, t astmodel.Type)
 			return it, nil
 		}
 
-		def, ok := definitions[it]
+		def, ok := c.definitions[it]
 		if !ok {
 			return nil, errors.Errorf("Failed to lookup %v", it)
 		}
@@ -450,7 +210,7 @@ func convertArmPropertyTypeIfNeeded(definitions astmodel.Types, t astmodel.Type)
 	return visitor.Visit(t, nil)
 }
 
-func convertPropertiesToArmTypes(t *astmodel.ObjectType, isSpecType bool, definitions astmodel.Types) (*astmodel.ObjectType, error) {
+func (c *armTypeCreator) convertPropertiesToArmTypes(t *astmodel.ObjectType, isSpecType bool) (*astmodel.ObjectType, error) {
 	result := t
 
 	var errs []error
@@ -461,7 +221,7 @@ func convertPropertiesToArmTypes(t *astmodel.ObjectType, isSpecType bool, defini
 			result = result.WithProperty(prop.WithType(astmodel.StringType))
 		} else {
 			propType := prop.PropertyType()
-			newType, err := convertArmPropertyTypeIfNeeded(definitions, propType)
+			newType, err := c.convertArmPropertyTypeIfNeeded(propType)
 			if err != nil {
 				errs = append(errs, err)
 			} else if newType != propType {
@@ -476,26 +236,4 @@ func convertPropertiesToArmTypes(t *astmodel.ObjectType, isSpecType bool, defini
 	}
 
 	return result, nil
-}
-
-func createOwnerProperty(idFactory astmodel.IdentifierFactory, ownerTypeName *astmodel.TypeName) (*astmodel.PropertyDefinition, error) {
-
-	knownResourceReferenceType := astmodel.MakeTypeName(
-		astmodel.GenRuntimeReference,
-		"KnownResourceReference")
-
-	prop := astmodel.NewPropertyDefinition(
-		idFactory.CreatePropertyName(astmodel.OwnerProperty, astmodel.Exported),
-		idFactory.CreateIdentifier(astmodel.OwnerProperty, astmodel.NotExported),
-		knownResourceReferenceType)
-
-	if localRef, ok := ownerTypeName.PackageReference.AsLocalPackage(); ok {
-		group := localRef.Group() + astmodel.GroupSuffix
-		prop = prop.WithTag("group", group).WithTag("kind", ownerTypeName.Name())
-		prop = prop.SetRequired(true) // Owner is always required
-	} else {
-		return nil, errors.New("owners from external packages not currently supported")
-	}
-
-	return prop, nil
 }

--- a/hack/generator/pkg/codegen/testdata/ARMCodeGeneratorPipeline.golden
+++ b/hack/generator/pkg/codegen/testdata/ARMCodeGeneratorPipeline.golden
@@ -15,7 +15,8 @@ filterTypes                                    Filter generated types
 stripUnreferenced                              Strip unreferenced types
 replaceAnyTypeWithJSON                         Replacing interface{}s with arbitrary JSON
 reportTypesAndVersions              azure      Generate reports on types and versions in each package
-createArmTypes                      azure      Create ARM types and remove ARM-only properties from Kubernetes types
+createArmTypes                      azure      Creates ARM types
+applyArmConversionInterface         azure      Apply the ARM conversion interface to Kubernetes types
 applyKubernetesResourceInterface    azure      Ensures that every resource implements the KubernetesResource interface
 addCrossplaneOwnerProperties        crossplane Adds the 3-tuple of (xName, xNameRef, xNameSelector) for each owning resource
 addCrossplaneForProviderProperty    crossplane Adds a 'ForProvider' property on every spec


### PR DESCRIPTION
 - Improve code clarity some.
 - Crossplane will likely make use of the first phase but likely will not make use of the second.
 - Fix a bug with how status types were handled in ARM code generation which would cause invalid code to be generated.