### PR TITLE
Rename AddWithEqualityCheck to AddAllowDuplicates

### DIFF
--- a/hack/generator/pkg/astmodel/type_walker.go
+++ b/hack/generator/pkg/astmodel/type_walker.go
@@ -110,7 +110,7 @@ func (t *TypeWalker) visitTypeName(this *TypeVisitor, it TypeName, ctx interface
 
 	delete(t.state.processing, def.Name())
 
-	err = t.state.result.AddWithEqualityCheck(updatedDef)
+	err = t.state.result.AddAllowDuplicates(updatedDef)
 	if err != nil {
 		return nil, err
 	}

--- a/hack/generator/pkg/astmodel/types.go
+++ b/hack/generator/pkg/astmodel/types.go
@@ -54,10 +54,10 @@ func (types Types) AddTypes(otherTypes Types) {
 	}
 }
 
-// AddWithEqualityCheck attempts to add the specified definition to the types collection.
+// AddAllowDuplicates attempts to add the specified definition to the types collection.
 // Multiple adds of a type with the same shape are allowed, but attempting to add two
 // types with the same name but different shape will trigger an error.
-func (types Types) AddWithEqualityCheck(def TypeDefinition) error {
+func (types Types) AddAllowDuplicates(def TypeDefinition) error {
 	if !types.Contains(def.Name()) {
 		types.Add(def)
 		return nil


### PR DESCRIPTION
  - Other Add methods also now have the "New" suffix to match.
  - AddWithEqualityCheck renamed to Add.