### PR TITLE
Default controller ENVTEST and RECORD_REPLAY to 1

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -170,7 +170,7 @@ tasks:
     deps: [controller:generate-crds]
     cmds:
     # -race fails at the moment in controller-runtime
-    - ENVTEST=1 RECORD_REPLAY=1 go test -v ./...
+    - RECORD_REPLAY=1 go test -v ./...
 
   controller:test-integration-envtest-cover:
     desc: Run integration tests with envtest using record/replay and output coverage.
@@ -178,7 +178,7 @@ tasks:
     deps: [controller:generate-crds]
     cmds:
     # -race fails at the moment in controller-runtime
-    - ENVTEST=1 RECORD_REPLAY=1 go test -covermode atomic -coverprofile=coverage-integration-envtest.out -coverpkg="./..." -v ./...
+    - RECORD_REPLAY=1 go test -covermode atomic -coverprofile=coverage-integration-envtest.out -coverpkg="./..." -v ./...
 
   controller:test-integration-envtest-live:
     desc: Run integration tests with envtest against live data and output coverage.
@@ -186,7 +186,7 @@ tasks:
     deps: [controller:generate-crds, cleanup-azure-resources]
     cmds:
     # -race fails at the moment in controller-runtime
-    - ENVTEST=1 go test -timeout 30m -covermode atomic -coverprofile=coverage-integration-envtest-live.out -coverpkg="./..." -v ./...
+    - go test -timeout 30m -covermode atomic -coverprofile=coverage-integration-envtest-live.out -coverpkg="./..." -v ./...
 
   controller:generate-types:
     desc: Run {{.GENERATOR_APP}} to generate input files for controller-gen for {{.CONTROLLER_APP}}.

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -170,7 +170,7 @@ tasks:
     deps: [controller:generate-crds]
     cmds:
     # -race fails at the moment in controller-runtime
-    - RECORD_REPLAY=1 go test -v ./...
+    - go test -v ./...
 
   controller:test-integration-envtest-cover:
     desc: Run integration tests with envtest using record/replay and output coverage.
@@ -178,7 +178,7 @@ tasks:
     deps: [controller:generate-crds]
     cmds:
     # -race fails at the moment in controller-runtime
-    - RECORD_REPLAY=1 go test -covermode atomic -coverprofile=coverage-integration-envtest.out -coverpkg="./..." -v ./...
+    - go test -covermode atomic -coverprofile=coverage-integration-envtest.out -coverpkg="./..." -v ./...
 
   controller:test-integration-envtest-live:
     desc: Run integration tests with envtest against live data and output coverage.
@@ -186,7 +186,7 @@ tasks:
     deps: [controller:generate-crds, cleanup-azure-resources]
     cmds:
     # -race fails at the moment in controller-runtime
-    - go test -timeout 30m -covermode atomic -coverprofile=coverage-integration-envtest-live.out -coverpkg="./..." -v ./...
+    - RECORD_REPLAY=0 go test -timeout 30m -covermode atomic -coverprofile=coverage-integration-envtest-live.out -coverpkg="./..." -v ./...
 
   controller:generate-types:
     desc: Run {{.GENERATOR_APP}} to generate input files for controller-gen for {{.CONTROLLER_APP}}.

--- a/hack/generated/controllers/suite_test.go
+++ b/hack/generated/controllers/suite_test.go
@@ -64,6 +64,6 @@ type Options struct {
 func getOptions() Options {
 	return Options{
 		useEnvTest:   os.Getenv("ENVTEST") != "0",
-		recordReplay: os.Getenv("RECORD_REPLAY") != "",
+		recordReplay: os.Getenv("RECORD_REPLAY") != "0",
 	}
 }

--- a/hack/generated/controllers/suite_test.go
+++ b/hack/generated/controllers/suite_test.go
@@ -63,7 +63,7 @@ type Options struct {
 
 func getOptions() Options {
 	return Options{
-		useEnvTest:   os.Getenv("ENVTEST") != "",
+		useEnvTest:   os.Getenv("ENVTEST") != "0",
 		recordReplay: os.Getenv("RECORD_REPLAY") != "",
 	}
 }

--- a/hack/generated/pkg/armclient/suite_test.go
+++ b/hack/generated/pkg/armclient/suite_test.go
@@ -41,7 +41,7 @@ func teardown() error {
 }
 
 func TestMain(m *testing.M) {
-	recordReplay := os.Getenv("RECORD_REPLAY") != ""
+	recordReplay := os.Getenv("RECORD_REPLAY") != "0"
 	os.Exit(testcommon.SetupTeardownTestMain(
 		m,
 		true,


### PR DESCRIPTION
This means that just running a controller test by default does what you probably want. Other modes are still supported by explicitly turning ENVTEST or RECORD_REPLAY off.