### PR TITLE
Debug descriptions for types

### DIFF
--- a/hack/generator/pkg/astmodel/allof_type.go
+++ b/hack/generator/pkg/astmodel/allof_type.go
@@ -159,3 +159,19 @@ func (allOf *AllOfType) String() string {
 
 	return fmt.Sprintf("(allOf: %s)", strings.Join(subStrings, ", "))
 }
+
+// DebugDescription adds a description of the current AnyOf type to the passed builder
+// builder receives the full description, including nested types
+// types is a dictionary for resolving named types
+func (allOf *AllOfType) WriteDebugDescription(builder *strings.Builder, types Types) {
+	builder.WriteString("AllOf[")
+	first := true
+	allOf.types.ForEach(func(t Type, ix int) {
+		if !first {
+			builder.WriteString("|")
+		}
+		t.WriteDebugDescription(builder, types)
+		first = false
+	})
+	builder.WriteString("]")
+}

--- a/hack/generator/pkg/astmodel/allof_type.go
+++ b/hack/generator/pkg/astmodel/allof_type.go
@@ -165,13 +165,11 @@ func (allOf *AllOfType) String() string {
 // types is a dictionary for resolving named types
 func (allOf *AllOfType) WriteDebugDescription(builder *strings.Builder, types Types) {
 	builder.WriteString("AllOf[")
-	first := true
 	allOf.types.ForEach(func(t Type, ix int) {
-		if !first {
+		if ix > 0 {
 			builder.WriteString("|")
 		}
 		t.WriteDebugDescription(builder, types)
-		first = false
 	})
 	builder.WriteString("]")
 }

--- a/hack/generator/pkg/astmodel/allof_type.go
+++ b/hack/generator/pkg/astmodel/allof_type.go
@@ -160,7 +160,7 @@ func (allOf *AllOfType) String() string {
 	return fmt.Sprintf("(allOf: %s)", strings.Join(subStrings, ", "))
 }
 
-// DebugDescription adds a description of the current AnyOf type to the passed builder
+// WriteDebugDescription adds a description of the current AnyOf type to the passed builder
 // builder receives the full description, including nested types
 // types is a dictionary for resolving named types
 func (allOf *AllOfType) WriteDebugDescription(builder *strings.Builder, types Types) {

--- a/hack/generator/pkg/astmodel/array_type.go
+++ b/hack/generator/pkg/astmodel/array_type.go
@@ -74,7 +74,7 @@ func (array *ArrayType) String() string {
 	return fmt.Sprintf("[]%s", array.element.String())
 }
 
-// DebugDescription adds a description of the current array type to the passed builder
+// WriteDebugDescription adds a description of the current array type to the passed builder
 // builder receives the full description, including nested types
 // types is a dictionary for resolving named types
 func (array *ArrayType) WriteDebugDescription(builder *strings.Builder, types Types) {

--- a/hack/generator/pkg/astmodel/array_type.go
+++ b/hack/generator/pkg/astmodel/array_type.go
@@ -7,6 +7,8 @@ package astmodel
 
 import (
 	"fmt"
+	"strings"
+
 	"github.com/dave/dst"
 )
 
@@ -70,4 +72,13 @@ func (array *ArrayType) Equals(t Type) bool {
 // String implements fmt.Stringer
 func (array *ArrayType) String() string {
 	return fmt.Sprintf("[]%s", array.element.String())
+}
+
+// DebugDescription adds a description of the current array type to the passed builder
+// builder receives the full description, including nested types
+// types is a dictionary for resolving named types
+func (array *ArrayType) WriteDebugDescription(builder *strings.Builder, types Types) {
+	builder.WriteString("Array[")
+	array.element.WriteDebugDescription(builder, types)
+	builder.WriteString("]")
 }

--- a/hack/generator/pkg/astmodel/enum_type.go
+++ b/hack/generator/pkg/astmodel/enum_type.go
@@ -184,7 +184,7 @@ func (enum *EnumType) String() string {
 	return fmt.Sprintf("(enum: %s)", enum.baseType.String())
 }
 
-// DebugDescription adds a description of the current enum type, including option names, to the
+// WriteDebugDescription adds a description of the current enum type, including option names, to the
 // passed builder
 // builder receives the full description
 // types is a dictionary for resolving named types

--- a/hack/generator/pkg/astmodel/enum_type.go
+++ b/hack/generator/pkg/astmodel/enum_type.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"go/token"
 	"sort"
+	"strings"
 
 	"github.com/Azure/k8s-infra/hack/generator/pkg/astbuilder"
 	"github.com/dave/dst"
@@ -181,4 +182,23 @@ func GetEnumValueId(name string, value EnumValue) string {
 // String implements fmt.Stringer
 func (enum *EnumType) String() string {
 	return fmt.Sprintf("(enum: %s)", enum.baseType.String())
+}
+
+// DebugDescription adds a description of the current enum type, including option names, to the
+// passed builder
+// builder receives the full description
+// types is a dictionary for resolving named types
+func (enum *EnumType) WriteDebugDescription(builder *strings.Builder, types Types) {
+	builder.WriteString("Enum[")
+	enum.baseType.WriteDebugDescription(builder, types)
+	builder.WriteString(":")
+	first := true
+	for _, v := range enum.options {
+		if !first {
+			builder.WriteString("|")
+		}
+		builder.WriteString(v.Identifier)
+		first = false
+	}
+	builder.WriteString("]")
 }

--- a/hack/generator/pkg/astmodel/enum_type.go
+++ b/hack/generator/pkg/astmodel/enum_type.go
@@ -192,13 +192,11 @@ func (enum *EnumType) WriteDebugDescription(builder *strings.Builder, types Type
 	builder.WriteString("Enum[")
 	enum.baseType.WriteDebugDescription(builder, types)
 	builder.WriteString(":")
-	first := true
-	for _, v := range enum.options {
-		if !first {
+	for i, v := range enum.options {
+		if i > 0 {
 			builder.WriteString("|")
 		}
 		builder.WriteString(v.Identifier)
-		first = false
 	}
 	builder.WriteString("]")
 }

--- a/hack/generator/pkg/astmodel/errored_type.go
+++ b/hack/generator/pkg/astmodel/errored_type.go
@@ -7,6 +7,7 @@ package astmodel
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/dave/dst"
 	"github.com/pkg/errors"
@@ -155,4 +156,24 @@ func (e *ErroredType) String() string {
 // Unwrap returns the type contained within the error type
 func (e *ErroredType) Unwrap() Type {
 	return e.inner
+}
+
+// DebugDescription adds a description of the current errored type to the passed builder,
+// builder receives the full description, including the nested type, errors and warnings
+// types is a dictionary for resolving named types
+func (e *ErroredType) WriteDebugDescription(builder *strings.Builder, types Types) {
+	builder.WriteString("Error[")
+	e.inner.WriteDebugDescription(builder, types)
+
+	for _, e := range e.errors {
+		builder.WriteString("|")
+		builder.WriteString(e)
+	}
+
+	for _, w := range e.warnings {
+		builder.WriteString("|")
+		builder.WriteString(w)
+	}
+
+	builder.WriteString("]")
 }

--- a/hack/generator/pkg/astmodel/errored_type.go
+++ b/hack/generator/pkg/astmodel/errored_type.go
@@ -158,7 +158,7 @@ func (e *ErroredType) Unwrap() Type {
 	return e.inner
 }
 
-// DebugDescription adds a description of the current errored type to the passed builder,
+// WriteDebugDescription adds a description of the current errored type to the passed builder,
 // builder receives the full description, including the nested type, errors and warnings
 // types is a dictionary for resolving named types
 func (e *ErroredType) WriteDebugDescription(builder *strings.Builder, types Types) {

--- a/hack/generator/pkg/astmodel/flagged_type.go
+++ b/hack/generator/pkg/astmodel/flagged_type.go
@@ -176,7 +176,7 @@ func (ft *FlaggedType) Unwrap() Type {
 	return ft.element
 }
 
-// DebugDescription adds a description of the current type to the passed builder
+// WriteDebugDescription adds a description of the current type to the passed builder
 // builder receives the full description, including nested types
 // types is a dictionary for resolving named types
 func (ft *FlaggedType) WriteDebugDescription(builder *strings.Builder, types Types) {

--- a/hack/generator/pkg/astmodel/flagged_type.go
+++ b/hack/generator/pkg/astmodel/flagged_type.go
@@ -175,3 +175,15 @@ func (ft *FlaggedType) String() string {
 func (ft *FlaggedType) Unwrap() Type {
 	return ft.element
 }
+
+// DebugDescription adds a description of the current type to the passed builder
+// builder receives the full description, including nested types
+// types is a dictionary for resolving named types
+func (ft *FlaggedType) WriteDebugDescription(builder *strings.Builder, types Types) {
+	ft.element.WriteDebugDescription(builder, types)
+	for f := range ft.flags {
+		builder.WriteString("[#")
+		builder.WriteString(f.String())
+		builder.WriteString("]")
+	}
+}

--- a/hack/generator/pkg/astmodel/map_type.go
+++ b/hack/generator/pkg/astmodel/map_type.go
@@ -7,6 +7,8 @@ package astmodel
 
 import (
 	"fmt"
+	"strings"
+
 	"github.com/dave/dst"
 )
 
@@ -85,4 +87,14 @@ func (m *MapType) Equals(t Type) bool {
 // String implements fmt.Stringer
 func (m *MapType) String() string {
 	return fmt.Sprintf("map[%s]%s", m.key.String(), m.value.String())
+}
+
+// DebugDescription adds a description of the current type to the passed builder
+// builder receives the full description, including nested types
+// types is a dictionary for resolving named types
+func (m *MapType) WriteDebugDescription(builder *strings.Builder, types Types) {
+	builder.WriteString("Map[")
+	m.key.WriteDebugDescription(builder, types)
+	builder.WriteString("]")
+	m.value.WriteDebugDescription(builder, types)
 }

--- a/hack/generator/pkg/astmodel/map_type.go
+++ b/hack/generator/pkg/astmodel/map_type.go
@@ -89,7 +89,7 @@ func (m *MapType) String() string {
 	return fmt.Sprintf("map[%s]%s", m.key.String(), m.value.String())
 }
 
-// DebugDescription adds a description of the current type to the passed builder
+// WriteDebugDescription adds a description of the current type to the passed builder
 // builder receives the full description, including nested types
 // types is a dictionary for resolving named types
 func (m *MapType) WriteDebugDescription(builder *strings.Builder, types Types) {

--- a/hack/generator/pkg/astmodel/object_type.go
+++ b/hack/generator/pkg/astmodel/object_type.go
@@ -528,7 +528,7 @@ func extractEmbeddedTypeName(t Type) (TypeName, error) {
 	return TypeName{}, errors.Errorf("embedded property type must be TypeName, was: %T", t)
 }
 
-// DebugDescription adds a description of the current type to the passed builder
+// WriteDebugDescription adds a description of the current type to the passed builder
 // builder receives the full description, including nested types
 // types is a dictionary for resolving named types
 func (objectType *ObjectType) WriteDebugDescription(builder *strings.Builder, types Types) {

--- a/hack/generator/pkg/astmodel/object_type.go
+++ b/hack/generator/pkg/astmodel/object_type.go
@@ -8,6 +8,7 @@ package astmodel
 import (
 	"go/token"
 	"sort"
+	"strings"
 
 	"github.com/Azure/k8s-infra/hack/generator/pkg/astbuilder"
 	"github.com/dave/dst"
@@ -525,4 +526,11 @@ func extractEmbeddedTypeName(t Type) (TypeName, error) {
 	}
 
 	return TypeName{}, errors.Errorf("embedded property type must be TypeName, was: %T", t)
+}
+
+// DebugDescription adds a description of the current type to the passed builder
+// builder receives the full description, including nested types
+// types is a dictionary for resolving named types
+func (objectType *ObjectType) WriteDebugDescription(builder *strings.Builder, types Types) {
+	builder.WriteString("Object")
 }

--- a/hack/generator/pkg/astmodel/oneof_type.go
+++ b/hack/generator/pkg/astmodel/oneof_type.go
@@ -123,3 +123,19 @@ func (oneOf *OneOfType) String() string {
 
 	return fmt.Sprintf("(oneOf: %s)", strings.Join(subStrings, ", "))
 }
+
+// DebugDescription adds a description of the current type to the passed builder
+// builder receives the full description, including nested types
+// types is a dictionary for resolving named types
+func (oneOf *OneOfType) WriteDebugDescription(builder *strings.Builder, types Types) {
+	builder.WriteString("OneOf[")
+	first := true
+	oneOf.types.ForEach(func(t Type, ix int) {
+		if !first {
+			builder.WriteString("|")
+		}
+		t.WriteDebugDescription(builder, types)
+		first = false
+	})
+	builder.WriteString("]")
+}

--- a/hack/generator/pkg/astmodel/oneof_type.go
+++ b/hack/generator/pkg/astmodel/oneof_type.go
@@ -124,7 +124,7 @@ func (oneOf *OneOfType) String() string {
 	return fmt.Sprintf("(oneOf: %s)", strings.Join(subStrings, ", "))
 }
 
-// DebugDescription adds a description of the current type to the passed builder
+// WriteDebugDescription adds a description of the current type to the passed builder
 // builder receives the full description, including nested types
 // types is a dictionary for resolving named types
 func (oneOf *OneOfType) WriteDebugDescription(builder *strings.Builder, types Types) {

--- a/hack/generator/pkg/astmodel/oneof_type.go
+++ b/hack/generator/pkg/astmodel/oneof_type.go
@@ -129,13 +129,11 @@ func (oneOf *OneOfType) String() string {
 // types is a dictionary for resolving named types
 func (oneOf *OneOfType) WriteDebugDescription(builder *strings.Builder, types Types) {
 	builder.WriteString("OneOf[")
-	first := true
 	oneOf.types.ForEach(func(t Type, ix int) {
-		if !first {
+		if ix > 0 {
 			builder.WriteString("|")
 		}
 		t.WriteDebugDescription(builder, types)
-		first = false
 	})
 	builder.WriteString("]")
 }

--- a/hack/generator/pkg/astmodel/optional_type.go
+++ b/hack/generator/pkg/astmodel/optional_type.go
@@ -7,6 +7,7 @@ package astmodel
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/dave/dst"
 )
@@ -109,4 +110,13 @@ func (optional *OptionalType) String() string {
 // Unwrap returns the type contained within the wrapper type
 func (optional *OptionalType) Unwrap() Type {
 	return optional.element
+}
+
+// DebugDescription adds a description of the current type to the passed builder
+// builder receives the full description, including nested types
+// types is a dictionary for resolving named types
+func (optional *OptionalType) WriteDebugDescription(builder *strings.Builder, types Types) {
+	builder.WriteString("Optional[")
+	optional.element.WriteDebugDescription(builder, types)
+	builder.WriteString("]")
 }

--- a/hack/generator/pkg/astmodel/optional_type.go
+++ b/hack/generator/pkg/astmodel/optional_type.go
@@ -112,7 +112,7 @@ func (optional *OptionalType) Unwrap() Type {
 	return optional.element
 }
 
-// DebugDescription adds a description of the current type to the passed builder
+// WriteDebugDescription adds a description of the current type to the passed builder
 // builder receives the full description, including nested types
 // types is a dictionary for resolving named types
 func (optional *OptionalType) WriteDebugDescription(builder *strings.Builder, types Types) {

--- a/hack/generator/pkg/astmodel/primitive_type.go
+++ b/hack/generator/pkg/astmodel/primitive_type.go
@@ -88,7 +88,7 @@ func (prim *PrimitiveType) String() string {
 	return prim.name
 }
 
-// DebugDescription adds a description of this primitive type to the passed builder
+// WriteDebugDescription adds a description of this primitive type to the passed builder
 func (prim *PrimitiveType) WriteDebugDescription(builder *strings.Builder, _ Types) {
 	builder.WriteString(prim.name)
 }

--- a/hack/generator/pkg/astmodel/primitive_type.go
+++ b/hack/generator/pkg/astmodel/primitive_type.go
@@ -7,6 +7,7 @@ package astmodel
 
 import (
 	"github.com/dave/dst"
+	"strings"
 )
 
 // PrimitiveType represents a Go primitive type
@@ -85,4 +86,9 @@ func (prim *PrimitiveType) Name() string {
 // String implements fmt.Stringer
 func (prim *PrimitiveType) String() string {
 	return prim.name
+}
+
+// DebugDescription adds a description of this primitive type to the passed builder
+func (prim *PrimitiveType) WriteDebugDescription(builder *strings.Builder, _ Types) {
+	builder.WriteString(prim.name)
 }

--- a/hack/generator/pkg/astmodel/resource.go
+++ b/hack/generator/pkg/astmodel/resource.go
@@ -452,7 +452,7 @@ func (resource *ResourceType) HasTestCases() bool {
 	return len(resource.testcases) > 0
 }
 
-// DebugDescription adds a description of the current type to the passed builder
+// WriteDebugDescription adds a description of the current type to the passed builder
 // builder receives the full description, including nested types
 // types is a dictionary for resolving named types
 func (resource *ResourceType) WriteDebugDescription(builder *strings.Builder, types Types) {

--- a/hack/generator/pkg/astmodel/resource.go
+++ b/hack/generator/pkg/astmodel/resource.go
@@ -451,3 +451,14 @@ func (resource *ResourceType) copy() *ResourceType {
 func (resource *ResourceType) HasTestCases() bool {
 	return len(resource.testcases) > 0
 }
+
+// DebugDescription adds a description of the current type to the passed builder
+// builder receives the full description, including nested types
+// types is a dictionary for resolving named types
+func (resource *ResourceType) WriteDebugDescription(builder *strings.Builder, types Types) {
+	builder.WriteString("Resource[spec:")
+	resource.spec.WriteDebugDescription(builder, types)
+	builder.WriteString("|status:")
+	resource.status.WriteDebugDescription(builder, types)
+	builder.WriteString("]")
+}

--- a/hack/generator/pkg/astmodel/type.go
+++ b/hack/generator/pkg/astmodel/type.go
@@ -41,7 +41,7 @@ type Type interface {
 	// This doesn't need to be a full representation of the type.
 	fmt.Stringer
 
-	// DebugDescription adds a description of the current type to the passed builder
+	// WriteDebugDescription adds a description of the current type to the passed builder
 	// builder receives the full description, including nested types
 	// types is a dictionary for resolving named types
 	WriteDebugDescription(builder *strings.Builder, types Types)

--- a/hack/generator/pkg/astmodel/type.go
+++ b/hack/generator/pkg/astmodel/type.go
@@ -7,6 +7,7 @@ package astmodel
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/dave/dst"
 )
@@ -39,6 +40,11 @@ type Type interface {
 	// Make sure all Types have a printable version for debugging/user info.
 	// This doesn't need to be a full representation of the type.
 	fmt.Stringer
+
+	// DebugDescription adds a description of the current type to the passed builder
+	// builder receives the full description, including nested types
+	// types is a dictionary for resolving named types
+	WriteDebugDescription(builder *strings.Builder, types Types)
 }
 
 // IgnoringErrors returns the type stripped of any ErroredType wrapper

--- a/hack/generator/pkg/astmodel/type_name.go
+++ b/hack/generator/pkg/astmodel/type_name.go
@@ -178,5 +178,7 @@ func (typeName TypeName) WriteDebugDescription(builder *strings.Builder, types T
 
 	if definition, ok := types[typeName]; ok {
 		definition.Type().WriteDebugDescription(builder, types)
+	} else {
+		builder.WriteString("NOTDEFINED")
 	}
 }

--- a/hack/generator/pkg/astmodel/type_name.go
+++ b/hack/generator/pkg/astmodel/type_name.go
@@ -174,11 +174,13 @@ func (typeName TypeName) WriteDebugDescription(builder *strings.Builder, types T
 	builder.WriteString(typeName.PackageReference.String())
 	builder.WriteString("/")
 	builder.WriteString(typeName.name)
-	builder.WriteString(":")
 
-	if definition, ok := types[typeName]; ok {
-		definition.Type().WriteDebugDescription(builder, types)
-	} else {
-		builder.WriteString("NOTDEFINED")
+	if _, ok := typeName.PackageReference.AsLocalPackage(); ok {
+		builder.WriteString(":")
+		if definition, ok := types[typeName]; ok {
+			definition.Type().WriteDebugDescription(builder, types)
+		} else {
+			builder.WriteString("NOTDEFINED")
+		}
 	}
 }

--- a/hack/generator/pkg/astmodel/type_name.go
+++ b/hack/generator/pkg/astmodel/type_name.go
@@ -166,3 +166,17 @@ func (typeName TypeName) Plural() TypeName {
 
 	return MakeTypeName(typeName.PackageReference, flect.Pluralize(typeName.name))
 }
+
+// DebugDescription adds a description of the current type to the passed builder
+// builder receives the full description, including nested types
+// types is a dictionary for resolving named types
+func (typeName TypeName) WriteDebugDescription(builder *strings.Builder, types Types) {
+	builder.WriteString(typeName.PackageReference.String())
+	builder.WriteString("/")
+	builder.WriteString(typeName.name)
+	builder.WriteString(":")
+
+	if definition, ok := types[typeName]; ok {
+		definition.Type().WriteDebugDescription(builder, types)
+	}
+}

--- a/hack/generator/pkg/astmodel/type_name.go
+++ b/hack/generator/pkg/astmodel/type_name.go
@@ -167,7 +167,7 @@ func (typeName TypeName) Plural() TypeName {
 	return MakeTypeName(typeName.PackageReference, flect.Pluralize(typeName.name))
 }
 
-// DebugDescription adds a description of the current type to the passed builder
+// WriteDebugDescription adds a description of the current type to the passed builder
 // builder receives the full description, including nested types
 // types is a dictionary for resolving named types
 func (typeName TypeName) WriteDebugDescription(builder *strings.Builder, types Types) {

--- a/hack/generator/pkg/astmodel/type_test.go
+++ b/hack/generator/pkg/astmodel/type_test.go
@@ -39,6 +39,8 @@ func TestWriteDebugDescription(t *testing.T) {
 		{"String", StringType, "string"},
 		{"OptionalInteger", NewOptionalType(IntType), "Optional[int]"},
 		{"OptionalString", NewOptionalType(StringType), "Optional[string]"},
+		{"ArrayOfString", NewArrayType(StringType), "Array[string]"},
+		{"ArrayOfOptionalString", NewArrayType(NewOptionalType(StringType)), "Array[Optional[string]]"},
 	}
 
 	for _, c := range cases {

--- a/hack/generator/pkg/astmodel/type_test.go
+++ b/hack/generator/pkg/astmodel/type_test.go
@@ -37,6 +37,8 @@ func TestWriteDebugDescription(t *testing.T) {
 	}{
 		{"Integer", IntType, "int"},
 		{"String", StringType, "string"},
+		{"OptionalInteger", NewOptionalType(IntType), "Optional[int]"},
+		{"OptionalString", NewOptionalType(StringType), "Optional[string]"},
 	}
 
 	for _, c := range cases {

--- a/hack/generator/pkg/astmodel/type_test.go
+++ b/hack/generator/pkg/astmodel/type_test.go
@@ -25,6 +25,9 @@ func TestWriteDebugDescription(t *testing.T) {
 	suitEnum := NewEnumType(StringType, diamonds, hearts, clubs, spades)
 	suitDefinition := MakeTypeDefinition(suit, suitEnum)
 
+	armAge := ArmFlag.ApplyTo(age)
+	armSuit := ArmFlag.ApplyTo(suit)
+
 	types := make(Types)
 	types.Add(ageDefinition)
 	types.Add(personIdDefinition)
@@ -49,6 +52,8 @@ func TestWriteDebugDescription(t *testing.T) {
 		{"SuitEnum", suitEnum, "Enum[string:clubs|diamonds|hearts|spades]"}, // alphabetical
 		{"SuitName", suit, "local/test/v1/Suit:Enum[string:clubs|diamonds|hearts|spades]"},
 		{"MapOfSuitToAge", NewMapType(suit, age), "Map[local/test/v1/Suit:Enum[string:clubs|diamonds|hearts|spades]]local/test/v1/Age:int"},
+		{"FlaggedAge", armAge, "local/test/v1/Age:int[#arm]"},
+		{"FlaggedSuit", armSuit, "local/test/v1/Suit:Enum[string:clubs|diamonds|hearts|spades][#arm]"},
 	}
 
 	for _, c := range cases {

--- a/hack/generator/pkg/astmodel/type_test.go
+++ b/hack/generator/pkg/astmodel/type_test.go
@@ -28,6 +28,8 @@ func TestWriteDebugDescription(t *testing.T) {
 	armAge := ArmFlag.ApplyTo(age)
 	armSuit := ArmFlag.ApplyTo(suit)
 
+	erroredAge := NewErroredType(age, []string{"boom"}, []string{"oh oh"})
+
 	types := make(Types)
 	types.Add(ageDefinition)
 	types.Add(personIdDefinition)
@@ -54,6 +56,7 @@ func TestWriteDebugDescription(t *testing.T) {
 		{"MapOfSuitToAge", NewMapType(suit, age), "Map[local/test/v1/Suit:Enum[string:clubs|diamonds|hearts|spades]]local/test/v1/Age:int"},
 		{"FlaggedAge", armAge, "local/test/v1/Age:int[#arm]"},
 		{"FlaggedSuit", armSuit, "local/test/v1/Suit:Enum[string:clubs|diamonds|hearts|spades][#arm]"},
+		{"ErroredAge", erroredAge, "Error[local/test/v1/Age:int|boom|oh oh]"},
 	}
 
 	for _, c := range cases {

--- a/hack/generator/pkg/astmodel/type_test.go
+++ b/hack/generator/pkg/astmodel/type_test.go
@@ -41,6 +41,8 @@ func TestWriteDebugDescription(t *testing.T) {
 		{"OptionalString", NewOptionalType(StringType), "Optional[string]"},
 		{"ArrayOfString", NewArrayType(StringType), "Array[string]"},
 		{"ArrayOfOptionalString", NewArrayType(NewOptionalType(StringType)), "Array[Optional[string]]"},
+		{"MapOfStringToInt", NewMapType(StringType, IntType), "Map[string]int"},
+		{"MapOfStringToOptionalString", NewMapType(StringType, NewOptionalType(StringType)), "Map[string]Optional[string]"},
 	}
 
 	for _, c := range cases {

--- a/hack/generator/pkg/astmodel/type_test.go
+++ b/hack/generator/pkg/astmodel/type_test.go
@@ -30,8 +30,8 @@ func TestWriteDebugDescription(t *testing.T) {
 	suitEnum := NewEnumType(StringType, diamonds, hearts, clubs, spades)
 	suitDefinition := MakeTypeDefinition(suit, suitEnum)
 
-	armAge := ArmFlag.ApplyTo(age)
-	armSuit := ArmFlag.ApplyTo(suit)
+	armAge := ARMFlag.ApplyTo(age)
+	armSuit := ARMFlag.ApplyTo(suit)
 
 	erroredAge := NewErroredType(age, []string{"boom"}, []string{"oh oh"})
 

--- a/hack/generator/pkg/astmodel/type_test.go
+++ b/hack/generator/pkg/astmodel/type_test.go
@@ -43,6 +43,9 @@ func TestWriteDebugDescription(t *testing.T) {
 		{"ArrayOfOptionalString", NewArrayType(NewOptionalType(StringType)), "Array[Optional[string]]"},
 		{"MapOfStringToInt", NewMapType(StringType, IntType), "Map[string]int"},
 		{"MapOfStringToOptionalString", NewMapType(StringType, NewOptionalType(StringType)), "Map[string]Optional[string]"},
+		{"AliasedType", age, "local/test/v1/Age:int"},
+		{"MapOfStringToAge", NewMapType(StringType, age), "Map[string]local/test/v1/Age:int"},
+		{"MapOfPersonIDToAge", NewMapType(personId, age), "Map[local/test/v1/PersonId:string]local/test/v1/Age:int"},
 	}
 
 	for _, c := range cases {

--- a/hack/generator/pkg/astmodel/type_test.go
+++ b/hack/generator/pkg/astmodel/type_test.go
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) Microsoft Corporation.
+ * Licensed under the MIT license.
+ */
+
 package astmodel
 
 import (

--- a/hack/generator/pkg/astmodel/type_test.go
+++ b/hack/generator/pkg/astmodel/type_test.go
@@ -46,6 +46,9 @@ func TestWriteDebugDescription(t *testing.T) {
 		{"AliasedType", age, "local/test/v1/Age:int"},
 		{"MapOfStringToAge", NewMapType(StringType, age), "Map[string]local/test/v1/Age:int"},
 		{"MapOfPersonIDToAge", NewMapType(personId, age), "Map[local/test/v1/PersonId:string]local/test/v1/Age:int"},
+		{"SuitEnum", suitEnum, "Enum[string:clubs|diamonds|hearts|spades]"}, // alphabetical
+		{"SuitName", suit, "local/test/v1/Suit:Enum[string:clubs|diamonds|hearts|spades]"},
+		{"MapOfSuitToAge", NewMapType(suit, age), "Map[local/test/v1/Suit:Enum[string:clubs|diamonds|hearts|spades]]local/test/v1/Age:int"},
 	}
 
 	for _, c := range cases {

--- a/hack/generator/pkg/astmodel/type_test.go
+++ b/hack/generator/pkg/astmodel/type_test.go
@@ -1,0 +1,53 @@
+package astmodel
+
+import (
+	"strings"
+	"testing"
+
+	. "github.com/onsi/gomega"
+)
+
+func TestWriteDebugDescription(t *testing.T) {
+
+	here := MakeLocalPackageReference("local", "test", "v1")
+
+	age := MakeTypeName(here, "Age")
+	ageDefinition := MakeTypeDefinition(age, IntType)
+
+	personId := MakeTypeName(here, "PersonId")
+	personIdDefinition := MakeTypeDefinition(personId, StringType)
+
+	suit := MakeTypeName(here, "Suit")
+	diamonds := EnumValue{"diamonds", "Diamonds"}
+	hearts := EnumValue{"hearts", "Hearts"}
+	clubs := EnumValue{"clubs", "Clubs"}
+	spades := EnumValue{"spades", "Spades"}
+	suitEnum := NewEnumType(StringType, diamonds, hearts, clubs, spades)
+	suitDefinition := MakeTypeDefinition(suit, suitEnum)
+
+	types := make(Types)
+	types.Add(ageDefinition)
+	types.Add(personIdDefinition)
+	types.Add(suitDefinition)
+
+	cases := []struct {
+		name     string
+		subject  Type
+		expected string
+	}{
+		{"Integer", IntType, "int"},
+		{"String", StringType, "string"},
+	}
+
+	for _, c := range cases {
+		c := c
+		t.Run(c.name, func(t *testing.T) {
+			t.Parallel()
+			g := NewGomegaWithT(t)
+
+			var builder strings.Builder
+			c.subject.WriteDebugDescription(&builder, types)
+			g.Expect(builder.String()).To(Equal(c.expected))
+		})
+	}
+}

--- a/hack/generator/pkg/astmodel/validated_type.go
+++ b/hack/generator/pkg/astmodel/validated_type.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"math/big"
 	"regexp"
+	"strings"
 
 	"github.com/dave/dst"
 )
@@ -229,4 +230,13 @@ func equalOptionalRegexps(left *regexp.Regexp, right *regexp.Regexp) bool {
 // Unwrap returns the type contained within the validated type
 func (v ValidatedType) Unwrap() Type {
 	return v.element
+}
+
+// DebugDescription adds a description of the current type to the passed builder
+// builder receives the full description, including nested types
+// types is a dictionary for resolving named types
+func (v ValidatedType) WriteDebugDescription(builder *strings.Builder, types Types) {
+	builder.WriteString("Validated[")
+	v.element.WriteDebugDescription(builder, types)
+	builder.WriteString("]")
 }

--- a/hack/generator/pkg/astmodel/validated_type.go
+++ b/hack/generator/pkg/astmodel/validated_type.go
@@ -232,7 +232,7 @@ func (v ValidatedType) Unwrap() Type {
 	return v.element
 }
 
-// DebugDescription adds a description of the current type to the passed builder
+// WriteDebugDescription adds a description of the current type to the passed builder
 // builder receives the full description, including nested types
 // types is a dictionary for resolving named types
 func (v ValidatedType) WriteDebugDescription(builder *strings.Builder, types Types) {


### PR DESCRIPTION
The existing `String()` implementations on `Type` are insufficient for troubleshooting some issues because they stop at a `TypeName`, not showing what lies underneath.

Without the ability to add a `Types` parameter to `String()` to allow resolution of type names, I've added instead `WriteDebugDescription()`.