### PR TITLE
Create TypeNameQueue

### DIFF
--- a/hack/generator/pkg/astmodel/type_name_queue.go
+++ b/hack/generator/pkg/astmodel/type_name_queue.go
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) Microsoft Corporation.
+ * Licensed under the MIT license.
+ */
+
+package astmodel
+
+import (
+	"github.com/pkg/errors"
+)
+
+// TypeNameQueue is a classic FIFO queue of TypeNames
+type TypeNameQueue struct {
+	queue []TypeName
+}
+
+// MakeTypeNameQueue creates a new empty queue
+func MakeTypeNameQueue() TypeNameQueue {
+	return TypeNameQueue{}
+}
+
+// Enqueue adds the specified TypeName to back of the queue
+// Duplicates are allowed
+func (q *TypeNameQueue) Enqueue(name TypeName) {
+	q.queue = append(q.queue, name)
+}
+
+// Dequeue removes the front item from the queue
+// An error will be returned if no item is available
+func (q *TypeNameQueue) Dequeue() (TypeName, error) {
+	if len(q.queue) == 0 {
+		return TypeName{}, errors.New("queue is empty")
+	}
+
+	result := q.queue[0]
+	q.queue = q.queue[1:]
+	return result, nil
+}
+
+// Len returns the length of the queue
+func (q *TypeNameQueue) Len() int {
+	return len(q.queue)
+}
+
+// Process will drain the queue, passing each item in turn to the supplied func
+// It's permissible for the func to add more items to the queue for processing
+// If the func returns an error, processing of the queue will terminate at that point, with the
+// error returned
+func (q *TypeNameQueue) Process(processor func(TypeName) error) error {
+	for len(q.queue) > 0 {
+		def, err := q.Dequeue()
+		if err != nil {
+			return err
+		}
+
+		err = processor(def)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/hack/generator/pkg/astmodel/type_name_queue_test.go
+++ b/hack/generator/pkg/astmodel/type_name_queue_test.go
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) Microsoft Corporation.
+ * Licensed under the MIT license.
+ */
+
+package astmodel
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+)
+
+func TestMakeTypeNameQueue_Len_IsZero(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	queue := MakeTypeNameQueue()
+	g.Expect(queue.Len()).To(Equal(0))
+}
+
+func TestTypeNameQueue_Enqueue(t *testing.T) {
+	g := NewGomegaWithT(t)
+	email := MakeTypeName(emailTestRef, "Email")
+
+	queue := MakeTypeNameQueue()
+	initialLength := queue.Len()
+
+	queue.Enqueue(email)
+
+	g.Expect(queue.Len() > initialLength).To(BeTrue())
+}
+
+func TestTypeNameQueue_Dequeue(t *testing.T) {
+	g := NewGomegaWithT(t)
+	email := MakeTypeName(emailTestRef, "Email")
+
+	queue := MakeTypeNameQueue()
+	queue.Enqueue(email)
+
+	initialLength := queue.Len()
+
+	n, err := queue.Dequeue()
+
+	g.Expect(err).To(BeNil())
+	g.Expect(queue.Len() < initialLength).To(BeTrue())
+	g.Expect(n).To(Equal(email))
+}
+
+func TestTypeNameQueue_Process(t *testing.T) {
+	g := NewGomegaWithT(t)
+	email := MakeTypeName(emailTestRef, "Email")
+	inbox := MakeTypeName(emailTestRef, "Inbox")
+	mailingList := MakeTypeName(emailTestRef, "MailingList")
+
+	queue := MakeTypeNameQueue()
+	queue.Enqueue(email)
+	queue.Enqueue(inbox)
+	queue.Enqueue(mailingList)
+
+	initialQueueSize := queue.Len()
+	processed := 0
+
+	queue.Process(func(n TypeName) error {
+		processed++
+		return nil
+	})
+
+	g.Expect(processed).To(Equal(initialQueueSize))
+}

--- a/hack/generator/pkg/astmodel/type_name_queue_test.go
+++ b/hack/generator/pkg/astmodel/type_name_queue_test.go
@@ -60,10 +60,11 @@ func TestTypeNameQueue_Process(t *testing.T) {
 	initialQueueSize := queue.Len()
 	processed := 0
 
-	queue.Process(func(n TypeName) error {
+	err := queue.Process(func(n TypeName) error {
 		processed++
 		return nil
 	})
 
+	g.Expect(err).To(BeNil())
 	g.Expect(processed).To(Equal(initialQueueSize))
 }

--- a/hack/generator/pkg/astmodel/type_name_queue_test.go
+++ b/hack/generator/pkg/astmodel/type_name_queue_test.go
@@ -39,11 +39,14 @@ func TestTypeNameQueue_Dequeue(t *testing.T) {
 
 	initialLength := queue.Len()
 
-	n, err := queue.Dequeue()
+	n, ok := queue.Dequeue()
 
-	g.Expect(err).To(BeNil())
+	g.Expect(ok).To(BeTrue())
 	g.Expect(queue.Len() < initialLength).To(BeTrue())
 	g.Expect(n).To(Equal(email))
+
+	_, ok = queue.Dequeue()
+	g.Expect(ok).To(BeFalse())
 }
 
 func TestTypeNameQueue_Process(t *testing.T) {


### PR DESCRIPTION
I have a scenario in an upcoming PR where I need to collect a set of related types and later process them once I've found them all. Breaking this out as a separate type made the code much simpler.

Given that the branch threatens to be too big to easily review, splitting this off for separate review.