### PR TITLE
Fix config for removing ResourceCopy property

### DIFF
--- a/hack/generator/azure-arm.yaml
+++ b/hack/generator/azure-arm.yaml
@@ -190,7 +190,7 @@ typeTransformers:
     property: Copy
     ifType:
       group: deploymenttemplate
-      version: v*api20150101
+      version: v1alpha1api20150101
       name: ResourceCopy
       optional: true
     remove: true


### PR DESCRIPTION
Currently the config does not accept wildcards, so this change hardcodes the version for now.