### PR TITLE
Add TypeMerger

### DIFF
--- a/hack/generator/pkg/astmodel/type_merger.go
+++ b/hack/generator/pkg/astmodel/type_merger.go
@@ -15,9 +15,9 @@ import (
 //
 // Conceptually it takes (via Add) a list of functions of the form:
 //
-//     func ([ctx interface{},] a <: Type, b <: Type) (Type, error)
+//     func ([ctx interface{},] left {some Type}, right {some Type}) (Type, error)
 //
-// where `a` and `b` can be concrete types that implement the `Type` interface.
+// where `left` and `right` can be concrete types that implement the `Type` interface.
 //
 // When `TypeMerger.Merge(Type, Type)` is invoked, it will iterate through the
 // provided functions and invoke the first one that matches the concrete types
@@ -58,7 +58,7 @@ func validateMerger(merger interface{}) validatedMerger {
 
 	mergerType := it.Type()
 
-	badArgumentsMsg := "merger must take take arguments of type (left Type, right Type) or (ctx X, left Type, right Type)"
+	badArgumentsMsg := "merger must take take arguments of type (left [some Type], right [some Type]) or (ctx X, left [some Type], right [some Type])"
 	if mergerType.NumIn() < 2 || mergerType.NumIn() > 3 {
 		panic(badArgumentsMsg)
 	}

--- a/hack/generator/pkg/astmodel/type_merger.go
+++ b/hack/generator/pkg/astmodel/type_merger.go
@@ -58,8 +58,9 @@ func validateMerger(merger interface{}) validatedMerger {
 
 	mergerType := it.Type()
 
-	if mergerType.NumIn() != 2 && mergerType.NumIn() != 3 {
-		panic("merger must take 2 arguments (left Type, right Type) or 3 arguments (ctx X, left Type, right Type)")
+	badArgumentsMsg := "merger must take take arguments of type (left Type, right Type) or (ctx X, left Type, right Type)"
+	if mergerType.NumIn() < 2 || mergerType.NumIn() > 3 {
+		panic(badArgumentsMsg)
 	}
 
 	argOffset := mergerType.NumIn() - 2
@@ -69,7 +70,7 @@ func validateMerger(merger interface{}) validatedMerger {
 	rightArg := mergerType.In(argOffset + 1)
 
 	if !leftArg.AssignableTo(typeInterface) || !rightArg.AssignableTo(typeInterface) {
-		panic("merger must take in types assignable to Type")
+		panic(badArgumentsMsg)
 	}
 
 	if mergerType.NumOut() != 2 ||

--- a/hack/generator/pkg/astmodel/type_merger.go
+++ b/hack/generator/pkg/astmodel/type_merger.go
@@ -43,7 +43,6 @@ func NewTypeMerger(fallback MergerFunc) TypeMerger {
 var typeInterface reflect.Type = reflect.TypeOf((*Type)(nil)).Elem() // yuck
 var errorInterface reflect.Type = reflect.TypeOf((*error)(nil)).Elem()
 var mergerFuncType reflect.Type = reflect.TypeOf((*MergerFunc)(nil)).Elem()
-var interfaceInterface reflect.Type = reflect.TypeOf((*interface{})(nil)).Elem()
 
 type validatedMerger struct {
 	merger                    reflect.Value
@@ -60,7 +59,7 @@ func validateMerger(merger interface{}) validatedMerger {
 	mergerType := it.Type()
 
 	if mergerType.NumIn() != 2 && mergerType.NumIn() != 3 {
-		panic("merger must take 2 arguments (left Type, right Type) or 3 arguments (ctx interface{}, left Type, right Type)")
+		panic("merger must take 2 arguments (left Type, right Type) or 3 arguments (ctx X, left Type, right Type)")
 	}
 
 	argOffset := mergerType.NumIn() - 2
@@ -68,10 +67,6 @@ func validateMerger(merger interface{}) validatedMerger {
 	needsCtx := argOffset != 0
 	leftArg := mergerType.In(argOffset + 0)
 	rightArg := mergerType.In(argOffset + 1)
-
-	if needsCtx && mergerType.In(0) != interfaceInterface {
-		panic("with 3 arguments, first (context) argument must be of type interface{}")
-	}
 
 	if !leftArg.AssignableTo(typeInterface) || !rightArg.AssignableTo(typeInterface) {
 		panic("merger must take in types assignable to Type")

--- a/hack/generator/pkg/astmodel/type_merger.go
+++ b/hack/generator/pkg/astmodel/type_merger.go
@@ -30,8 +30,9 @@ type TypeMerger struct {
 }
 
 type mergerRegistration struct {
-	left, right reflect.Type
-	merge       MergerFunc
+	left  reflect.Type
+	right reflect.Type
+	merge MergerFunc
 }
 
 type MergerFunc func(ctx interface{}, left, right Type) (Type, error)

--- a/hack/generator/pkg/astmodel/type_merger.go
+++ b/hack/generator/pkg/astmodel/type_merger.go
@@ -43,6 +43,7 @@ func NewTypeMerger(fallback MergerFunc) TypeMerger {
 var typeInterface reflect.Type = reflect.TypeOf((*Type)(nil)).Elem() // yuck
 var errorInterface reflect.Type = reflect.TypeOf((*error)(nil)).Elem()
 var mergerFuncType reflect.Type = reflect.TypeOf((*MergerFunc)(nil)).Elem()
+var interfaceInterface reflect.Type = reflect.TypeOf((*interface{})(nil)).Elem()
 
 type validatedMerger struct {
 	merger                    reflect.Value
@@ -59,12 +60,18 @@ func validateMerger(merger interface{}) validatedMerger {
 	mergerType := it.Type()
 
 	if mergerType.NumIn() != 2 && mergerType.NumIn() != 3 {
-		panic("merger must take 2 arguments (Type, Type) or 3 arguments (X, Type, Type)")
+		panic("merger must take 2 arguments (left Type, right Type) or 3 arguments (ctx interface{}, left Type, right Type)")
 	}
 
 	argOffset := mergerType.NumIn() - 2
+
+	needsCtx := argOffset != 0
 	leftArg := mergerType.In(argOffset + 0)
 	rightArg := mergerType.In(argOffset + 1)
+
+	if needsCtx && mergerType.In(0) != interfaceInterface {
+		panic("with 3 arguments, first (context) argument must be of type interface{}")
+	}
 
 	if !leftArg.AssignableTo(typeInterface) || !rightArg.AssignableTo(typeInterface) {
 		panic("merger must take in types assignable to Type")
@@ -80,7 +87,7 @@ func validateMerger(merger interface{}) validatedMerger {
 		merger:       it,
 		leftArgType:  leftArg,
 		rightArgType: rightArg,
-		needsCtx:     argOffset != 0,
+		needsCtx:     needsCtx,
 	}
 }
 

--- a/hack/generator/pkg/astmodel/type_merger.go
+++ b/hack/generator/pkg/astmodel/type_merger.go
@@ -12,7 +12,18 @@ import (
 )
 
 // TypeMerger is like a visitor for 2 types.
-// The `ctx` argument can be used to “smuggle” additional data down the call-chain.
+//
+// Conceptually it takes (via Add) a list of functions of the form:
+//
+//     func ([ctx interface{},] a <: Type, b <: Type) (Type, error)
+//
+// where `a` and `b` can be concrete types that implement the `Type` interface.
+//
+// When `TypeMerger.Merge(Type, Type)` is invoked, it will iterate through the
+// provided functions and invoke the first one that matches the concrete types
+// passed. If none match then the fallback provided to `NewTypeMerger` will be invoked.
+//
+// The `ctx` argument can optionally be used to “smuggle” additional data down the call-chain.
 type TypeMerger struct {
 	mergers  []mergerRegistration
 	fallback MergerFunc

--- a/hack/generator/pkg/astmodel/type_merger.go
+++ b/hack/generator/pkg/astmodel/type_merger.go
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) Microsoft Corporation.
+ * Licensed under the MIT license.
+ */
+
+package astmodel
+
+import (
+	"reflect"
+)
+
+// TypeMerger is like a visitor for 2 types.
+// The `ctx` argument can be used to “smuggle” additional data down the call-chain.
+type TypeMerger struct {
+	mergers  map[TypePair]TypeMergerFunc
+	fallback TypeMergerFunc
+}
+
+type TypePair struct{ left, right reflect.Type }
+type TypeMergerFunc func(left, right Type) Type
+
+func NewTypeMerger(fallback TypeMergerFunc) TypeMerger {
+	return TypeMerger{
+		mergers:  make(map[TypePair]TypeMergerFunc),
+		fallback: fallback,
+	}
+}
+
+var typeInterface reflect.Type = reflect.TypeOf((*Type)(nil)).Elem() // yuck
+
+func (m *TypeMerger) Add(merger interface{}) {
+
+	it := reflect.ValueOf(merger)
+	if it.Kind() != reflect.Func {
+		panic("merger must be a function")
+	}
+
+	mergerType := it.Type()
+
+	if mergerType.NumIn() != 2 {
+		panic("merger must take two arguments")
+	}
+
+	if mergerType.NumOut() != 1 {
+		panic("merger must return one value")
+	}
+
+	if mergerType.Out(0) != typeInterface {
+		panic("merger must return a Type")
+	}
+
+	leftArg := mergerType.In(0)
+	rightArg := mergerType.In(1)
+	if !leftArg.AssignableTo(typeInterface) || !rightArg.AssignableTo(typeInterface) {
+		panic("merger must take in types assignable to Type")
+	}
+
+	key := TypePair{leftArg, rightArg}
+	m.mergers[key] = func(left, right Type) Type {
+		return it.Call([]reflect.Value{reflect.ValueOf(left), reflect.ValueOf(right)})[0].Interface().(Type)
+	}
+}
+
+// Merge merges the two types according to the provided mergers and fallback
+func (m *TypeMerger) Merge(left, right Type) Type {
+	if left == nil {
+		return right
+	}
+
+	if right == nil {
+		return left
+	}
+
+	leftType := reflect.ValueOf(left).Type()
+	rightType := reflect.ValueOf(right).Type()
+
+	if merger, ok := m.mergers[TypePair{leftType, rightType}]; ok {
+		return merger(left, right)
+	}
+
+	return m.fallback(left, right)
+}

--- a/hack/generator/pkg/astmodel/type_merger.go
+++ b/hack/generator/pkg/astmodel/type_merger.go
@@ -148,7 +148,9 @@ func (m *TypeMerger) Merge(left, right Type, ctx ...interface{}) (Type, error) {
 	for _, merger := range m.mergers {
 		if (merger.left == leftType || merger.left == typeInterface) &&
 			(merger.right == rightType || merger.right == typeInterface) {
+
 			result, err := merger.merge(ctxValue, left, right)
+
 			if (result == nil && err == nil) || errors.Is(err, ContinueMerge) {
 				// these conditions indicate that the merger was not actually applicable,
 				// despite having a type that matched

--- a/hack/generator/pkg/astmodel/type_merger_test.go
+++ b/hack/generator/pkg/astmodel/type_merger_test.go
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) Microsoft Corporation.
+ * Licensed under the MIT license.
+ */
+
+package astmodel
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+)
+
+func TestCanMergeSameTypes(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	merger := NewTypeMerger(func(l, r Type) Type {
+		t.Fatal("reached fallback")
+		return nil
+	})
+
+	merger.Add(func(l, r *PrimitiveType) Type {
+		return StringType
+	})
+
+	result := merger.Merge(IntType, BoolType)
+
+	g.Expect(result).To(Equal(StringType))
+}
+
+func TestCanMergeDifferentTypes(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	merger := NewTypeMerger(func(l, r Type) Type {
+		return BoolType
+	})
+
+	merger.Add(func(l *ObjectType, r *PrimitiveType) Type {
+		return StringType
+	})
+
+	result := merger.Merge(NewObjectType(), IntType) // shouldn't hit fallback
+	g.Expect(result).To(Equal(StringType))
+
+	result2 := merger.Merge(IntType, NewObjectType()) // should hit fallback
+	g.Expect(result2).To(Equal(BoolType))
+}

--- a/hack/generator/pkg/astmodel/type_merger_test.go
+++ b/hack/generator/pkg/astmodel/type_merger_test.go
@@ -9,39 +9,81 @@ import (
 	"testing"
 
 	. "github.com/onsi/gomega"
+	"github.com/pkg/errors"
 )
 
 func TestCanMergeSameTypes(t *testing.T) {
 	g := NewGomegaWithT(t)
 
-	merger := NewTypeMerger(func(l, r Type) Type {
-		t.Fatal("reached fallback")
-		return nil
+	merger := NewTypeMerger(func(_ interface{}, l, r Type) (Type, error) {
+		return nil, errors.New("reached fallback")
 	})
 
-	merger.Add(func(l, r *PrimitiveType) Type {
-		return StringType
+	merger.Add(func(l, r *PrimitiveType) (Type, error) {
+		return StringType, nil
 	})
 
-	result := merger.Merge(IntType, BoolType)
-
+	result, err := merger.Merge(IntType, BoolType)
+	g.Expect(err).To(Not(HaveOccurred()))
 	g.Expect(result).To(Equal(StringType))
 }
 
 func TestCanMergeDifferentTypes(t *testing.T) {
 	g := NewGomegaWithT(t)
 
-	merger := NewTypeMerger(func(l, r Type) Type {
-		return BoolType
+	merger := NewTypeMerger(func(_ interface{}, l, r Type) (Type, error) {
+		return BoolType, nil
 	})
 
-	merger.Add(func(l *ObjectType, r *PrimitiveType) Type {
-		return StringType
+	merger.Add(func(l *ObjectType, r *PrimitiveType) (Type, error) {
+		return StringType, nil
 	})
 
-	result := merger.Merge(NewObjectType(), IntType) // shouldn't hit fallback
+	result, err := merger.Merge(NewObjectType(), IntType) // shouldn't hit fallback
+	g.Expect(err).To(Not(HaveOccurred()))
 	g.Expect(result).To(Equal(StringType))
 
-	result2 := merger.Merge(IntType, NewObjectType()) // should hit fallback
-	g.Expect(result2).To(Equal(BoolType))
+	result, err = merger.Merge(IntType, NewObjectType()) // should hit fallback
+	g.Expect(err).To(Not(HaveOccurred()))
+	g.Expect(result).To(Equal(BoolType))
+}
+
+func TestCanMergeWithGenericTypeArgument(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	merger := NewTypeMerger(func(_ interface{}, l, r Type) (Type, error) {
+		return BoolType, nil
+	})
+
+	merger.Add(func(l *ObjectType, r Type) (Type, error) {
+		return StringType, nil
+	})
+
+	result, err := merger.Merge(NewObjectType(), IntType) // shouldn't hit fallback
+	g.Expect(err).To(Not(HaveOccurred()))
+	g.Expect(result).To(Equal(StringType))
+
+	result, err = merger.Merge(IntType, NewObjectType()) // should hit fallback
+	g.Expect(err).To(Not(HaveOccurred()))
+	g.Expect(result).To(Equal(BoolType))
+}
+
+func TestCanMergeWithUnorderedMerger(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	merger := NewTypeMerger(func(_ interface{}, l, r Type) (Type, error) {
+		return BoolType, nil
+	})
+
+	merger.AddUnordered(func(l *ObjectType, r Type) (Type, error) {
+		return StringType, nil
+	})
+
+	result, err := merger.Merge(NewObjectType(), IntType) // shouldn't hit fallback
+	g.Expect(err).To(Not(HaveOccurred()))
+	g.Expect(result).To(Equal(StringType))
+
+	result, err = merger.Merge(IntType, NewObjectType()) // shouldn't hit fallback either
+	g.Expect(err).To(Not(HaveOccurred()))
+	g.Expect(result).To(Equal(StringType))
 }

--- a/hack/generator/pkg/astmodel/type_merger_test.go
+++ b/hack/generator/pkg/astmodel/type_merger_test.go
@@ -103,7 +103,7 @@ func TestMergerFuncMustTakeTwoOrThreeArguments(t *testing.T) {
 
 	merger := NewTypeMerger(leftFallback)
 
-	msg := "merger must take 2 arguments (left Type, right Type) or 3 arguments (ctx X, left Type, right Type)"
+	msg := "merger must take take arguments of type (left Type, right Type) or (ctx X, left Type, right Type)"
 
 	g.Expect(func() { merger.Add(func() (Type, error) { return nil, nil }) }).To(PanicWith(msg))
 	g.Expect(func() { merger.Add(func(x Type) (Type, error) { return x, nil }) }).To(PanicWith(msg))
@@ -115,7 +115,7 @@ func TestMergerFuncMustTakeTypesAssignableToTypeAsArguments(t *testing.T) {
 
 	merger := NewTypeMerger(leftFallback)
 
-	msg := "merger must take in types assignable to Type"
+	msg := "merger must take take arguments of type (left Type, right Type) or (ctx X, left Type, right Type)"
 
 	// left side wrong
 	g.Expect(func() { merger.Add(func(_ int, _ Type) (Type, error) { return nil, nil }) }).To(PanicWith(msg))

--- a/hack/generator/pkg/astmodel/type_merger_test.go
+++ b/hack/generator/pkg/astmodel/type_merger_test.go
@@ -103,21 +103,11 @@ func TestMergerFuncMustTakeTwoOrThreeArguments(t *testing.T) {
 
 	merger := NewTypeMerger(leftFallback)
 
-	msg := "merger must take 2 arguments (left Type, right Type) or 3 arguments (ctx interface{}, left Type, right Type)"
+	msg := "merger must take 2 arguments (left Type, right Type) or 3 arguments (ctx X, left Type, right Type)"
 
 	g.Expect(func() { merger.Add(func() (Type, error) { return nil, nil }) }).To(PanicWith(msg))
 	g.Expect(func() { merger.Add(func(x Type) (Type, error) { return x, nil }) }).To(PanicWith(msg))
 	g.Expect(func() { merger.Add(func(x, _, _, _ Type) (Type, error) { return x, nil }) }).To(PanicWith(msg))
-}
-
-func TestMergerFuncWithThreeArgumentsMustTakeCtxAsFirst(t *testing.T) {
-	g := NewGomegaWithT(t)
-
-	merger := NewTypeMerger(leftFallback)
-
-	msg := "with 3 arguments, first (context) argument must be of type interface{}"
-
-	g.Expect(func() { merger.Add(func(x, _, _ Type) (Type, error) { return x, nil }) }).To(PanicWith(msg))
 }
 
 func TestMergerFuncMustTakeTypesAssignableToTypeAsArguments(t *testing.T) {

--- a/hack/generator/pkg/astmodel/type_merger_test.go
+++ b/hack/generator/pkg/astmodel/type_merger_test.go
@@ -103,7 +103,7 @@ func TestMergerFuncMustTakeTwoOrThreeArguments(t *testing.T) {
 
 	merger := NewTypeMerger(leftFallback)
 
-	msg := "merger must take take arguments of type (left Type, right Type) or (ctx X, left Type, right Type)"
+	msg := "merger must take take arguments of type (left [some Type], right [some Type]) or (ctx X, left [some Type], right [some Type])"
 
 	g.Expect(func() { merger.Add(func() (Type, error) { return nil, nil }) }).To(PanicWith(msg))
 	g.Expect(func() { merger.Add(func(x Type) (Type, error) { return x, nil }) }).To(PanicWith(msg))
@@ -115,7 +115,7 @@ func TestMergerFuncMustTakeTypesAssignableToTypeAsArguments(t *testing.T) {
 
 	merger := NewTypeMerger(leftFallback)
 
-	msg := "merger must take take arguments of type (left Type, right Type) or (ctx X, left Type, right Type)"
+	msg := "merger must take take arguments of type (left [some Type], right [some Type]) or (ctx X, left [some Type], right [some Type])"
 
 	// left side wrong
 	g.Expect(func() { merger.Add(func(_ int, _ Type) (Type, error) { return nil, nil }) }).To(PanicWith(msg))

--- a/hack/generator/pkg/codegen/pipeline_augment_status.go
+++ b/hack/generator/pkg/codegen/pipeline_augment_status.go
@@ -135,9 +135,9 @@ func generateStatusTypes(swaggerTypes swaggerTypes) (statusTypes, error) {
 		return astmodel.MakeTypeName(typeName.PackageReference, typeName.Name()+"_Status")
 	}
 
-	var errs []error
 	renamer := makeRenamingVisitor(appendStatusToName)
 
+	var errs []error
 	var otherTypes []astmodel.TypeDefinition
 	for _, typeDef := range swaggerTypes.otherTypes {
 		renamedDef, err := renamer.VisitDefinition(typeDef, nil)

--- a/hack/generator/pkg/codegen/pipeline_convert_allof_and_oneof_to_objects.go
+++ b/hack/generator/pkg/codegen/pipeline_convert_allof_and_oneof_to_objects.go
@@ -270,7 +270,7 @@ func (s synthesizer) oneOfObject(oneOf *astmodel.OneOfType, propNames []property
 }
 
 func (s synthesizer) intersectTypes(left astmodel.Type, right astmodel.Type) (astmodel.Type, error) {
-	return intersector.Merge(left, right, s)
+	return intersector.MergeWithContext(s, left, right)
 }
 
 var intersector astmodel.TypeMerger

--- a/hack/generator/pkg/codegen/pipeline_convert_allof_and_oneof_to_objects.go
+++ b/hack/generator/pkg/codegen/pipeline_convert_allof_and_oneof_to_objects.go
@@ -270,63 +270,44 @@ func (s synthesizer) oneOfObject(oneOf *astmodel.OneOfType, propNames []property
 }
 
 func (s synthesizer) intersectTypes(left astmodel.Type, right astmodel.Type) (astmodel.Type, error) {
-	for _, handler := range intersectHandlers {
-		result, err := handler(s, left, right)
-		if err != nil {
-			return nil, errors.Wrapf(err, "error intersecting types")
-		}
-
-		if result != nil {
-			return result, nil
-		}
-	}
-
-	return nil, errors.Errorf("don't know how to intersect types: %s and %s", left, right)
+	return intersector.Merge(left, right, s)
 }
 
-// intersectHandler knows how to do intersection for one case only. It is biased to examine
-// the LHS type (but some are symmetric and handle both sides at once). The handler can return
-// nil,nil which indicates it doesn't apply to this combination of types.
-type intersectHandler = func(synthesizer, astmodel.Type, astmodel.Type) (astmodel.Type, error)
-
-// handles the same case for the right hand side
-func flip(f intersectHandler) intersectHandler {
-	return func(s synthesizer, left astmodel.Type, right astmodel.Type) (astmodel.Type, error) {
-		return f(s, right, left)
-	}
-}
-
-var intersectHandlers []intersectHandler
+var intersector astmodel.TypeMerger
 
 func init() {
-	intersectHandlers = []intersectHandler{
-		synthesizer.handleEqualTypes, // equality is symmetric
-		synthesizer.handleValidatedAndNonValidated, flip(synthesizer.handleValidatedAndNonValidated),
-		synthesizer.handleAnyType, flip(synthesizer.handleAnyType),
-		synthesizer.handleAllOfType, flip(synthesizer.handleAllOfType),
-		synthesizer.handleTypeName, flip(synthesizer.handleTypeName),
-		synthesizer.handleOneOf, flip(synthesizer.handleOneOf),
-		synthesizer.handleOptionalOptional,                           // symmetric
-		synthesizer.handleOptional, flip(synthesizer.handleOptional), // needs to be before Enum
-		synthesizer.handleResourceResource, // symmetric
-		synthesizer.handleResourceType, flip(synthesizer.handleResourceType),
-		synthesizer.handleEnumEnum, // symmetric
-		synthesizer.handleEnum, flip(synthesizer.handleEnum),
-		synthesizer.handleObjectObject, // symmetric
-		synthesizer.handleMapMap,       // symmetric
-		synthesizer.handleArrayArray,   // symmetric
-		synthesizer.handleMapObject, flip(synthesizer.handleMapObject),
-		synthesizer.handleErrored, flip(synthesizer.handleErrored),
-	}
+	i := astmodel.NewTypeMerger(func(_ctx interface{}, left, right astmodel.Type) (astmodel.Type, error) {
+		return nil, errors.Errorf("don't know how to intersect types: %s and %s", left, right)
+	})
+
+	i.Add(synthesizer.handleEqualTypes)
+	i.AddUnordered(synthesizer.handleValidatedAndNonValidated)
+	i.AddUnordered(synthesizer.handleAnyType)
+	i.AddUnordered(synthesizer.handleAllOfType)
+	i.AddUnordered(synthesizer.handleTypeName)
+	i.AddUnordered(synthesizer.handleOneOf)
+
+	i.Add(synthesizer.handleOptionalOptional)
+	i.AddUnordered(synthesizer.handleOptional)
+
+	i.Add(synthesizer.handleResourceResource)
+	i.AddUnordered(synthesizer.handleResourceType)
+
+	i.Add(synthesizer.handleEnumEnum)
+	i.AddUnordered(synthesizer.handleEnum)
+
+	i.Add(synthesizer.handleObjectObject)
+	i.Add(synthesizer.handleMapMap)
+	i.Add(synthesizer.handleArrayArray)
+
+	i.AddUnordered(synthesizer.handleMapObject)
+	i.AddUnordered(synthesizer.handleErrored)
+
+	intersector = i
 }
 
-func (s synthesizer) handleErrored(left astmodel.Type, right astmodel.Type) (astmodel.Type, error) {
+func (s synthesizer) handleErrored(leftErrored *astmodel.ErroredType, right astmodel.Type) (astmodel.Type, error) {
 	// can merge the contents of an ErroredType, if we preserve the errors
-	leftErrored, ok := left.(*astmodel.ErroredType)
-	if !ok {
-		return nil, nil
-	}
-
 	if leftErrored.InnerType() == nil {
 		return leftErrored.WithType(right), nil
 	}
@@ -343,27 +324,12 @@ func (s synthesizer) handleErrored(left astmodel.Type, right astmodel.Type) (ast
 	return leftErrored.WithType(combined), nil
 }
 
-func (s synthesizer) handleOptional(left astmodel.Type, right astmodel.Type) (astmodel.Type, error) {
-	leftOptional, ok := left.(*astmodel.OptionalType)
-	if !ok {
-		return nil, nil
-	}
-
+func (s synthesizer) handleOptional(leftOptional *astmodel.OptionalType, right astmodel.Type) (astmodel.Type, error) {
 	// is this wrong? it feels wrong, but needed for {optional{enum}, string}
 	return s.intersectTypes(leftOptional.Element(), right)
 }
 
-func (s synthesizer) handleResourceResource(left astmodel.Type, right astmodel.Type) (astmodel.Type, error) {
-	leftResource, ok := left.(*astmodel.ResourceType)
-	if !ok {
-		return nil, nil
-	}
-
-	rightResource, ok := right.(*astmodel.ResourceType)
-	if !ok {
-		return nil, nil
-	}
-
+func (s synthesizer) handleResourceResource(leftResource *astmodel.ResourceType, rightResource *astmodel.ResourceType) (astmodel.Type, error) {
 	// merge two resources: merge spec/status
 	spec, err := s.intersectTypes(leftResource.SpecType(), rightResource.SpecType())
 	if err != nil {
@@ -386,12 +352,7 @@ func (s synthesizer) handleResourceResource(left astmodel.Type, right astmodel.T
 	return leftResource.WithSpec(spec).WithStatus(status), nil
 }
 
-func (s synthesizer) handleResourceType(left astmodel.Type, right astmodel.Type) (astmodel.Type, error) {
-	leftResource, ok := left.(*astmodel.ResourceType)
-	if !ok {
-		return nil, nil
-	}
-
+func (s synthesizer) handleResourceType(leftResource *astmodel.ResourceType, right astmodel.Type) (astmodel.Type, error) {
 	if s.specOrStatus == chooseStatus {
 		if leftResource.StatusType() != nil {
 			newT, err := s.intersectTypes(leftResource.StatusType(), right)
@@ -415,18 +376,8 @@ func (s synthesizer) handleResourceType(left astmodel.Type, right astmodel.Type)
 	}
 }
 
-func (s synthesizer) handleOptionalOptional(left astmodel.Type, right astmodel.Type) (astmodel.Type, error) {
+func (s synthesizer) handleOptionalOptional(leftOptional *astmodel.OptionalType, rightOptional *astmodel.OptionalType) (astmodel.Type, error) {
 	// if both optional merge their contents and put back in an optional
-	leftOptional, ok := left.(*astmodel.OptionalType)
-	if !ok {
-		return nil, nil
-	}
-
-	rightOptional, ok := right.(*astmodel.OptionalType)
-	if !ok {
-		return nil, nil
-	}
-
 	result, err := s.intersectTypes(leftOptional.Element(), rightOptional.Element())
 	if err != nil {
 		return nil, err
@@ -435,17 +386,7 @@ func (s synthesizer) handleOptionalOptional(left astmodel.Type, right astmodel.T
 	return astmodel.NewOptionalType(result), nil
 }
 
-func (s synthesizer) handleMapMap(left astmodel.Type, right astmodel.Type) (astmodel.Type, error) {
-	leftMap, ok := left.(*astmodel.MapType)
-	if !ok {
-		return nil, nil
-	}
-
-	rightMap, ok := right.(*astmodel.MapType)
-	if !ok {
-		return nil, nil
-	}
-
+func (s synthesizer) handleMapMap(leftMap *astmodel.MapType, rightMap *astmodel.MapType) (astmodel.Type, error) {
 	keyType, err := s.intersectTypes(leftMap.KeyType(), rightMap.KeyType())
 	if err != nil {
 		return nil, err
@@ -460,17 +401,7 @@ func (s synthesizer) handleMapMap(left astmodel.Type, right astmodel.Type) (astm
 }
 
 // intersection of array types is array of intersection of their element types
-func (s synthesizer) handleArrayArray(left astmodel.Type, right astmodel.Type) (astmodel.Type, error) {
-	leftArray, ok := left.(*astmodel.ArrayType)
-	if !ok {
-		return nil, nil
-	}
-
-	rightArray, ok := right.(*astmodel.ArrayType)
-	if !ok {
-		return nil, nil
-	}
-
+func (s synthesizer) handleArrayArray(leftArray *astmodel.ArrayType, rightArray *astmodel.ArrayType) (astmodel.Type, error) {
 	intersected, err := s.intersectTypes(leftArray.Element(), rightArray.Element())
 	if err != nil {
 		return nil, err
@@ -479,17 +410,7 @@ func (s synthesizer) handleArrayArray(left astmodel.Type, right astmodel.Type) (
 	return astmodel.NewArrayType(intersected), nil
 }
 
-func (s synthesizer) handleObjectObject(left astmodel.Type, right astmodel.Type) (astmodel.Type, error) {
-	leftObj, ok := left.(*astmodel.ObjectType)
-	if !ok {
-		return nil, nil
-	}
-
-	rightObj, ok := right.(*astmodel.ObjectType)
-	if !ok {
-		return nil, nil
-	}
-
+func (s synthesizer) handleObjectObject(leftObj *astmodel.ObjectType, rightObj *astmodel.ObjectType) (astmodel.Type, error) {
 	mergedProps := make(map[astmodel.PropertyName]*astmodel.PropertyDefinition)
 
 	for _, p := range leftObj.Properties() {
@@ -522,18 +443,7 @@ func (s synthesizer) handleObjectObject(left astmodel.Type, right astmodel.Type)
 	return leftObj.WithProperties(properties...), nil
 }
 
-func (s synthesizer) handleEnumEnum(left astmodel.Type, right astmodel.Type) (astmodel.Type, error) {
-	leftEnum, ok := left.(*astmodel.EnumType)
-	if !ok {
-		return nil, nil
-	}
-
-	// if both are enums then the elements must be common
-	rightEnum, ok := right.(*astmodel.EnumType)
-	if !ok {
-		return nil, nil
-	}
-
+func (s synthesizer) handleEnumEnum(leftEnum *astmodel.EnumType, rightEnum *astmodel.EnumType) (astmodel.Type, error) {
 	if !leftEnum.BaseType().Equals(rightEnum.BaseType()) {
 		return nil, errors.Errorf("cannot merge enums with differing base types")
 	}
@@ -552,12 +462,7 @@ func (s synthesizer) handleEnumEnum(left astmodel.Type, right astmodel.Type) (as
 	return astmodel.NewEnumType(leftEnum.BaseType(), inBoth...), nil
 }
 
-func (s synthesizer) handleEnum(left astmodel.Type, right astmodel.Type) (astmodel.Type, error) {
-	leftEnum, ok := left.(*astmodel.EnumType)
-	if !ok {
-		return nil, nil
-	}
-
+func (s synthesizer) handleEnum(leftEnum *astmodel.EnumType, right astmodel.Type) (astmodel.Type, error) {
 	// we can restrict from a (maybe optional) base type to an enum type
 	if leftEnum.BaseType().Equals(right) ||
 		astmodel.NewOptionalType(leftEnum.BaseType()).Equals(right) {
@@ -572,12 +477,7 @@ func (s synthesizer) handleEnum(left astmodel.Type, right astmodel.Type) (astmod
 	return nil, errors.Errorf("don't know how to merge enum type (%s) with %s", strings.Join(strs, ", "), right)
 }
 
-func (s synthesizer) handleAllOfType(left astmodel.Type, right astmodel.Type) (astmodel.Type, error) {
-	leftAllOf, ok := left.(*astmodel.AllOfType)
-	if !ok {
-		return nil, nil
-	}
-
+func (s synthesizer) handleAllOfType(leftAllOf *astmodel.AllOfType, right astmodel.Type) (astmodel.Type, error) {
 	result, err := s.allOfObject(leftAllOf)
 	if err != nil {
 		return nil, err
@@ -587,12 +487,7 @@ func (s synthesizer) handleAllOfType(left astmodel.Type, right astmodel.Type) (a
 }
 
 // if combining a type with a oneOf that contains that type, the result is that type
-func (s synthesizer) handleOneOf(left astmodel.Type, right astmodel.Type) (astmodel.Type, error) {
-	leftOneOf, ok := left.(*astmodel.OneOfType)
-	if !ok {
-		return nil, nil
-	}
-
+func (s synthesizer) handleOneOf(leftOneOf *astmodel.OneOfType, right astmodel.Type) (astmodel.Type, error) {
 	// if there is an equal case, use that:
 	{
 		var result astmodel.Type
@@ -626,12 +521,7 @@ func (s synthesizer) handleOneOf(left astmodel.Type, right astmodel.Type) (astmo
 	return astmodel.BuildOneOfType(newTypes...), nil
 }
 
-func (s synthesizer) handleTypeName(left astmodel.Type, right astmodel.Type) (astmodel.Type, error) {
-	leftName, ok := left.(astmodel.TypeName)
-	if !ok {
-		return nil, nil
-	}
-
+func (s synthesizer) handleTypeName(leftName astmodel.TypeName, right astmodel.Type) (astmodel.Type, error) {
 	if found, ok := s.defs[leftName]; !ok {
 		return nil, errors.Errorf("couldn't find type %s", leftName)
 	} else {
@@ -654,7 +544,7 @@ func (s synthesizer) handleTypeName(left astmodel.Type, right astmodel.Type) (as
 }
 
 // any type always disappears when intersected with another type
-func (synthesizer) handleAnyType(left astmodel.Type, right astmodel.Type) (astmodel.Type, error) {
+func (synthesizer) handleAnyType(left *astmodel.PrimitiveType, right astmodel.Type) (astmodel.Type, error) {
 	if left.Equals(astmodel.AnyType) {
 		return right, nil
 	}
@@ -672,31 +562,25 @@ func (synthesizer) handleEqualTypes(left astmodel.Type, right astmodel.Type) (as
 }
 
 // a validated and non-validated version of the same type become the valiated version
-func (synthesizer) handleValidatedAndNonValidated(left astmodel.Type, right astmodel.Type) (astmodel.Type, error) {
-	if validated, ok := left.(*astmodel.ValidatedType); ok {
-		if validated.ElementType().Equals(right) {
-			return left, nil
-		}
+func (synthesizer) handleValidatedAndNonValidated(validated *astmodel.ValidatedType, right astmodel.Type) (astmodel.Type, error) {
+	if validated.ElementType().Equals(right) {
+		return validated, nil
 	}
 
 	return nil, nil
 }
 
 // a string map and object can be combined with the map type becoming additionalProperties
-func (synthesizer) handleMapObject(left astmodel.Type, right astmodel.Type) (astmodel.Type, error) {
-	if leftMap, ok := left.(*astmodel.MapType); ok {
-		if leftMap.KeyType().Equals(astmodel.StringType) {
-			if rightObj, ok := right.(*astmodel.ObjectType); ok {
-				if len(rightObj.Properties()) == 0 {
-					// no properties, treat as map
-					// TODO: there could be other things in the object to check?
-					return leftMap, nil
-				}
-
-				additionalProps := astmodel.NewPropertyDefinition("additionalProperties", "additionalProperties", leftMap)
-				return rightObj.WithProperties(additionalProps), nil
-			}
+func (synthesizer) handleMapObject(leftMap *astmodel.MapType, rightObj *astmodel.ObjectType) (astmodel.Type, error) {
+	if leftMap.KeyType().Equals(astmodel.StringType) {
+		if len(rightObj.Properties()) == 0 {
+			// no properties, treat as map
+			// TODO: there could be other things in the object to check?
+			return leftMap, nil
 		}
+
+		additionalProps := astmodel.NewPropertyDefinition("additionalProperties", "additionalProperties", leftMap)
+		return rightObj.WithProperties(additionalProps), nil
 	}
 
 	return nil, nil


### PR DESCRIPTION
This is called `TypeMerger` but it is really multiple dispatch for functions with type `(a <: Type, b <: Type) → Type`. Ideally this would be a bit more generalized to _n_ arguments but Go doesn’t support that kind of thing.

----

Open question: _Should_ this be generalized to allow functions of any arity (in which case I’d probably rename to `TypeFuncDispatcher` or something similarly obtuse)? 

Self answer: probably not. If we need `(a <: Type) → Type` we have type switches already, and I can’t see any reason for a 3-argument version.