### PR TITLE
Fix detection of preview versions

### DIFF
--- a/hack/generator/pkg/astmodel/identifier_factory.go
+++ b/hack/generator/pkg/astmodel/identifier_factory.go
@@ -26,7 +26,6 @@ const (
 type IdentifierFactory interface {
 	CreateIdentifier(name string, visibility Visibility) string
 	CreatePropertyName(propertyName string, visibility Visibility) PropertyName
-	CreatePackageNameFromVersion(version string) string
 	CreateGroupName(name string) string
 	// CreateEnumIdentifier generates the canonical name for an enumeration
 	CreateEnumIdentifier(namehint string) string
@@ -157,29 +156,12 @@ func createReservedWords() map[string]string {
 	}
 }
 
-func (factory *identifierFactory) CreatePackageNameFromVersion(version string) string {
-	return "v1alpha1api" + sanitizePackageName(version)
-}
-
 func (factory *identifierFactory) CreateGroupName(group string) string {
 	return strings.ToLower(group)
 }
 
 func (factory *identifierFactory) CreateEnumIdentifier(namehint string) string {
 	return factory.CreateIdentifier(namehint, Exported)
-}
-
-// sanitizePackageName removes all non-alphanum characters and converts to lower case
-func sanitizePackageName(input string) string {
-	var builder []rune = make([]rune, 0, len(input))
-
-	for _, r := range input {
-		if unicode.IsLetter(r) || unicode.IsNumber(r) {
-			builder = append(builder, unicode.ToLower(rune(r)))
-		}
-	}
-
-	return string(builder)
 }
 
 // transformToSnakeCase transforms a string LikeThis to a snake-case string like_this

--- a/hack/generator/pkg/astmodel/local_package_reference.go
+++ b/hack/generator/pkg/astmodel/local_package_reference.go
@@ -8,6 +8,7 @@ package astmodel
 import (
 	"fmt"
 	"strings"
+	"unicode"
 )
 
 // LocalPackageReference specifies a local package name or reference
@@ -20,9 +21,32 @@ type LocalPackageReference struct {
 var _ PackageReference = LocalPackageReference{}
 var _ fmt.Stringer = LocalPackageReference{}
 
+const generatorVersionPrefix string = "v1alpha1api"
+
 // MakeLocalPackageReference Creates a new local package reference from a group and version
 func MakeLocalPackageReference(prefix string, group string, version string) LocalPackageReference {
-	return LocalPackageReference{localPathPrefix: prefix, group: group, version: version}
+	return LocalPackageReference{
+		localPathPrefix: prefix,
+		group:           group,
+		version:         version,
+	}
+}
+
+func CreateLocalPackageNameFromVersion(version string) string {
+	return generatorVersionPrefix + sanitizePackageName(version)
+}
+
+// sanitizePackageName removes all non-alphanum characters and converts to lower case
+func sanitizePackageName(input string) string {
+	var builder []rune = make([]rune, 0, len(input))
+
+	for _, r := range input {
+		if unicode.IsLetter(r) || unicode.IsNumber(r) {
+			builder = append(builder, unicode.ToLower(rune(r)))
+		}
+	}
+
+	return string(builder)
 }
 
 // AsLocalPackage returns this instance and true

--- a/hack/generator/pkg/astmodel/local_package_reference.go
+++ b/hack/generator/pkg/astmodel/local_package_reference.go
@@ -32,6 +32,8 @@ func MakeLocalPackageReference(prefix string, group string, version string) Loca
 	}
 }
 
+// CreateLocalPackageNameFromVersion transforms a version string (2018-06-01) into a package
+// name (v1alpha1api20180601)
 func CreateLocalPackageNameFromVersion(version string) string {
 	return generatorVersionPrefix + sanitizePackageName(version)
 }

--- a/hack/generator/pkg/astmodel/local_package_reference_test.go
+++ b/hack/generator/pkg/astmodel/local_package_reference_test.go
@@ -122,22 +122,17 @@ func TestLocalPackageReferences_Equals_GivesExpectedResults(t *testing.T) {
 }
 
 func TestLocalPackageReferenceIsPreview(t *testing.T) {
-	batchRef := makeTestLocalPackageReference("microsoft.batch", "v20200901")
-	previewRef := makeTestLocalPackageReference("microsoft.batch", "v20200901preview")
-	preview2Ref := makeTestLocalPackageReference("microsoft.batch", "v20200901preview2")
-	alphaRef := makeTestLocalPackageReference("microsoft.batch", "v20200901alpha")
-	betaRef := makeTestLocalPackageReference("microsoft.batch", "v20200901beta")
 
 	cases := []struct {
 		name      string
-		ref       PackageReference
+		version   string
 		isPreview bool
 	}{
-		{"GA Release is not preview", batchRef, false},
-		{"Preview release is preview", previewRef, true},
-		{"Preview rerelease is preview", preview2Ref, true},
-		{"Alpha release is preview", alphaRef, true},
-		{"Beta release is preview", betaRef, true},
+		{"GA Release is not preview", "v20200901", false},
+		{"Preview release is preview", "v20200901preview", true},
+		{"Preview rerelease is preview", "v20200901preview2", true},
+		{"Alpha release is preview", "v20200901alpha", true},
+		{"Beta release is preview", "v20200901beta", true},
 	}
 
 	for _, c := range cases {
@@ -146,7 +141,11 @@ func TestLocalPackageReferenceIsPreview(t *testing.T) {
 			t.Parallel()
 			g := NewGomegaWithT(t)
 
-			g.Expect(c.ref.IsPreview()).To(Equal(c.isPreview))
+			ref := makeTestLocalPackageReference(
+				"microsoft.storage",
+				CreateLocalPackageNameFromVersion(c.version))
+
+			g.Expect(ref.IsPreview()).To(Equal(c.isPreview))
 		})
 	}
 }

--- a/hack/generator/pkg/astmodel/package_reference.go
+++ b/hack/generator/pkg/astmodel/package_reference.go
@@ -269,7 +269,6 @@ func (v *versionComparer) isPreviewVersionLabel(identifier string) (int, bool) {
 // special set, and if so returns its true. If the passed identifier does not contain one,
 // returns false.
 func containsPreviewVersionLabel(identifier string) bool {
-
 	for _, id := range previewVersionLabels {
 		if strings.LastIndex(identifier, id) > len(generatorVersionPrefix) {
 			return true

--- a/hack/generator/pkg/astmodel/package_reference.go
+++ b/hack/generator/pkg/astmodel/package_reference.go
@@ -269,8 +269,9 @@ func (v *versionComparer) isPreviewVersionLabel(identifier string) (int, bool) {
 // special set, and if so returns its true. If the passed identifier does not contain one,
 // returns false.
 func containsPreviewVersionLabel(identifier string) bool {
+
 	for _, id := range previewVersionLabels {
-		if strings.Contains(identifier, id) {
+		if strings.LastIndex(identifier, id) > len(generatorVersionPrefix) {
 			return true
 		}
 	}

--- a/hack/generator/pkg/astmodel/storage_package_reference_test.go
+++ b/hack/generator/pkg/astmodel/storage_package_reference_test.go
@@ -67,22 +67,16 @@ func TestStoragePackageReferenceEquals(t *testing.T) {
 }
 
 func TestStoragePackageReferenceIsPreview(t *testing.T) {
-	batchRef := MakeStoragePackageReference(makeTestLocalPackageReference("microsoft.batch", "v20200901"))
-	previewRef := MakeStoragePackageReference(makeTestLocalPackageReference("microsoft.batch", "v20200901preview"))
-	preview2Ref := MakeStoragePackageReference(makeTestLocalPackageReference("microsoft.batch", "v20200901preview2"))
-	alphaRef := MakeStoragePackageReference(makeTestLocalPackageReference("microsoft.batch", "v20200901alpha"))
-	betaRef := MakeStoragePackageReference(makeTestLocalPackageReference("microsoft.batch", "v20200901beta"))
-
 	cases := []struct {
 		name      string
-		ref       PackageReference
+		version   string
 		isPreview bool
 	}{
-		{"GA storage Release is not preview", batchRef, false},
-		{"Preview storage release is preview", previewRef, true},
-		{"Preview storage re-release is preview", preview2Ref, true},
-		{"Alpha storage release is preview", alphaRef, true},
-		{"Beta storage release is preview", betaRef, true},
+		{"GA storage Release is not preview", "v20200901", false},
+		{"Preview storage release is preview", "v20200901preview", true},
+		{"Preview storage re-release is preview", "v20200901preview2", true},
+		{"Alpha storage release is preview", "v20200901alpha", true},
+		{"Beta storage release is preview", "v20200901betas", true},
 	}
 
 	for _, c := range cases {
@@ -91,7 +85,12 @@ func TestStoragePackageReferenceIsPreview(t *testing.T) {
 			t.Parallel()
 			g := NewGomegaWithT(t)
 
-			g.Expect(c.ref.IsPreview()).To(Equal(c.isPreview))
+			ref := MakeStoragePackageReference(
+				makeTestLocalPackageReference(
+					"microsoft.storage",
+					CreateLocalPackageNameFromVersion(c.version)))
+
+			g.Expect(ref.IsPreview()).To(Equal(c.isPreview))
 		})
 	}
 }

--- a/hack/generator/pkg/jsonast/jsonast.go
+++ b/hack/generator/pkg/jsonast/jsonast.go
@@ -229,7 +229,7 @@ func (scanner *SchemaScanner) GenerateAllDefinitions(ctx context.Context, schema
 
 	rootPackage := scanner.configuration.MakeLocalPackageReference(
 		scanner.idFactory.CreateGroupName(rootGroup),
-		scanner.idFactory.CreatePackageNameFromVersion(rootVersion))
+		astmodel.CreateLocalPackageNameFromVersion(rootVersion))
 	rootTypeName := astmodel.MakeTypeName(rootPackage, rootName)
 
 	_, err = generateDefinitionsFor(ctx, scanner, rootTypeName, schema)
@@ -597,7 +597,7 @@ func refHandler(ctx context.Context, scanner *SchemaScanner, schema Schema) (ast
 	typeName := astmodel.MakeTypeName(
 		scanner.configuration.MakeLocalPackageReference(
 			scanner.idFactory.CreateGroupName(group),
-			scanner.idFactory.CreatePackageNameFromVersion(version)),
+			astmodel.CreateLocalPackageNameFromVersion(version)),
 		scanner.idFactory.CreateIdentifier(name, astmodel.Exported))
 
 	// Prune the graph according to the configuration

--- a/hack/generator/pkg/jsonast/swagger_type_extractor.go
+++ b/hack/generator/pkg/jsonast/swagger_type_extractor.go
@@ -55,7 +55,7 @@ func (extractor *SwaggerTypeExtractor) ExtractTypes(
 	resources astmodel.Types,
 	otherTypes astmodel.Types) error {
 
-	packageName := extractor.idFactory.CreatePackageNameFromVersion(extractor.outputVersion)
+	packageName := astmodel.CreateLocalPackageNameFromVersion(extractor.outputVersion)
 
 	scanner := NewSchemaScanner(extractor.idFactory, extractor.config)
 


### PR DESCRIPTION
With the change to include the Generator version `v1alpha1` in the generated packages, **_all_** versions were being identified as preview.

This was incorrect - the `IsPreview()` test should ignore the version of the generator and pay attention only to the API version.