### PR TITLE
Fix controller_resources_gen.go generation

### DIFF
--- a/hack/generated/controllers/controller_resources.go
+++ b/hack/generated/controllers/controller_resources.go
@@ -11,6 +11,14 @@ import (
 	resources "github.com/Azure/k8s-infra/hack/generated/_apis/microsoft.resources/v1alpha1api20200601"
 )
 
+func GetKnownStorageTypes() []runtime.Object {
+	knownTypes := getKnownStorageTypes()
+
+	knownTypes = append(knownTypes, new(resources.ResourceGroup))
+
+	return knownTypes
+}
+
 func GetKnownTypes() []runtime.Object {
 	knownTypes := getKnownTypes()
 

--- a/hack/generated/main.go
+++ b/hack/generated/main.go
@@ -71,10 +71,13 @@ func main() {
 		os.Exit(1)
 	}
 
-	if errs := controllers.RegisterAll(mgr, armApplier, controllers.GetKnownTypes(), ctrl.Log.WithName("controllers"), concurrency(1)); errs != nil {
-		for _, err := range errs {
-			setupLog.Error(err, "failed to register gvk: %v")
-		}
+	if errs := controllers.RegisterAll(mgr, armApplier, controllers.GetKnownStorageTypes(), ctrl.Log.WithName("controllers"), concurrency(1)); errs != nil {
+		setupLog.Error(err, "failed to register gvks")
+		os.Exit(1)
+	}
+
+	if errs := controllers.RegisterWebhooks(mgr, controllers.GetKnownTypes()); errs != nil {
+		setupLog.Error(err, "failed to register webhook for gvks")
 		os.Exit(1)
 	}
 

--- a/hack/generator/pkg/astmodel/file_definition.go
+++ b/hack/generator/pkg/astmodel/file_definition.go
@@ -143,7 +143,7 @@ func (file *FileDefinition) generateImports() *PackageImportSet {
 	// Force local imports to have explicit names based on the service
 	for _, imp := range requiredImports.AsSlice() {
 		if IsLocalPackageReference(imp.packageReference) && !imp.HasExplicitName() {
-			name := requiredImports.ServiceNameForImport(imp)
+			name := imp.ServiceNameForImport()
 			requiredImports.AddImport(imp.WithName(name))
 		}
 	}

--- a/hack/generator/pkg/astmodel/package_import.go
+++ b/hack/generator/pkg/astmodel/package_import.go
@@ -7,6 +7,7 @@ package astmodel
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/Azure/k8s-infra/hack/generator/pkg/astbuilder"
 	"github.com/dave/dst"
@@ -73,4 +74,30 @@ func (pi PackageImport) String() string {
 	}
 
 	return pi.packageReference.String()
+}
+
+// TODO: There's an assumption here that this package is a local package, or at least a package that has a format
+// TODO: similar to one
+// ServiceNameForImport extracts a name for the service for use to disambiguate imports
+// E.g. for microsoft.batch/v201700401, extract "batch"
+//      for microsoft.storage/v20200101 extract "storage"
+//      for microsoft.storsimple.1200 extract "storsimple1200" and so on
+func (pi PackageImport) ServiceNameForImport() string {
+	pathBits := strings.Split(pi.packageReference.PackagePath(), "/")
+	index := len(pathBits) - 1
+	if index > 0 {
+		index--
+	}
+
+	nameBits := strings.Split(pathBits[index], ".")
+	result := strings.Join(nameBits[1:], "")
+	return result
+}
+
+// Create a versioned name based on the service for use to disambiguate imports
+// E.g. for microsoft.batch/v201700401, extract "batchv201700401"
+//      for microsoft.storage/v20200101 extract "storagev20200101" and so on
+func (pi PackageImport) VersionedNameForImport() string {
+	service := pi.ServiceNameForImport()
+	return service + pi.packageReference.PackageName()
 }

--- a/hack/generator/pkg/astmodel/package_import_set_test.go
+++ b/hack/generator/pkg/astmodel/package_import_set_test.go
@@ -335,46 +335,6 @@ func TestPackageImportSet_ResolveConflicts_GivenImplicityNamedConflicts_AssignsE
 }
 
 /*
- * ServiceNameForImport() tests
- */
-
-func TestPackageImportSet_ServiceNameForImport_GivenImport_ReturnsExpectedName(t *testing.T) {
-	cases := []struct {
-		name     string
-		ref      PackageReference
-		expected string
-	}{
-		{
-			"Batch",
-			MakeExternalPackageReference("github.com/Azure/k8s-infra/hack/generated/_apis/microsoft.batch/v201700401"),
-			"batch",
-		},
-		{
-			"Storage",
-			MakeExternalPackageReference("github.com/Azure/k8s-infra/hack/generated/_apis/microsoft.storage/v20200101"),
-			"storage",
-		},
-		{
-			"StorSimple",
-			MakeExternalPackageReference("github.com/Azure/k8s-infra/hack/generated/_apis/microsoft.storsimple.1200/v20161001"),
-			"storsimple1200",
-		},
-	}
-
-	for _, c := range cases {
-		c := c
-		t.Run(c.name, func(t *testing.T) {
-			t.Parallel()
-			g := NewGomegaWithT(t)
-			imp := NewPackageImport(c.ref)
-			set := NewPackageImportSet()
-			name := set.ServiceNameForImport(imp)
-			g.Expect(name).To(Equal(c.expected))
-		})
-	}
-}
-
-/*
  * orderImports() tests
  */
 

--- a/hack/generator/pkg/astmodel/package_import_test.go
+++ b/hack/generator/pkg/astmodel/package_import_test.go
@@ -101,3 +101,42 @@ func TestPackageImport_Equals(t *testing.T) {
 		})
 	}
 }
+
+/*
+ * ServiceNameForImport() tests
+ */
+
+func TestPackageImport_ServiceNameForImport_GivenImport_ReturnsExpectedName(t *testing.T) {
+	cases := []struct {
+		name     string
+		ref      PackageReference
+		expected string
+	}{
+		{
+			"Batch",
+			MakeExternalPackageReference("github.com/Azure/k8s-infra/hack/generated/_apis/microsoft.batch/v201700401"),
+			"batch",
+		},
+		{
+			"Storage",
+			MakeExternalPackageReference("github.com/Azure/k8s-infra/hack/generated/_apis/microsoft.storage/v20200101"),
+			"storage",
+		},
+		{
+			"StorSimple",
+			MakeExternalPackageReference("github.com/Azure/k8s-infra/hack/generated/_apis/microsoft.storsimple.1200/v20161001"),
+			"storsimple1200",
+		},
+	}
+
+	for _, c := range cases {
+		c := c
+		t.Run(c.name, func(t *testing.T) {
+			t.Parallel()
+			g := NewGomegaWithT(t)
+			imp := NewPackageImport(c.ref)
+			name := imp.ServiceNameForImport()
+			g.Expect(name).To(Equal(c.expected))
+		})
+	}
+}

--- a/hack/generator/pkg/astmodel/test_file_definition.go
+++ b/hack/generator/pkg/astmodel/test_file_definition.go
@@ -107,7 +107,7 @@ func (file *TestFileDefinition) generateImports() *PackageImportSet {
 	// Force local imports to have explicit names based on the service
 	for _, imp := range requiredImports.AsSlice() {
 		if IsLocalPackageReference(imp.packageReference) && !imp.HasExplicitName() {
-			name := requiredImports.ServiceNameForImport(imp)
+			name := imp.ServiceNameForImport()
 			requiredImports.AddImport(imp.WithName(name))
 		}
 	}


### PR DESCRIPTION
  - Only storage types should be used to create GenericReconciler's.
  - All types should be used to register webhooks.
  - Improve resolver to have a better chance of finding the storage
    version.