### PR TITLE
Only generate v1beta1 admission review versions

### DIFF
--- a/.devcontainer/install-dependencies.sh
+++ b/.devcontainer/install-dependencies.sh
@@ -53,10 +53,8 @@ echo "Installing Go tools…"
 
 # go tools for vscode are preinstalled by base image (see first comment in Dockerfile)
 go get \
-    github.com/mikefarah/yq/v3@3.4.1 \
-    github.com/mitchellh/gox@v1.0.1 \
     k8s.io/code-generator/cmd/conversion-gen@v0.18.2 \
-    sigs.k8s.io/controller-tools/cmd/controller-gen@v0.4.0 \
+    sigs.k8s.io/controller-tools/cmd/controller-gen@v0.4.1 \
     sigs.k8s.io/kind@v0.9.0 \
     sigs.k8s.io/kustomize/kustomize/v3@v3.8.6 
 

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -163,19 +163,10 @@ tasks:
     cmds:
     - go build -o ./bin/{{.CONTROLLER_APP}}
 
-  controller:fixup-webhooks:
-    dir: "{{.CONTROLLER_ROOT}}"
-    deps: [controller:generate-crds]
-    cmds:
-    # need to remove v1 from the manifest as it doesn't work with controller-runtime currently: https://github.com/kubernetes-sigs/controller-runtime/issues/1272
-    - yq delete -P -i {{.IN}} 'webhooks[*].admissionReviewVersions(. == v1)' 
-    vars:
-      IN: config/webhook/manifests.yaml
-
   controller:test-integration-envtest:
     desc: Run integration tests with envtest using record/replay.
     dir: "{{.CONTROLLER_ROOT}}"
-    deps: [controller:fixup-webhooks]
+    deps: [controller:generate-crds]
     cmds:
     # -race fails at the moment in controller-runtime
     - ENVTEST=1 RECORD_REPLAY=1 go test -v ./...
@@ -183,7 +174,7 @@ tasks:
   controller:test-integration-envtest-cover:
     desc: Run integration tests with envtest using record/replay and output coverage.
     dir: "{{.CONTROLLER_ROOT}}"
-    deps: [controller:fixup-webhooks]
+    deps: [controller:generate-crds]
     cmds:
     # -race fails at the moment in controller-runtime
     - ENVTEST=1 RECORD_REPLAY=1 go test -covermode atomic -coverprofile=coverage-integration-envtest.out -coverpkg="./..." -v ./...
@@ -191,7 +182,7 @@ tasks:
   controller:test-integration-envtest-live:
     desc: Run integration tests with envtest against live data and output coverage.
     dir: "{{.CONTROLLER_ROOT}}"
-    deps: [controller:fixup-webhooks, cleanup-azure-resources]
+    deps: [controller:generate-crds, cleanup-azure-resources]
     cmds:
     # -race fails at the moment in controller-runtime
     - ENVTEST=1 go test -covermode atomic -coverprofile=coverage-integration-envtest-live.out -coverpkg="./..." -v ./...

--- a/hack/generated/_apis/microsoft.resources/v20200601/resourcegroup_types.go
+++ b/hack/generated/_apis/microsoft.resources/v20200601/resourcegroup_types.go
@@ -21,7 +21,7 @@ type ResourceGroup struct {
 	Status            ResourceGroupStatus `json:"status,omitempty"`
 }
 
-// +kubebuilder:webhook:path=/mutate-microsoft-resources-infra-azure-com-v20200601-resourcegroup,mutating=true,sideEffects=None,matchPolicy=Exact,failurePolicy=fail,groups=microsoft.resources.infra.azure.com,resources=resourcegroups,verbs=create;update,versions=v20200601,name=default.v20200601.resourcegroups.microsoft.resources.infra.azure.com
+// +kubebuilder:webhook:path=/mutate-microsoft-resources-infra-azure-com-v20200601-resourcegroup,mutating=true,sideEffects=None,matchPolicy=Exact,failurePolicy=fail,groups=microsoft.resources.infra.azure.com,resources=resourcegroups,verbs=create;update,versions=v20200601,name=default.v20200601.resourcegroups.microsoft.resources.infra.azure.com,admissionReviewVersions=v1beta1
 
 var _ admission.Defaulter = &ResourceGroup{}
 

--- a/hack/generator/pkg/astmodel/kubernetes_resource_interface.go
+++ b/hack/generator/pkg/astmodel/kubernetes_resource_interface.go
@@ -130,7 +130,7 @@ func generateDefaulter(resourceName TypeName, spec *ObjectType, idFactory Identi
 	annotation := fmt.Sprintf(
 		"+kubebuilder:webhook:path=%s,mutating=true,sideEffects=None,"+
 			"matchPolicy=Exact,failurePolicy=fail,groups=%s,resources=%s,"+
-			"verbs=create;update,versions=%s,name=%s",
+			"verbs=create;update,versions=%s,name=%s,admissionReviewVersions=v1beta1", // admission review version v1 is not yet supported by controller-runtime
 		path,
 		group,
 		resource,

--- a/hack/generator/pkg/codegen/testdata/ArmResource/Arm_oneof_resource_conversion_on_arm_type_only_azure.golden
+++ b/hack/generator/pkg/codegen/testdata/ArmResource/Arm_oneof_resource_conversion_on_arm_type_only_azure.golden
@@ -20,7 +20,7 @@ type FakeResource struct {
 	Spec              FakeResource_Spec `json:"spec,omitempty"`
 }
 
-// +kubebuilder:webhook:path=/mutate-test-infra-azure-com-v20200101-fakeresource,mutating=true,sideEffects=None,matchPolicy=Exact,failurePolicy=fail,groups=test.infra.azure.com,resources=fakeresources,verbs=create;update,versions=v20200101,name=default.v20200101.fakeresources.test.infra.azure.com
+// +kubebuilder:webhook:path=/mutate-test-infra-azure-com-v20200101-fakeresource,mutating=true,sideEffects=None,matchPolicy=Exact,failurePolicy=fail,groups=test.infra.azure.com,resources=fakeresources,verbs=create;update,versions=v20200101,name=default.v20200101.fakeresources.test.infra.azure.com,admissionReviewVersions=v1beta1
 
 var _ admission.Defaulter = &FakeResource{}
 

--- a/hack/generator/pkg/codegen/testdata/ArmResource/Arm_test_dependent_resource_and_ownership_azure.golden
+++ b/hack/generator/pkg/codegen/testdata/ArmResource/Arm_test_dependent_resource_and_ownership_azure.golden
@@ -19,7 +19,7 @@ type A struct {
 	Spec              A_Spec `json:"spec,omitempty"`
 }
 
-// +kubebuilder:webhook:path=/mutate-test-infra-azure-com-v20200101-a,mutating=true,sideEffects=None,matchPolicy=Exact,failurePolicy=fail,groups=test.infra.azure.com,resources=as,verbs=create;update,versions=v20200101,name=default.v20200101.as.test.infra.azure.com
+// +kubebuilder:webhook:path=/mutate-test-infra-azure-com-v20200101-a,mutating=true,sideEffects=None,matchPolicy=Exact,failurePolicy=fail,groups=test.infra.azure.com,resources=as,verbs=create;update,versions=v20200101,name=default.v20200101.as.test.infra.azure.com,admissionReviewVersions=v1beta1
 
 var _ admission.Defaulter = &A{}
 
@@ -83,7 +83,7 @@ type B struct {
 	Spec              B_Spec `json:"spec,omitempty"`
 }
 
-// +kubebuilder:webhook:path=/mutate-test-infra-azure-com-v20200101-b,mutating=true,sideEffects=None,matchPolicy=Exact,failurePolicy=fail,groups=test.infra.azure.com,resources=bs,verbs=create;update,versions=v20200101,name=default.v20200101.bs.test.infra.azure.com
+// +kubebuilder:webhook:path=/mutate-test-infra-azure-com-v20200101-b,mutating=true,sideEffects=None,matchPolicy=Exact,failurePolicy=fail,groups=test.infra.azure.com,resources=bs,verbs=create;update,versions=v20200101,name=default.v20200101.bs.test.infra.azure.com,admissionReviewVersions=v1beta1
 
 var _ admission.Defaulter = &B{}
 
@@ -147,7 +147,7 @@ type C struct {
 	Spec              C_Spec `json:"spec,omitempty"`
 }
 
-// +kubebuilder:webhook:path=/mutate-test-infra-azure-com-v20200101-c,mutating=true,sideEffects=None,matchPolicy=Exact,failurePolicy=fail,groups=test.infra.azure.com,resources=cs,verbs=create;update,versions=v20200101,name=default.v20200101.cs.test.infra.azure.com
+// +kubebuilder:webhook:path=/mutate-test-infra-azure-com-v20200101-c,mutating=true,sideEffects=None,matchPolicy=Exact,failurePolicy=fail,groups=test.infra.azure.com,resources=cs,verbs=create;update,versions=v20200101,name=default.v20200101.cs.test.infra.azure.com,admissionReviewVersions=v1beta1
 
 var _ admission.Defaulter = &C{}
 
@@ -211,7 +211,7 @@ type D struct {
 	Spec              D_Spec `json:"spec,omitempty"`
 }
 
-// +kubebuilder:webhook:path=/mutate-test-infra-azure-com-v20200101-d,mutating=true,sideEffects=None,matchPolicy=Exact,failurePolicy=fail,groups=test.infra.azure.com,resources=ds,verbs=create;update,versions=v20200101,name=default.v20200101.ds.test.infra.azure.com
+// +kubebuilder:webhook:path=/mutate-test-infra-azure-com-v20200101-d,mutating=true,sideEffects=None,matchPolicy=Exact,failurePolicy=fail,groups=test.infra.azure.com,resources=ds,verbs=create;update,versions=v20200101,name=default.v20200101.ds.test.infra.azure.com,admissionReviewVersions=v1beta1
 
 var _ admission.Defaulter = &D{}
 

--- a/hack/generator/pkg/codegen/testdata/ArmResource/Arm_test_simple_resource_array_properties_azure.golden
+++ b/hack/generator/pkg/codegen/testdata/ArmResource/Arm_test_simple_resource_array_properties_azure.golden
@@ -19,7 +19,7 @@ type FakeResource struct {
 	Spec              FakeResource_Spec `json:"spec,omitempty"`
 }
 
-// +kubebuilder:webhook:path=/mutate-test-infra-azure-com-v20200101-fakeresource,mutating=true,sideEffects=None,matchPolicy=Exact,failurePolicy=fail,groups=test.infra.azure.com,resources=fakeresources,verbs=create;update,versions=v20200101,name=default.v20200101.fakeresources.test.infra.azure.com
+// +kubebuilder:webhook:path=/mutate-test-infra-azure-com-v20200101-fakeresource,mutating=true,sideEffects=None,matchPolicy=Exact,failurePolicy=fail,groups=test.infra.azure.com,resources=fakeresources,verbs=create;update,versions=v20200101,name=default.v20200101.fakeresources.test.infra.azure.com,admissionReviewVersions=v1beta1
 
 var _ admission.Defaulter = &FakeResource{}
 

--- a/hack/generator/pkg/codegen/testdata/ArmResource/Arm_test_simple_resource_complex_properties_azure.golden
+++ b/hack/generator/pkg/codegen/testdata/ArmResource/Arm_test_simple_resource_complex_properties_azure.golden
@@ -19,7 +19,7 @@ type FakeResource struct {
 	Spec              FakeResource_Spec `json:"spec,omitempty"`
 }
 
-// +kubebuilder:webhook:path=/mutate-test-infra-azure-com-v20200101-fakeresource,mutating=true,sideEffects=None,matchPolicy=Exact,failurePolicy=fail,groups=test.infra.azure.com,resources=fakeresources,verbs=create;update,versions=v20200101,name=default.v20200101.fakeresources.test.infra.azure.com
+// +kubebuilder:webhook:path=/mutate-test-infra-azure-com-v20200101-fakeresource,mutating=true,sideEffects=None,matchPolicy=Exact,failurePolicy=fail,groups=test.infra.azure.com,resources=fakeresources,verbs=create;update,versions=v20200101,name=default.v20200101.fakeresources.test.infra.azure.com,admissionReviewVersions=v1beta1
 
 var _ admission.Defaulter = &FakeResource{}
 

--- a/hack/generator/pkg/codegen/testdata/ArmResource/Arm_test_simple_resource_json_fields_azure.golden
+++ b/hack/generator/pkg/codegen/testdata/ArmResource/Arm_test_simple_resource_json_fields_azure.golden
@@ -20,7 +20,7 @@ type FakeResource struct {
 	Spec              FakeResource_Spec `json:"spec,omitempty"`
 }
 
-// +kubebuilder:webhook:path=/mutate-test-infra-azure-com-v20200101-fakeresource,mutating=true,sideEffects=None,matchPolicy=Exact,failurePolicy=fail,groups=test.infra.azure.com,resources=fakeresources,verbs=create;update,versions=v20200101,name=default.v20200101.fakeresources.test.infra.azure.com
+// +kubebuilder:webhook:path=/mutate-test-infra-azure-com-v20200101-fakeresource,mutating=true,sideEffects=None,matchPolicy=Exact,failurePolicy=fail,groups=test.infra.azure.com,resources=fakeresources,verbs=create;update,versions=v20200101,name=default.v20200101.fakeresources.test.infra.azure.com,admissionReviewVersions=v1beta1
 
 var _ admission.Defaulter = &FakeResource{}
 

--- a/hack/generator/pkg/codegen/testdata/ArmResource/Arm_test_simple_resource_map_properties_azure.golden
+++ b/hack/generator/pkg/codegen/testdata/ArmResource/Arm_test_simple_resource_map_properties_azure.golden
@@ -19,7 +19,7 @@ type FakeResource struct {
 	Spec              FakeResource_Spec `json:"spec,omitempty"`
 }
 
-// +kubebuilder:webhook:path=/mutate-test-infra-azure-com-v20200101-fakeresource,mutating=true,sideEffects=None,matchPolicy=Exact,failurePolicy=fail,groups=test.infra.azure.com,resources=fakeresources,verbs=create;update,versions=v20200101,name=default.v20200101.fakeresources.test.infra.azure.com
+// +kubebuilder:webhook:path=/mutate-test-infra-azure-com-v20200101-fakeresource,mutating=true,sideEffects=None,matchPolicy=Exact,failurePolicy=fail,groups=test.infra.azure.com,resources=fakeresources,verbs=create;update,versions=v20200101,name=default.v20200101.fakeresources.test.infra.azure.com,admissionReviewVersions=v1beta1
 
 var _ admission.Defaulter = &FakeResource{}
 

--- a/hack/generator/pkg/codegen/testdata/ArmResource/Arm_test_simple_resource_renders_spec_azure.golden
+++ b/hack/generator/pkg/codegen/testdata/ArmResource/Arm_test_simple_resource_renders_spec_azure.golden
@@ -19,7 +19,7 @@ type FakeResource struct {
 	Spec              FakeResource_Spec `json:"spec,omitempty"`
 }
 
-// +kubebuilder:webhook:path=/mutate-test-infra-azure-com-v20200101-fakeresource,mutating=true,sideEffects=None,matchPolicy=Exact,failurePolicy=fail,groups=test.infra.azure.com,resources=fakeresources,verbs=create;update,versions=v20200101,name=default.v20200101.fakeresources.test.infra.azure.com
+// +kubebuilder:webhook:path=/mutate-test-infra-azure-com-v20200101-fakeresource,mutating=true,sideEffects=None,matchPolicy=Exact,failurePolicy=fail,groups=test.infra.azure.com,resources=fakeresources,verbs=create;update,versions=v20200101,name=default.v20200101.fakeresources.test.infra.azure.com,admissionReviewVersions=v1beta1
 
 var _ admission.Defaulter = &FakeResource{}
 

--- a/hack/generator/pkg/codegen/testdata/EmbeddedTypes/Embedded_type_simple_resource.golden
+++ b/hack/generator/pkg/codegen/testdata/EmbeddedTypes/Embedded_type_simple_resource.golden
@@ -23,7 +23,7 @@ type FakeResource struct {
 	Spec              FakeResource_Spec `json:"spec,omitempty"`
 }
 
-// +kubebuilder:webhook:path=/mutate-test-infra-azure-com-v20200101-fakeresource,mutating=true,sideEffects=None,matchPolicy=Exact,failurePolicy=fail,groups=test.infra.azure.com,resources=fakeresources,verbs=create;update,versions=v20200101,name=default.v20200101.fakeresources.test.infra.azure.com
+// +kubebuilder:webhook:path=/mutate-test-infra-azure-com-v20200101-fakeresource,mutating=true,sideEffects=None,matchPolicy=Exact,failurePolicy=fail,groups=test.infra.azure.com,resources=fakeresources,verbs=create;update,versions=v20200101,name=default.v20200101.fakeresources.test.infra.azure.com,admissionReviewVersions=v1beta1
 
 var _ admission.Defaulter = &FakeResource{}
 

--- a/hack/generator/pkg/codegen/testdata/EnumNames/Multi_valued_enum_name.golden
+++ b/hack/generator/pkg/codegen/testdata/EnumNames/Multi_valued_enum_name.golden
@@ -19,7 +19,7 @@ type AResource struct {
 	Spec              AResource_Spec `json:"spec,omitempty"`
 }
 
-// +kubebuilder:webhook:path=/mutate-test-infra-azure-com-v20200101-aresource,mutating=true,sideEffects=None,matchPolicy=Exact,failurePolicy=fail,groups=test.infra.azure.com,resources=aresources,verbs=create;update,versions=v20200101,name=default.v20200101.aresources.test.infra.azure.com
+// +kubebuilder:webhook:path=/mutate-test-infra-azure-com-v20200101-aresource,mutating=true,sideEffects=None,matchPolicy=Exact,failurePolicy=fail,groups=test.infra.azure.com,resources=aresources,verbs=create;update,versions=v20200101,name=default.v20200101.aresources.test.infra.azure.com,admissionReviewVersions=v1beta1
 
 var _ admission.Defaulter = &AResource{}
 


### PR DESCRIPTION
Update to `controller-gen` 0.4.1 and remove `yq` bits. We can now generate the `v1beta1` version only, so no longer need to prune the `v1` version out.