### PR TITLE
Fix webhook pluralization

### DIFF
--- a/hack/generator/pkg/astmodel/kubernetes_resource_interface.go
+++ b/hack/generator/pkg/astmodel/kubernetes_resource_interface.go
@@ -117,7 +117,7 @@ func generateDefaulter(resourceName TypeName, spec *ObjectType, idFactory Identi
 
 	group = strings.ToLower(group + GroupSuffix)
 	nonPluralResource := strings.ToLower(resource)
-	resource = strings.ToLower(resource) + "s" // TODO: this should come from resource?
+	resource = strings.ToLower(resourceName.Plural().Name())
 
 	// e.g. "mutate-microsoft-network-infra-azure-com-v1-backendaddresspool"
 	// note that this must match _exactly_ how controller-runtime generates the path

--- a/hack/generator/pkg/astmodel/type_name_test.go
+++ b/hack/generator/pkg/astmodel/type_name_test.go
@@ -39,3 +39,32 @@ func TestSingular_GivesExpectedResults(t *testing.T) {
 		})
 	}
 }
+
+func TestPlural_GivesExpectedResults(t *testing.T) {
+	cases := []struct {
+		name     string
+		expected string
+	}{
+		{"Account", "Accounts"},
+		{"Accounts", "Accounts"},
+		{"Batch", "Batches"},
+		{"Batches", "Batches"},
+		{"ImportService", "ImportServices"},
+		{"Exportservice", "Exportservices"},
+		{"AzureRedis", "AzureRedis"},
+	}
+
+	ref := makeTestLocalPackageReference("Demo", "v2010")
+
+	for _, c := range cases {
+		c := c
+		t.Run(c.name, func(t *testing.T) {
+			t.Parallel()
+			g := NewGomegaWithT(t)
+
+			name := MakeTypeName(ref, c.name)
+			result := name.Plural()
+			g.Expect(result.name).To(Equal(c.expected))
+		})
+	}
+}


### PR DESCRIPTION
This avoids things like "PublicIPAddressess" - which mismatches with the name that Kuberentes uses and causes the webhook to not be executed.

We basically want to do what controller-gen does, which you can see here: https://github.com/kubernetes-sigs/controller-tools/pull/522/files
