### PR TITLE
Simplify property conversions

### DIFF
--- a/hack/generator/pkg/astbuilder/builder.go
+++ b/hack/generator/pkg/astbuilder/builder.go
@@ -6,6 +6,7 @@
 package astbuilder
 
 import (
+	"fmt"
 	"go/token"
 
 	"github.com/dave/dst"
@@ -347,6 +348,23 @@ func EnsureStatementBlock(statement dst.Stmt) *dst.BlockStmt {
 	}
 
 	return StatementBlock(statement)
+}
+
+// Statements creates a sequence of statements from the provided values, each of which may be a
+// single dst.Stmt or a slice of multiple []dst.Stmts
+func Statements(statements ...interface{}) []dst.Stmt {
+	var result []dst.Stmt
+	for _, s := range statements {
+		if stmt, ok := s.(dst.Stmt); ok {
+			result = append(result, stmt)
+		} else if stmts, ok := s.([]dst.Stmt); ok {
+			result = append(result, stmts...)
+		} else {
+			panic(fmt.Sprintf("expected dst.Stmt or []dst.Stmt, but found %T", s))
+		}
+	}
+
+	return result
 }
 
 // cloneExprSlice is a utility method to clone a slice of expressions

--- a/hack/generator/pkg/astmodel/package_import_set.go
+++ b/hack/generator/pkg/astmodel/package_import_set.go
@@ -149,7 +149,7 @@ func (set *PackageImportSet) ResolveConflicts() error {
 		}
 
 		remappedImports[imp.packageReference] = imp
-		klog.Warningf("Remapped %v to %v", imp.packageReference, name)
+		klog.V(3).Infof("Remapped %v to %v", imp.packageReference, name)
 		return imp.WithName(name)
 	})
 
@@ -159,7 +159,7 @@ func (set *PackageImportSet) ResolveConflicts() error {
 		// Only rename imports we already renamed above
 		if _, ok := remappedImports[imp.packageReference]; ok {
 			name := imp.VersionedNameForImport()
-			klog.Warningf("Remapped %v to %v", imp.packageReference, name)
+			klog.V(3).Infof("Remapped %v to %v", imp.packageReference, name)
 			return imp.WithName(name)
 		}
 

--- a/hack/generator/pkg/astmodel/storage_conversion_endpoint.go
+++ b/hack/generator/pkg/astmodel/storage_conversion_endpoint.go
@@ -44,7 +44,7 @@ func (endpoint *StorageConversionEndpoint) Type() Type {
 // Each call will return a unique identifier
 func (endpoint *StorageConversionEndpoint) CreateLocal(suffix ...string) string {
 	singular := flect.Singularize(endpoint.name)
-	return endpoint.knownLocals.createLocal(singular)
+	return endpoint.knownLocals.createLocal(singular, suffix...)
 }
 
 // WithType creates a new endpoint with a different type

--- a/hack/generator/pkg/astmodel/storage_conversion_factories.go
+++ b/hack/generator/pkg/astmodel/storage_conversion_factories.go
@@ -15,8 +15,9 @@ import (
 )
 
 // StorageTypeConversion generates the AST for a given conversion.
-// reader is an expression to read the original value
-// writer is a function that creates one or more statements to write the converted value
+// reader is an expression to read the original value.
+// writer is a function that accepts an expression for reading a value and creates one or more
+// statements to write that value.
 // Both of these might be complex expressions, possibly involving indexing into arrays or maps.
 type StorageTypeConversion func(reader dst.Expr, writer func(dst.Expr) []dst.Stmt, generationContext *CodeGenerationContext) []dst.Stmt
 
@@ -234,6 +235,8 @@ func assignPrimitiveTypeFromOptionalPrimitiveType(
 //
 // <arr> := make([]<type>, len(<reader>))
 // for <index>, <value> := range <reader> {
+//     // Shadow the loop variable to avoid aliasing
+//     <value> := <value>
 //     <arr>[<index>] := <value> // Or other conversion as required
 // }
 // <writer> = <arr>

--- a/hack/generator/pkg/astmodel/storage_conversion_factories.go
+++ b/hack/generator/pkg/astmodel/storage_conversion_factories.go
@@ -160,7 +160,7 @@ func assignOptionalPrimitiveTypeFromPrimitiveType(
 		return nil
 	}
 
-	copyVar := destinationEndpoint.CreateLocal("Value")
+	copyVar := destinationEndpoint.CreateLocal("", "Value")
 
 	return func(reader dst.Expr, writer dst.Expr, generationContext *CodeGenerationContext) []dst.Stmt {
 		return []dst.Stmt{
@@ -272,7 +272,7 @@ func assignOptionalPrimitiveTypeFromOptionalPrimitiveType(
 		return nil
 	}
 
-	copyVar := destinationEndpoint.CreateLocal("Value")
+	copyVar := destinationEndpoint.CreateLocal("", "Value")
 
 	return func(reader dst.Expr, writer dst.Expr, ctx *CodeGenerationContext) []dst.Stmt {
 
@@ -551,7 +551,7 @@ func assignEnumTypeFromOptionalEnumType(
 		return nil
 	}
 
-	local := destinationEndpoint.CreateLocal("Value")
+	local := destinationEndpoint.CreateLocal("", "Enum")
 
 	return func(reader dst.Expr, writer dst.Expr, ctx *CodeGenerationContext) []dst.Stmt {
 		// Need to check for null and only assign if we have a value
@@ -630,7 +630,7 @@ func assignOptionalEnumTypeFromEnumType(
 		return nil
 	}
 
-	copyVar := destinationEndpoint.CreateLocal("Value")
+	copyVar := destinationEndpoint.CreateLocal("", "Enum")
 
 	return func(reader dst.Expr, writer dst.Expr, ctx *CodeGenerationContext) []dst.Stmt {
 		return []dst.Stmt{
@@ -693,7 +693,7 @@ func assignOptionalEnumTypeFromOptionalEnumType(
 		return nil
 	}
 
-	copyVar := destinationEndpoint.CreateLocal("Value")
+	copyVar := destinationEndpoint.CreateLocal("", "Enum")
 
 	return func(reader dst.Expr, writer dst.Expr, ctx *CodeGenerationContext) []dst.Stmt {
 

--- a/hack/generator/pkg/astmodel/storage_conversion_factories.go
+++ b/hack/generator/pkg/astmodel/storage_conversion_factories.go
@@ -98,8 +98,6 @@ func assignToOptionalType(
 		return nil
 	}
 
-	//copyVar := destinationEndpoint.CreateLocal("", "Temp")
-
 	return func(reader dst.Expr, writer func(dst.Expr) []dst.Stmt, generationContext *CodeGenerationContext) []dst.Stmt {
 		// Create a writer that takes the address of the passed expression
 		// Note that we are dependent on any wrapping conversion to ensure no aliasing occurs

--- a/hack/generator/pkg/astmodel/storage_conversion_factories.go
+++ b/hack/generator/pkg/astmodel/storage_conversion_factories.go
@@ -341,10 +341,9 @@ func assignArrayFromArray(
 
 	return func(reader dst.Expr, writer func(dst.Expr) []dst.Stmt, generationContext *CodeGenerationContext) []dst.Stmt {
 		// We create three obviously related identifiers to use for the conversion
-		id := sourceEndpoint.CreateLocal()
-		itemId := id + "Item"
-		indexId := id + "Index"
-		tempId := id + "List"
+		itemId := sourceEndpoint.CreateLocal("Item")
+		indexId := sourceEndpoint.CreateLocal("Index")
+		tempId := sourceEndpoint.CreateLocal("List")
 
 		declaration := astbuilder.SimpleAssignment(
 			dst.NewIdent(tempId),
@@ -426,10 +425,9 @@ func assignMapFromMap(
 
 	return func(reader dst.Expr, writer func(dst.Expr) []dst.Stmt, generationContext *CodeGenerationContext) []dst.Stmt {
 		// We create three obviously related identifiers to use for the conversion
-		id := sourceEndpoint.CreateLocal()
-		itemId := id + "Value"
-		keyId := id + "Key"
-		tempId := id + "Map"
+		itemId := sourceEndpoint.CreateLocal("Value")
+		keyId := sourceEndpoint.CreateLocal("Key")
+		tempId := sourceEndpoint.CreateLocal("Map")
 
 		declaration := astbuilder.SimpleAssignment(
 			dst.NewIdent(tempId),

--- a/hack/generator/pkg/astmodel/testdata/NastyTest.golden
+++ b/hack/generator/pkg/astmodel/testdata/NastyTest.golden
@@ -15,15 +15,22 @@ func (person Person) ConvertFromVNext(source *vNext.Person) error {
 	// nasty
 	nastyMap := make(map[string][]map[string]bool)
 	for nastyKey, nastyValue := range source.nasty {
-		nasty1List := make([]map[string]bool, len(nastyValue))
-		for nasty1Index, nasty1Item := range nastyValue {
-			nasty2Map := make(map[string]bool)
-			for nasty2Key, nasty2Value := range nasty1Item {
-				nasty2Map[nasty2Key] = nasty2Value
+		// Shadow the loop variable to avoid aliasing
+		nastyValue := nastyValue
+		nastyList := make([]map[string]bool, len(nastyValue))
+		for nastyIndex, nastyItem := range nastyValue {
+			// Shadow the loop variable to avoid aliasing
+			nastyItem := nastyItem
+			nastyMap1 := make(map[string]bool)
+			for nastyKey1, nastyValue1 := range nastyItem {
+				// Shadow the loop variable to avoid aliasing
+				nastyValue1 := nastyValue1
+				nasty := nastyValue1
+				nastyMap1[nastyKey1] = nasty
 			}
-			nasty1List[nasty1Index] = nasty2Map
+			nastyList[nastyIndex] = nastyMap1
 		}
-		nastyMap[nastyKey] = nasty1List
+		nastyMap[nastyKey] = nastyList
 	}
 	person.nasty = nastyMap
 
@@ -37,15 +44,22 @@ func (person Person) ConvertToVNext(destination *vNext.Person) error {
 	// nasty
 	nastyMap := make(map[string][]map[string]bool)
 	for nastyKey, nastyValue := range person.nasty {
-		nasty1List := make([]map[string]bool, len(nastyValue))
-		for nasty1Index, nasty1Item := range nastyValue {
-			nasty2Map := make(map[string]bool)
-			for nasty2Key, nasty2Value := range nasty1Item {
-				nasty2Map[nasty2Key] = nasty2Value
+		// Shadow the loop variable to avoid aliasing
+		nastyValue := nastyValue
+		nastyList := make([]map[string]bool, len(nastyValue))
+		for nastyIndex, nastyItem := range nastyValue {
+			// Shadow the loop variable to avoid aliasing
+			nastyItem := nastyItem
+			nastyMap1 := make(map[string]bool)
+			for nastyKey1, nastyValue1 := range nastyItem {
+				// Shadow the loop variable to avoid aliasing
+				nastyValue1 := nastyValue1
+				nasty := nastyValue1
+				nastyMap1[nastyKey1] = nasty
 			}
-			nasty1List[nasty1Index] = nasty2Map
+			nastyList[nastyIndex] = nastyMap1
 		}
-		nastyMap[nastyKey] = nasty1List
+		nastyMap[nastyKey] = nastyList
 	}
 	destination.nasty = nastyMap
 

--- a/hack/generator/pkg/astmodel/testdata/SetArrayOfOptionalFromArrayOfRequired.golden
+++ b/hack/generator/pkg/astmodel/testdata/SetArrayOfOptionalFromArrayOfRequired.golden
@@ -13,12 +13,14 @@ type Person struct {
 func (person Person) ConvertFromVNext(source *vNext.Person) error {
 
 	// scores
-	score1List := make([]*int, len(source.scores))
-	for score1Index, score1Item := range source.scores {
-		score := score1Item
-		score1List[score1Index] = &score
+	scoreList := make([]*int, len(source.scores))
+	for scoreIndex, scoreItem := range source.scores {
+		// Shadow the loop variable to avoid aliasing
+		scoreItem := scoreItem
+		score := scoreItem
+		scoreList[scoreIndex] = &score
 	}
-	person.scores = score1List
+	person.scores = scoreList
 
 	// No error
 	return nil
@@ -30,11 +32,15 @@ func (person Person) ConvertToVNext(destination *vNext.Person) error {
 	// scores
 	scoreList := make([]int, len(person.scores))
 	for scoreIndex, scoreItem := range person.scores {
+		// Shadow the loop variable to avoid aliasing
+		scoreItem := scoreItem
+		var score int
 		if scoreItem != nil {
-			scoreList[scoreIndex] = *scoreItem
+			score = *scoreItem
 		} else {
-			scoreList[scoreIndex] = 0
+			score = 0
 		}
+		scoreList[scoreIndex] = score
 	}
 	destination.scores = scoreList
 

--- a/hack/generator/pkg/astmodel/testdata/SetArrayOfRequiredFromArrayOfOptional.golden
+++ b/hack/generator/pkg/astmodel/testdata/SetArrayOfRequiredFromArrayOfOptional.golden
@@ -15,11 +15,15 @@ func (person Person) ConvertFromVNext(source *vNext.Person) error {
 	// scores
 	scoreList := make([]int, len(source.scores))
 	for scoreIndex, scoreItem := range source.scores {
+		// Shadow the loop variable to avoid aliasing
+		scoreItem := scoreItem
+		var score int
 		if scoreItem != nil {
-			scoreList[scoreIndex] = *scoreItem
+			score = *scoreItem
 		} else {
-			scoreList[scoreIndex] = 0
+			score = 0
 		}
+		scoreList[scoreIndex] = score
 	}
 	person.scores = scoreList
 
@@ -31,12 +35,14 @@ func (person Person) ConvertFromVNext(source *vNext.Person) error {
 func (person Person) ConvertToVNext(destination *vNext.Person) error {
 
 	// scores
-	score1List := make([]*int, len(person.scores))
-	for score1Index, score1Item := range person.scores {
-		score := score1Item
-		score1List[score1Index] = &score
+	scoreList := make([]*int, len(person.scores))
+	for scoreIndex, scoreItem := range person.scores {
+		// Shadow the loop variable to avoid aliasing
+		scoreItem := scoreItem
+		score := scoreItem
+		scoreList[scoreIndex] = &score
 	}
-	destination.scores = score1List
+	destination.scores = scoreList
 
 	// No error
 	return nil

--- a/hack/generator/pkg/astmodel/testdata/SetArrayOfRequiredFromArrayOfRequired.golden
+++ b/hack/generator/pkg/astmodel/testdata/SetArrayOfRequiredFromArrayOfRequired.golden
@@ -15,7 +15,10 @@ func (person Person) ConvertFromVNext(source *vNext.Person) error {
 	// scores
 	scoreList := make([]int, len(source.scores))
 	for scoreIndex, scoreItem := range source.scores {
-		scoreList[scoreIndex] = scoreItem
+		// Shadow the loop variable to avoid aliasing
+		scoreItem := scoreItem
+		score := scoreItem
+		scoreList[scoreIndex] = score
 	}
 	person.scores = scoreList
 
@@ -29,7 +32,10 @@ func (person Person) ConvertToVNext(destination *vNext.Person) error {
 	// scores
 	scoreList := make([]int, len(person.scores))
 	for scoreIndex, scoreItem := range person.scores {
-		scoreList[scoreIndex] = scoreItem
+		// Shadow the loop variable to avoid aliasing
+		scoreItem := scoreItem
+		score := scoreItem
+		scoreList[scoreIndex] = score
 	}
 	destination.scores = scoreList
 

--- a/hack/generator/pkg/astmodel/testdata/SetIntFromInt.golden
+++ b/hack/generator/pkg/astmodel/testdata/SetIntFromInt.golden
@@ -13,7 +13,8 @@ type Person struct {
 func (person Person) ConvertFromVNext(source *vNext.Person) error {
 
 	// age
-	person.age = source.age
+	age := source.age
+	person.age = age
 
 	// No error
 	return nil
@@ -23,7 +24,8 @@ func (person Person) ConvertFromVNext(source *vNext.Person) error {
 func (person Person) ConvertToVNext(destination *vNext.Person) error {
 
 	// age
-	destination.age = person.age
+	age := person.age
+	destination.age = age
 
 	// No error
 	return nil

--- a/hack/generator/pkg/astmodel/testdata/SetIntFromOptionalInt.golden
+++ b/hack/generator/pkg/astmodel/testdata/SetIntFromOptionalInt.golden
@@ -13,11 +13,13 @@ type Person struct {
 func (person Person) ConvertFromVNext(source *vNext.Person) error {
 
 	// age
+	var age int
 	if source.age != nil {
-		person.age = *source.age
+		age = *source.age
 	} else {
-		person.age = 0
+		age = 0
 	}
+	person.age = age
 
 	// No error
 	return nil

--- a/hack/generator/pkg/astmodel/testdata/SetMapOfOptionalFromMapOfRequired.golden
+++ b/hack/generator/pkg/astmodel/testdata/SetMapOfOptionalFromMapOfRequired.golden
@@ -13,12 +13,14 @@ type Person struct {
 func (person Person) ConvertFromVNext(source *vNext.Person) error {
 
 	// ratings
-	rating1Map := make(map[string]*int)
-	for rating1Key, rating1Value := range source.ratings {
-		rating := rating1Value
-		rating1Map[rating1Key] = &rating
+	ratingMap := make(map[string]*int)
+	for ratingKey, ratingValue := range source.ratings {
+		// Shadow the loop variable to avoid aliasing
+		ratingValue := ratingValue
+		rating := ratingValue
+		ratingMap[ratingKey] = &rating
 	}
-	person.ratings = rating1Map
+	person.ratings = ratingMap
 
 	// No error
 	return nil
@@ -30,11 +32,15 @@ func (person Person) ConvertToVNext(destination *vNext.Person) error {
 	// ratings
 	ratingMap := make(map[string]int)
 	for ratingKey, ratingValue := range person.ratings {
+		// Shadow the loop variable to avoid aliasing
+		ratingValue := ratingValue
+		var rating int
 		if ratingValue != nil {
-			ratingMap[ratingKey] = *ratingValue
+			rating = *ratingValue
 		} else {
-			ratingMap[ratingKey] = 0
+			rating = 0
 		}
+		ratingMap[ratingKey] = rating
 	}
 	destination.ratings = ratingMap
 

--- a/hack/generator/pkg/astmodel/testdata/SetMapOfRequiredFromMapOfOptional.golden
+++ b/hack/generator/pkg/astmodel/testdata/SetMapOfRequiredFromMapOfOptional.golden
@@ -15,11 +15,15 @@ func (person Person) ConvertFromVNext(source *vNext.Person) error {
 	// ratings
 	ratingMap := make(map[string]int)
 	for ratingKey, ratingValue := range source.ratings {
+		// Shadow the loop variable to avoid aliasing
+		ratingValue := ratingValue
+		var rating int
 		if ratingValue != nil {
-			ratingMap[ratingKey] = *ratingValue
+			rating = *ratingValue
 		} else {
-			ratingMap[ratingKey] = 0
+			rating = 0
 		}
+		ratingMap[ratingKey] = rating
 	}
 	person.ratings = ratingMap
 
@@ -31,12 +35,14 @@ func (person Person) ConvertFromVNext(source *vNext.Person) error {
 func (person Person) ConvertToVNext(destination *vNext.Person) error {
 
 	// ratings
-	rating1Map := make(map[string]*int)
-	for rating1Key, rating1Value := range person.ratings {
-		rating := rating1Value
-		rating1Map[rating1Key] = &rating
+	ratingMap := make(map[string]*int)
+	for ratingKey, ratingValue := range person.ratings {
+		// Shadow the loop variable to avoid aliasing
+		ratingValue := ratingValue
+		rating := ratingValue
+		ratingMap[ratingKey] = &rating
 	}
-	destination.ratings = rating1Map
+	destination.ratings = ratingMap
 
 	// No error
 	return nil

--- a/hack/generator/pkg/astmodel/testdata/SetMapOfRequiredFromMapOfRequired.golden
+++ b/hack/generator/pkg/astmodel/testdata/SetMapOfRequiredFromMapOfRequired.golden
@@ -15,7 +15,10 @@ func (person Person) ConvertFromVNext(source *vNext.Person) error {
 	// ratings
 	ratingMap := make(map[string]int)
 	for ratingKey, ratingValue := range source.ratings {
-		ratingMap[ratingKey] = ratingValue
+		// Shadow the loop variable to avoid aliasing
+		ratingValue := ratingValue
+		rating := ratingValue
+		ratingMap[ratingKey] = rating
 	}
 	person.ratings = ratingMap
 
@@ -29,7 +32,10 @@ func (person Person) ConvertToVNext(destination *vNext.Person) error {
 	// ratings
 	ratingMap := make(map[string]int)
 	for ratingKey, ratingValue := range person.ratings {
-		ratingMap[ratingKey] = ratingValue
+		// Shadow the loop variable to avoid aliasing
+		ratingValue := ratingValue
+		rating := ratingValue
+		ratingMap[ratingKey] = rating
 	}
 	destination.ratings = ratingMap
 

--- a/hack/generator/pkg/astmodel/testdata/SetOptionalEnumFromOptionalEnum.golden
+++ b/hack/generator/pkg/astmodel/testdata/SetOptionalEnumFromOptionalEnum.golden
@@ -13,13 +13,13 @@ type Person struct {
 func (person Person) ConvertFromVNext(source *vNext.Person) error {
 
 	// release
+	var release Bucket
 	if source.release != nil {
-		// Copy to a local to avoid aliasing
-		release := Bucket(*source.release)
-		person.release = &release
+		release = Bucket(*source.release)
 	} else {
-		person.release = Bucket("")
+		release = Bucket("")
 	}
+	person.release = &release
 
 	// No error
 	return nil
@@ -29,13 +29,13 @@ func (person Person) ConvertFromVNext(source *vNext.Person) error {
 func (person Person) ConvertToVNext(destination *vNext.Person) error {
 
 	// release
+	var release Container
 	if person.release != nil {
-		// Copy to a local to avoid aliasing
-		release := Container(*person.release)
-		destination.release = &release
+		release = Container(*person.release)
 	} else {
-		destination.release = Container("")
+		release = Container("")
 	}
+	destination.release = &release
 
 	// No error
 	return nil

--- a/hack/generator/pkg/astmodel/testdata/SetOptionalEnumFromRequiredEnum.golden
+++ b/hack/generator/pkg/astmodel/testdata/SetOptionalEnumFromRequiredEnum.golden
@@ -24,12 +24,13 @@ func (person Person) ConvertFromVNext(source *vNext.Person) error {
 func (person Person) ConvertToVNext(destination *vNext.Person) error {
 
 	// release
+	var release Container
 	if person.release != nil {
-		release := Container(*person.release)
-		destination.release = release
+		release = Container(*person.release)
 	} else {
-		destination.release = Container("")
+		release = Container("")
 	}
+	destination.release = release
 
 	// No error
 	return nil

--- a/hack/generator/pkg/astmodel/testdata/SetOptionalObjectFromOptionalObject.golden
+++ b/hack/generator/pkg/astmodel/testdata/SetOptionalObjectFromOptionalObject.golden
@@ -13,16 +13,14 @@ type Person struct {
 func (person Person) ConvertFromVNext(source *vNext.Person) error {
 
 	// role
+	var role Release
 	if source.role != nil {
-		var role Release
-		err := role.ConvertFromVNext(source.role)
+		err := role.ConvertFromVNext(&source.role)
 		if err != nil {
 			return errors.Wrap(err, "populating role from role, calling ConvertFromVNext()")
 		}
-		person.role = &role
-	} else {
-		person.role = nil
 	}
+	person.role = &role
 
 	// No error
 	return nil
@@ -32,16 +30,14 @@ func (person Person) ConvertFromVNext(source *vNext.Person) error {
 func (person Person) ConvertToVNext(destination *vNext.Person) error {
 
 	// role
+	var role vNext.Release
 	if person.role != nil {
-		var role vNext.Release
 		err := person.role.ConvertToVNext(role)
 		if err != nil {
 			return errors.Wrap(err, "populating role from role, calling ConvertToVNext()")
 		}
-		destination.role = &role
-	} else {
-		destination.role = nil
 	}
+	destination.role = &role
 
 	// No error
 	return nil

--- a/hack/generator/pkg/astmodel/testdata/SetOptionalStringFromOptionalString.golden
+++ b/hack/generator/pkg/astmodel/testdata/SetOptionalStringFromOptionalString.golden
@@ -13,13 +13,13 @@ type Person struct {
 func (person Person) ConvertFromVNext(source *vNext.Person) error {
 
 	// name
+	var name string
 	if source.name != nil {
-		// Copy to a local to avoid aliasing
-		name := *source.name
-		person.name = &name
+		name = *source.name
 	} else {
-		person.name = nil
+		name = ""
 	}
+	person.name = &name
 
 	// No error
 	return nil
@@ -29,13 +29,13 @@ func (person Person) ConvertFromVNext(source *vNext.Person) error {
 func (person Person) ConvertToVNext(destination *vNext.Person) error {
 
 	// name
+	var name string
 	if person.name != nil {
-		// Copy to a local to avoid aliasing
-		name := *person.name
-		destination.name = &name
+		name = *person.name
 	} else {
-		destination.name = nil
+		name = ""
 	}
+	destination.name = &name
 
 	// No error
 	return nil

--- a/hack/generator/pkg/astmodel/testdata/SetOptionalStringFromString.golden
+++ b/hack/generator/pkg/astmodel/testdata/SetOptionalStringFromString.golden
@@ -24,11 +24,13 @@ func (person Person) ConvertFromVNext(source *vNext.Person) error {
 func (person Person) ConvertToVNext(destination *vNext.Person) error {
 
 	// name
+	var name string
 	if person.name != nil {
-		destination.name = *person.name
+		name = *person.name
 	} else {
-		destination.name = ""
+		name = ""
 	}
+	destination.name = name
 
 	// No error
 	return nil

--- a/hack/generator/pkg/astmodel/testdata/SetRequiredEnumFromOptionalEnum.golden
+++ b/hack/generator/pkg/astmodel/testdata/SetRequiredEnumFromOptionalEnum.golden
@@ -13,12 +13,13 @@ type Person struct {
 func (person Person) ConvertFromVNext(source *vNext.Person) error {
 
 	// release
+	var release Bucket
 	if source.release != nil {
-		release := Bucket(*source.release)
-		person.release = release
+		release = Bucket(*source.release)
 	} else {
-		person.release = Bucket("")
+		release = Bucket("")
 	}
+	person.release = release
 
 	// No error
 	return nil

--- a/hack/generator/pkg/astmodel/testdata/SetRequiredEnumFromRequiredEnum.golden
+++ b/hack/generator/pkg/astmodel/testdata/SetRequiredEnumFromRequiredEnum.golden
@@ -13,7 +13,8 @@ type Person struct {
 func (person Person) ConvertFromVNext(source *vNext.Person) error {
 
 	// release
-	person.release = Bucket(source.release)
+	release := Bucket(source.release)
+	person.release = release
 
 	// No error
 	return nil
@@ -23,7 +24,8 @@ func (person Person) ConvertFromVNext(source *vNext.Person) error {
 func (person Person) ConvertToVNext(destination *vNext.Person) error {
 
 	// release
-	destination.release = Container(person.release)
+	release := Container(person.release)
+	destination.release = release
 
 	// No error
 	return nil

--- a/hack/generator/pkg/astmodel/testdata/SetRequiredObjectFromOptionalObject.golden
+++ b/hack/generator/pkg/astmodel/testdata/SetRequiredObjectFromOptionalObject.golden
@@ -15,7 +15,7 @@ func (person Person) ConvertFromVNext(source *vNext.Person) error {
 	// role
 	var role Release
 	if source.role != nil {
-		err := role.ConvertFromVNext(source.role)
+		err := role.ConvertFromVNext(&source.role)
 		if err != nil {
 			return errors.Wrap(err, "populating role from role, calling ConvertFromVNext()")
 		}
@@ -31,7 +31,7 @@ func (person Person) ConvertToVNext(destination *vNext.Person) error {
 
 	// role
 	var role vNext.Release
-	err := person.role.ConvertToVNext(&role)
+	err := person.role.ConvertToVNext(role)
 	if err != nil {
 		return errors.Wrap(err, "populating role from role, calling ConvertToVNext()")
 	}

--- a/hack/generator/pkg/astmodel/testdata/SetRequiredObjectFromRequiredObject.golden
+++ b/hack/generator/pkg/astmodel/testdata/SetRequiredObjectFromRequiredObject.golden
@@ -14,7 +14,7 @@ func (person Person) ConvertFromVNext(source *vNext.Person) error {
 
 	// role
 	var role Release
-	err := role.ConvertFromVNext(source.role)
+	err := role.ConvertFromVNext(&source.role)
 	if err != nil {
 		return errors.Wrap(err, "populating role from role, calling ConvertFromVNext()")
 	}

--- a/hack/generator/pkg/astmodel/testdata/SetStringFromOptionalString.golden
+++ b/hack/generator/pkg/astmodel/testdata/SetStringFromOptionalString.golden
@@ -13,11 +13,13 @@ type Person struct {
 func (person Person) ConvertFromVNext(source *vNext.Person) error {
 
 	// name
+	var name string
 	if source.name != nil {
-		person.name = *source.name
+		name = *source.name
 	} else {
-		person.name = ""
+		name = ""
 	}
+	person.name = name
 
 	// No error
 	return nil

--- a/hack/generator/pkg/astmodel/testdata/SetStringFromString.golden
+++ b/hack/generator/pkg/astmodel/testdata/SetStringFromString.golden
@@ -13,7 +13,8 @@ type Person struct {
 func (person Person) ConvertFromVNext(source *vNext.Person) error {
 
 	// name
-	person.name = source.name
+	name := source.name
+	person.name = name
 
 	// No error
 	return nil
@@ -23,7 +24,8 @@ func (person Person) ConvertFromVNext(source *vNext.Person) error {
 func (person Person) ConvertToVNext(destination *vNext.Person) error {
 
 	// name
-	destination.name = person.name
+	name := person.name
+	destination.name = name
 
 	// No error
 	return nil


### PR DESCRIPTION
Handle assignments _**to optional**_ destination fields once, instead of requiring each kind of property conversion to handle it independently. This halves the number of conversion factory methods we need.

Also

* Modify both Array and Map generation to create a local shadow of the loop variable to avoid aliasing errors during conversions
* Modify handling of optional source fields to create local variables for clarity
* Change warnings to level 3 logs to reduce noise
* Fix bug where potential suffixes for local variables were not being used
* Introduce `astbuilder.Statements()` for building `[]dst.Stmt` from a sequence of statements
