### PR TITLE
Improve Integration tests by adding headers to each stage

### DIFF
--- a/hack/generated/controllers/crd_cosmosdb_test.go
+++ b/hack/generated/controllers/crd_cosmosdb_test.go
@@ -12,6 +12,8 @@ import (
 	. "github.com/onsi/gomega"
 
 	documentdb "github.com/Azure/k8s-infra/hack/generated/_apis/microsoft.documentdb/v20150408"
+	util "github.com/Azure/k8s-infra/hack/generated/pkg/util"
+
 	"github.com/Azure/k8s-infra/hack/generated/pkg/testcommon"
 )
 
@@ -19,10 +21,14 @@ func Test_CosmosDB_CRUD(t *testing.T) {
 	t.Parallel()
 
 	g := NewGomegaWithT(t)
+	log := util.NewBannerLogger()
+	log.Header(t.Name())
+
 	ctx := context.Background()
 	testContext, err := testContext.ForTest(t)
 	g.Expect(err).ToNot(HaveOccurred())
 
+	log.Subheader("Create resource group")
 	rg, err := testContext.CreateNewTestResourceGroup(testcommon.WaitForCreation)
 	g.Expect(err).ToNot(HaveOccurred())
 
@@ -30,6 +36,7 @@ func Test_CosmosDB_CRUD(t *testing.T) {
 	namer := testContext.Namer.WithSeparator("")
 
 	// Create a Cosmos DB account
+	log.Subheader("Create cosmosdb account")
 	kind := documentdb.DatabaseAccountsSpecKindGlobalDocumentDB
 	acct := &documentdb.DatabaseAccount{
 		ObjectMeta: testContext.MakeObjectMetaWithName(namer.GenerateName("db")),
@@ -67,6 +74,7 @@ func Test_CosmosDB_CRUD(t *testing.T) {
 	*/
 
 	// Delete
+	log.Subheader("Delete cosmosdb account")
 	err = testContext.KubeClient.Delete(ctx, acct)
 	g.Expect(err).ToNot(HaveOccurred())
 	g.Eventually(acct).Should(testContext.Match.BeDeleted(ctx))

--- a/hack/generated/controllers/crd_resourcegroup_test.go
+++ b/hack/generated/controllers/crd_resourcegroup_test.go
@@ -12,17 +12,22 @@ import (
 	. "github.com/onsi/gomega"
 
 	"github.com/Azure/k8s-infra/hack/generated/pkg/armclient"
+	util "github.com/Azure/k8s-infra/hack/generated/pkg/util"
 )
 
 func Test_ResourceGroup_CRUD(t *testing.T) {
 	t.Parallel()
 
 	g := NewGomegaWithT(t)
+	log := util.NewBannerLogger()
+	log.Header(t.Name())
+
 	ctx := context.Background()
 	testContext, err := testContext.ForTest(t)
 	g.Expect(err).ToNot(HaveOccurred())
 
 	// Create a resource group
+	log.Subheader("Create resource group")
 	rg := testContext.NewTestResourceGroup()
 	err = testContext.KubeClient.Create(ctx, rg)
 	g.Expect(err).ToNot(HaveOccurred())
@@ -36,6 +41,7 @@ func Test_ResourceGroup_CRUD(t *testing.T) {
 	armId := rg.Status.ID
 
 	// Delete the resource group
+	log.Subheader("Delete resource group")
 	err = testContext.KubeClient.Delete(ctx, rg)
 	g.Expect(err).ToNot(HaveOccurred())
 	g.Eventually(rg).Should(testContext.Match.BeDeleted(ctx))

--- a/hack/generated/controllers/crd_servicebus_test.go
+++ b/hack/generated/controllers/crd_servicebus_test.go
@@ -7,21 +7,22 @@ package controllers_test
 
 import (
 	"context"
-	util "github.com/Azure/k8s-infra/hack/generated/pkg/util"
 	"testing"
 
+	"github.com/Azure/k8s-infra/hack/generated/pkg/testcommon"
+
 	. "github.com/onsi/gomega"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	servicebus "github.com/Azure/k8s-infra/hack/generated/_apis/microsoft.servicebus/v20180101preview"
-	"github.com/Azure/k8s-infra/hack/generated/pkg/testcommon"
+	util "github.com/Azure/k8s-infra/hack/generated/pkg/util"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func Test_ServiceBus_Namespace_CRUD(t *testing.T) {
 	t.Parallel()
 
 	g := NewGomegaWithT(t)
-	log := controllers.NewBannerLogger()
+	log := util.NewBannerLogger()
 	log.Header(t.Name())
 
 	ctx := context.Background()

--- a/hack/generated/pkg/util/banner_logger.go
+++ b/hack/generated/pkg/util/banner_logger.go
@@ -31,6 +31,12 @@ func (b *BannerLogger) WriteBanner(line string, content string) {
 	fmt.Println(strings.Repeat(line, lineLength))
 }
 
+func (b *BannerLogger) NewSublogger() *BannerLogger {
+	return &BannerLogger{
+		parent: b,
+	}
+}
+
 // label returns an indexed identifier for the current stage
 func (b *BannerLogger) label() string {
 	if b.parent == nil {

--- a/hack/generated/pkg/util/banner_logger.go
+++ b/hack/generated/pkg/util/banner_logger.go
@@ -1,0 +1,41 @@
+package controllers
+
+import (
+	"fmt"
+	"strings"
+	"unicode/utf8"
+)
+
+type BannerLogger struct {
+	currentStage int
+	parent       *BannerLogger
+}
+
+// NewBannerLogger creates a new BannerLogger with an expected number of stages
+func NewBannerLogger() *BannerLogger {
+	return &BannerLogger{}
+}
+
+func (b *BannerLogger) Header(content string) {
+	b.WriteBanner("=", fmt.Sprintf("%s %s", b.label(), content))
+}
+
+func (b *BannerLogger) Subheader(content string) {
+	b.WriteBanner("-", fmt.Sprintf("%s %s", b.label(), content))
+}
+
+func (b *BannerLogger) WriteBanner(line string, content string) {
+	lineLength := utf8.RuneCountInString(content)
+	fmt.Println(strings.Repeat(line, lineLength))
+	fmt.Println(content)
+	fmt.Println(strings.Repeat(line, lineLength))
+}
+
+// label returns an indexed identifier for the current stage
+func (b *BannerLogger) label() string {
+	if b.parent == nil {
+		return fmt.Sprint(b.currentStage)
+	}
+
+	return fmt.Sprintf("%s.%d", b.parent.label(), b.currentStage)
+}

--- a/hack/generated/pkg/util/banner_logger.go
+++ b/hack/generated/pkg/util/banner_logger.go
@@ -1,3 +1,8 @@
+/*
+Copyright (c) Microsoft Corporation.
+Licensed under the MIT license.
+*/
+
 package controllers
 
 import (

--- a/hack/generated/pkg/util/banner_logger.go
+++ b/hack/generated/pkg/util/banner_logger.go
@@ -25,15 +25,15 @@ func (b *BannerLogger) Header(content string) {
 	lineLength := utf8.RuneCountInString(content)
 	fmt.Println(strings.Repeat("=", lineLength))
 	fmt.Println(content)
-	fmt.Println(strings.Repeat(line, lineLength))
+	fmt.Println(strings.Repeat("=", lineLength))
 }
 
 func (b *BannerLogger) Subheader(content string) {
 	text := fmt.Sprintf("%s %s", b.label(), content)
 	lineLength := utf8.RuneCountInString(text)
-	fmt.Println(strings.Repeat(line, lineLength))
+	fmt.Println(strings.Repeat("-", lineLength))
 	fmt.Println(text)
-	fmt.Println(strings.Repeat(line, lineLength))
+	fmt.Println(strings.Repeat("-", lineLength))
 }
 
 func (b *BannerLogger) NewSublogger() *BannerLogger {

--- a/hack/generated/pkg/util/banner_logger.go
+++ b/hack/generated/pkg/util/banner_logger.go
@@ -29,6 +29,7 @@ func (b *BannerLogger) Header(content string) {
 }
 
 func (b *BannerLogger) Subheader(content string) {
+	b.currentStage++
 	text := fmt.Sprintf("%s %s", b.label(), content)
 	lineLength := utf8.RuneCountInString(text)
 	fmt.Println(strings.Repeat("-", lineLength))

--- a/hack/generated/pkg/util/banner_logger_test.go
+++ b/hack/generated/pkg/util/banner_logger_test.go
@@ -1,3 +1,8 @@
+/*
+Copyright (c) Microsoft Corporation.
+Licensed under the MIT license.
+*/
+
 package controllers
 
 import (

--- a/hack/generated/pkg/util/banner_logger_test.go
+++ b/hack/generated/pkg/util/banner_logger_test.go
@@ -1,0 +1,20 @@
+package controllers
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+)
+
+func TestBannerLoggerLabels(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	var logger = &BannerLogger{
+		currentStage: 2,
+		parent: &BannerLogger{
+			currentStage: 4,
+		},
+	}
+
+	g.Expect(logger.label()).To(Equal("4.2"))
+}


### PR DESCRIPTION
Adds banner headings into the log output for each integration test, allowing the different stages/phases of the test to be easily identified while scanning the test log. 

Each banner is numbered for reference:
```
[controller:test-integration-envtest-cover] 2021/03/18 23:55:16 Webhook server running at: :34365
[controller:test-integration-envtest-cover] 2021/03/18 23:55:16 http: TLS handshake error from 127.0.0.1:46798: EOF
[controller:test-integration-envtest-cover] -----------------------
[controller:test-integration-envtest-cover] 1 Create resource group
[controller:test-integration-envtest-cover] -----------------------
[controller:test-integration-envtest-cover] 2021/03/18 23:55:16 Creating test resource group "k8sinfratest-rg-dnhfns"
[controller:test-integration-envtest-cover] 2021/03/18 23:55:17 Creating & starting controller-runtime manager
[controller:test-integration-envtest-cover] 2021/03/18 23:55:17 Minimizing requeue delay
[controller:test-integration-envtest-cover] 2021/03/18 23:55:17 Registering custom controllers
```

Nested headings are supported too:
```
[controller:test-integration-envtest-cover] === RUN   Test_StorageAccount_CRUD/Blob_Services_CRUD
[controller:test-integration-envtest-cover] -----------------------
[controller:test-integration-envtest-cover] 2.1 Create blob service
[controller:test-integration-envtest-cover] -----------------------
[controller:test-integration-envtest-cover] I0318 23:55:29.118536   11911 generic_controller.go:390] StorageAccountsBlobServiceController "msg"="Starting new deployment to Azure" "name"="k8sinfratest-blobservice-nayxdk" "namespace"="k8s-infra-test-ns" "action"="BeginDeployment"
```

